### PR TITLE
n:task:snipe-enclosing-perf: AST walker for O(1) enclosing lookup

### DIFF
--- a/BASELINE.json
+++ b/BASELINE.json
@@ -1,35 +1,35 @@
 {
-  "timestamp": "2026-01-17T11:53:06Z",
-  "git_commit": "9b98446",
+  "timestamp": "2026-01-17T11:57:36Z",
+  "git_commit": "bf12f8f",
   "go_version": "go1.25.5",
   "codebase": {
     "go_files": 44,
-    "symbols": 418,
-    "refs": 1553,
-    "call_edges": 449,
+    "symbols": 424,
+    "refs": 1581,
+    "call_edges": 450,
     "db_size_kb": 4
   },
   "index": {
-    "total_ms": 1801,
-    "load_ms": 817,
-    "extract_ms": 294,
-    "persist_ms": 574,
-    "peak_mem_mb": 84
+    "total_ms": 495,
+    "load_ms": 453,
+    "extract_ms": 23,
+    "persist_ms": 15,
+    "peak_mem_mb": 78
   },
   "query": {
-    "def_by_name_ms": 1.14034,
-    "def_by_pos_ms": 1.56448,
-    "refs_by_id_ms": 2.9347399999999997
+    "def_by_name_ms": 0.01701,
+    "def_by_pos_ms": 0.0318,
+    "refs_by_id_ms": 0.05942
   },
   "search": {
-    "simple_pattern_ms": 9.278360000000001,
-    "regex_pattern_ms": 7.890020000000001
+    "simple_pattern_ms": 4.22345,
+    "regex_pattern_ms": 7.12432
   },
   "quality": {
-    "symbols_with_doc": 207,
-    "symbols_with_sig": 418,
-    "doc_coverage_pct": 49.52153110047847,
-    "refs_per_symbol": 3.715311004784689,
-    "callgraph_coverage_pct": 167.4418604651163
+    "symbols_with_doc": 212,
+    "symbols_with_sig": 424,
+    "doc_coverage_pct": 50,
+    "refs_per_symbol": 3.7287735849056602,
+    "callgraph_coverage_pct": 172.09302325581396
   }
 }

--- a/BASELINE_ORCA.json
+++ b/BASELINE_ORCA.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-01-17T11:53:10Z",
+  "timestamp": "2026-01-17T11:57:37Z",
   "git_commit": "d9bd512c5",
   "go_version": "go1.25.5",
   "codebase": {
@@ -7,23 +7,23 @@
     "symbols": 9855,
     "refs": 30118,
     "call_edges": 9203,
-    "db_size_kb": 27876
+    "db_size_kb": 27824
   },
   "index": {
-    "total_ms": 30462,
-    "load_ms": 2696,
-    "extract_ms": 13466,
-    "persist_ms": 14258,
-    "peak_mem_mb": 1646
+    "total_ms": 2132,
+    "load_ms": 751,
+    "extract_ms": 916,
+    "persist_ms": 461,
+    "peak_mem_mb": 1322
   },
   "query": {
-    "def_by_name_ms": 0.90143,
-    "def_by_pos_ms": 1.3115899999999998,
-    "refs_by_id_ms": 2.4043400000000004
+    "def_by_name_ms": 0.02068,
+    "def_by_pos_ms": 0.03133,
+    "refs_by_id_ms": 0.052020000000000004
   },
   "search": {
-    "simple_pattern_ms": 10.13767,
-    "regex_pattern_ms": 20.94139
+    "simple_pattern_ms": 5.208600000000001,
+    "regex_pattern_ms": 19.28247
   },
   "quality": {
     "symbols_with_doc": 5768,

--- a/internal/index/callgraph.go
+++ b/internal/index/callgraph.go
@@ -16,7 +16,9 @@ type CallEdge struct {
 	Col      int
 }
 
-// ExtractCallGraph extracts the static call graph from loaded packages
+// ExtractCallGraph extracts the static call graph from loaded packages.
+// Uses an optimized approach: single AST pass with function stack tracking
+// for O(1) enclosing function lookup per call.
 func ExtractCallGraph(result *LoadResult, symbols []Symbol) ([]CallEdge, error) {
 	// Build symbol lookup by definition position
 	symbolByPos := buildSymbolPosIndex(symbols)
@@ -34,30 +36,72 @@ func ExtractCallGraph(result *LoadResult, symbols []Symbol) ([]CallEdge, error) 
 			}
 			filePath := pkg.GoFiles[i]
 
-			// Build enclosing function map for this file
-			enclosingMap := buildEnclosingMap(file, filePath, result.Fset)
-
-			// Walk AST looking for call expressions
-			ast.Inspect(file, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-
-				edge := extractCallEdge(pkg, call, filePath, result.Fset, symbolByPos, enclosingMap)
-				if edge != nil {
-					edges = append(edges, *edge)
-				}
-
-				return true
-			})
+			// Extract call edges using AST walker with function stack tracking.
+			// This avoids the separate buildEnclosingMap + findEnclosing passes.
+			fileEdges := extractCallEdgesWithStack(pkg, file, filePath, result.Fset, symbolByPos)
+			edges = append(edges, fileEdges...)
 		}
 	}
 
 	return edges, nil
 }
 
-func extractCallEdge(pkg *packages.Package, call *ast.CallExpr, filePath string, fset *token.FileSet, symbolByPos map[string]string, enclosingMap []enclosingFunc) *CallEdge {
+// extractCallEdgesWithStack extracts all call edges from a file using a single AST pass.
+// Maintains a function stack to track the current enclosing function for O(1) lookup.
+func extractCallEdgesWithStack(pkg *packages.Package, file *ast.File, filePath string, fset *token.FileSet, symbolByPos map[string]string) []CallEdge {
+	var edges []CallEdge
+	var funcStack []string // Stack of enclosing function IDs
+
+	var inspector func(n ast.Node) bool
+	inspector = func(n ast.Node) bool {
+		if n == nil {
+			return true
+		}
+
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			if node.Body == nil || node.Name == nil {
+				return true
+			}
+			// Compute function ID
+			namePos := fset.Position(node.Name.Pos())
+			kind := KindFunc
+			if node.Recv != nil {
+				kind = KindMethod
+			}
+			funcID := generateID(filePath, namePos.Line, namePos.Column, string(kind))
+
+			// Push onto stack, traverse body, pop
+			funcStack = append(funcStack, funcID)
+			ast.Inspect(node.Body, inspector)
+			funcStack = funcStack[:len(funcStack)-1]
+
+			return false // Already handled children
+
+		case *ast.CallExpr:
+			// Extract call edge with current enclosing function
+			edge := extractCallEdgeFromExpr(pkg, node, filePath, fset, symbolByPos, funcStack)
+			if edge != nil {
+				edges = append(edges, *edge)
+			}
+		}
+
+		return true
+	}
+
+	ast.Inspect(file, inspector)
+	return edges
+}
+
+// extractCallEdgeFromExpr extracts a call edge from a call expression.
+// Uses the function stack for O(1) enclosing function lookup.
+func extractCallEdgeFromExpr(pkg *packages.Package, call *ast.CallExpr, filePath string, fset *token.FileSet, symbolByPos map[string]string, funcStack []string) *CallEdge {
+	// Get current enclosing function (caller)
+	if len(funcStack) == 0 {
+		return nil // Call not inside a function (e.g., init expression)
+	}
+	callerID := funcStack[len(funcStack)-1]
+
 	// Get the callee identifier
 	var calleeIdent *ast.Ident
 
@@ -102,12 +146,6 @@ func extractCallEdge(pkg *packages.Package, call *ast.CallExpr, filePath string,
 
 	// Get call position
 	callPos := fset.Position(call.Pos())
-
-	// Find the enclosing function (caller)
-	callerID := findEnclosing(call.Pos(), enclosingMap)
-	if callerID == "" {
-		return nil // Call not inside a function (e.g., init expression)
-	}
 
 	return &CallEdge{
 		CallerID: callerID,

--- a/internal/index/refs.go
+++ b/internal/index/refs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"sort"
 	"strings"
 
 	"github.com/dkoosis/snipe/internal/util"
@@ -21,8 +20,16 @@ type Ref struct {
 	Snippet     string // The line of code
 }
 
-// ExtractRefs extracts all references from loaded packages
+// ExtractRefs extracts all references from loaded packages.
+// Uses an optimized approach: single AST pass with function stack tracking
+// for O(1) enclosing function lookup per reference.
 func ExtractRefs(result *LoadResult, symbols []Symbol) ([]Ref, error) {
+	return ExtractRefsWithCache(result, symbols, nil)
+}
+
+// ExtractRefsWithCache extracts references using an optional file cache.
+// If cache is nil, files are loaded without caching.
+func ExtractRefsWithCache(result *LoadResult, symbols []Symbol, cache *util.FileCache) ([]Ref, error) {
 	// Build symbol lookup by definition position
 	symbolByPos := buildSymbolPosIndex(symbols)
 
@@ -39,14 +46,21 @@ func ExtractRefs(result *LoadResult, symbols []Symbol) ([]Ref, error) {
 			}
 			filePath := pkg.GoFiles[i]
 
-			// Load file content for snippets
-			lines, err := util.LoadFileLines(filePath)
+			// Load file content for snippets (with optional cache)
+			var lines []string
+			var err error
+			if cache != nil {
+				lines, err = cache.LoadLines(filePath)
+			} else {
+				lines, err = util.LoadFileLines(filePath)
+			}
 			if err != nil {
 				continue // Skip files we can't read
 			}
 
-			// Build enclosing function map for this file
-			enclosingMap := buildEnclosingMap(file, filePath, result.Fset)
+			// Build position-to-enclosing map using AST walker with function stack.
+			// This is O(N) single pass instead of binary search per reference.
+			enclosingByPos := buildEnclosingByPos(file, filePath, result.Fset)
 
 			// Extract references from Uses map
 			for ident, obj := range pkg.TypesInfo.Uses {
@@ -75,8 +89,8 @@ func ExtractRefs(result *LoadResult, symbols []Symbol) ([]Ref, error) {
 					continue // Skip if not in current file
 				}
 
-				// Get enclosing function
-				enclosingID := findEnclosing(ident.Pos(), enclosingMap)
+				// Get enclosing function - O(1) map lookup
+				enclosingID := enclosingByPos[ident.Pos()]
 
 				// Get snippet
 				snippet := ""
@@ -101,6 +115,57 @@ func ExtractRefs(result *LoadResult, symbols []Symbol) ([]Ref, error) {
 	return refs, nil
 }
 
+// buildEnclosingByPos creates a map from AST positions to enclosing function IDs.
+// Uses a single AST traversal with a function stack for O(1) lookup per position.
+// This replaces the previous approach of building a sorted list + binary search.
+func buildEnclosingByPos(file *ast.File, filePath string, fset *token.FileSet) map[token.Pos]string {
+	enclosingByPos := make(map[token.Pos]string)
+
+	// funcStack tracks the current enclosing function(s) during traversal
+	var funcStack []string
+
+	// Pre-allocate space for identifiers (typical Go file has many identifiers)
+	// We'll collect all idents during traversal and assign enclosing funcs
+	var inspector func(n ast.Node) bool
+	inspector = func(n ast.Node) bool {
+		if n == nil {
+			return true
+		}
+
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			if node.Body == nil || node.Name == nil {
+				return true
+			}
+			// Compute function ID
+			namePos := fset.Position(node.Name.Pos())
+			kind := KindFunc
+			if node.Recv != nil {
+				kind = KindMethod
+			}
+			funcID := generateID(filePath, namePos.Line, namePos.Column, string(kind))
+
+			// Push onto stack, traverse body, pop
+			funcStack = append(funcStack, funcID)
+			ast.Inspect(node.Body, inspector)
+			funcStack = funcStack[:len(funcStack)-1]
+
+			return false // Already handled children
+
+		case *ast.Ident:
+			// Record enclosing function for this identifier
+			if len(funcStack) > 0 {
+				enclosingByPos[node.Pos()] = funcStack[len(funcStack)-1]
+			}
+		}
+
+		return true
+	}
+
+	ast.Inspect(file, inspector)
+	return enclosingByPos
+}
+
 // buildSymbolPosIndex creates a map from position key to symbol ID
 // Uses NameLine/NameCol (identifier position) to match obj.Pos() in call graph lookups
 func buildSymbolPosIndex(symbols []Symbol) map[string]string {
@@ -114,66 +179,4 @@ func buildSymbolPosIndex(symbols []Symbol) map[string]string {
 
 func posKey(file string, line, col int) string {
 	return fmt.Sprintf("%s:%d:%d", file, line, col)
-}
-
-// enclosingFunc tracks function/method ranges for finding enclosing scope
-type enclosingFunc struct {
-	id    string
-	start token.Pos
-	end   token.Pos
-}
-
-func buildEnclosingMap(file *ast.File, filePath string, fset *token.FileSet) []enclosingFunc {
-	var funcs []enclosingFunc
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		if fn, ok := n.(*ast.FuncDecl); ok && fn.Body != nil && fn.Name != nil {
-			// Use fn.Name.Pos() to match symbol ID generation in symbols.go
-			namePos := fset.Position(fn.Name.Pos())
-			kind := KindFunc
-			if fn.Recv != nil {
-				kind = KindMethod
-			}
-			funcs = append(funcs, enclosingFunc{
-				id:    generateID(filePath, namePos.Line, namePos.Column, string(kind)),
-				start: fn.Body.Lbrace,
-				end:   fn.Body.Rbrace,
-			})
-		}
-		return true
-	})
-
-	// Sort by start position for binary search
-	sort.Slice(funcs, func(i, j int) bool {
-		return funcs[i].start < funcs[j].start
-	})
-
-	return funcs
-}
-
-// findEnclosing uses binary search to find the enclosing function for a position.
-// O(log N) instead of O(N) linear scan.
-func findEnclosing(pos token.Pos, funcs []enclosingFunc) string {
-	if len(funcs) == 0 {
-		return ""
-	}
-
-	// Binary search for rightmost function where start <= pos
-	idx := sort.Search(len(funcs), func(i int) bool {
-		return funcs[i].start > pos
-	})
-
-	// Check functions from idx-1 down to 0 (nested functions possible)
-	for i := idx - 1; i >= 0; i-- {
-		if pos >= funcs[i].start && pos <= funcs[i].end {
-			return funcs[i].id
-		}
-		// If this function ends before pos, earlier functions won't contain pos either
-		// (unless they're nested, but Go doesn't have nested named functions)
-		if funcs[i].end < pos {
-			break
-		}
-	}
-
-	return ""
 }


### PR DESCRIPTION
Stream C task. Replaces O(N*M) with function stack pattern.