### PR TITLE
Add SQLite PRAGMAs: synchronous=NORMAL and temp_store=MEMORY

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -39,6 +39,18 @@ func Open(path string) (*Store, error) {
 		return nil, fmt.Errorf("enable WAL mode: %w", err)
 	}
 
+	// Balance durability and latency for WAL workloads
+	if _, err := db.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("set synchronous: %w", err)
+	}
+
+	// Keep temporary data in memory for speed
+	if _, err := db.Exec("PRAGMA temp_store=MEMORY"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("set temp_store: %w", err)
+	}
+
 	// Set busy timeout to avoid "database is locked" errors during concurrent access
 	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
 		db.Close()


### PR DESCRIPTION
### Motivation
- Ensure SQLite connections use pragmas consistent with WAL workloads to balance durability and latency by explicitly setting `synchronous=NORMAL` and `temp_store=MEMORY` alongside existing pragmas.

### Description
- Add `PRAGMA synchronous=NORMAL` and `PRAGMA temp_store=MEMORY` in `internal/store/store.go` immediately after `PRAGMA journal_mode=WAL` so each opened connection configures these settings per the project's SQLite checklist.

### Testing
- No automated tests were run for this change; please run `go test ./...` and integration validation against a real SQLite file to verify runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681e7d062c8325b9241726de6ec7f4)