### PR TITLE
feat: add --max-tokens flag for output truncation

### DIFF
--- a/BASELINE.json
+++ b/BASELINE.json
@@ -1,35 +1,35 @@
 {
-  "timestamp": "2026-01-17T12:07:25Z",
-  "git_commit": "b48471e",
+  "timestamp": "2026-01-17T12:16:27Z",
+  "git_commit": "7971317",
   "go_version": "go1.25.5",
   "codebase": {
     "go_files": 47,
-    "symbols": 467,
-    "refs": 1685,
-    "call_edges": 473,
+    "symbols": 473,
+    "refs": 1726,
+    "call_edges": 501,
     "db_size_kb": 4
   },
   "index": {
-    "total_ms": 1960,
-    "load_ms": 775,
-    "extract_ms": 314,
-    "persist_ms": 748,
-    "peak_mem_mb": 90
+    "total_ms": 333,
+    "load_ms": 286,
+    "extract_ms": 24,
+    "persist_ms": 19,
+    "peak_mem_mb": 82
   },
   "query": {
-    "def_by_name_ms": 0.76754,
-    "def_by_pos_ms": 1.65476,
-    "refs_by_id_ms": 2.85024
+    "def_by_name_ms": 0.01706,
+    "def_by_pos_ms": 0.03136,
+    "refs_by_id_ms": 0.05992
   },
   "search": {
-    "simple_pattern_ms": 11.87251,
-    "regex_pattern_ms": 8.503350000000001
+    "simple_pattern_ms": 4.3396099999999995,
+    "regex_pattern_ms": 6.922359999999999
   },
   "quality": {
-    "symbols_with_doc": 227,
-    "symbols_with_sig": 467,
-    "doc_coverage_pct": 48.60813704496788,
-    "refs_per_symbol": 3.6081370449678802,
-    "callgraph_coverage_pct": 186.04651162790697
+    "symbols_with_doc": 231,
+    "symbols_with_sig": 473,
+    "doc_coverage_pct": 48.837209302325576,
+    "refs_per_symbol": 3.649048625792812,
+    "callgraph_coverage_pct": 190.69767441860466
   }
 }

--- a/BASELINE_ORCA.json
+++ b/BASELINE_ORCA.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-01-17T12:07:29Z",
+  "timestamp": "2026-01-17T12:16:29Z",
   "git_commit": "d9bd512c5",
   "go_version": "go1.25.5",
   "codebase": {
@@ -7,23 +7,23 @@
     "symbols": 9855,
     "refs": 27373,
     "call_edges": 7134,
-    "db_size_kb": 29288
+    "db_size_kb": 29308
   },
   "index": {
-    "total_ms": 33138,
-    "load_ms": 5100,
-    "extract_ms": 13426,
-    "persist_ms": 14567,
-    "peak_mem_mb": 1806
+    "total_ms": 3448,
+    "load_ms": 2021,
+    "extract_ms": 942,
+    "persist_ms": 480,
+    "peak_mem_mb": 1459
   },
   "query": {
-    "def_by_name_ms": 0.8935299999999999,
-    "def_by_pos_ms": 1.33196,
-    "refs_by_id_ms": 2.4213899999999997
+    "def_by_name_ms": 0.02121,
+    "def_by_pos_ms": 0.03277,
+    "refs_by_id_ms": 0.05429
   },
   "search": {
-    "simple_pattern_ms": 10.20707,
-    "regex_pattern_ms": 21.13588
+    "simple_pattern_ms": 5.50206,
+    "regex_pattern_ms": 19.70507
   },
   "quality": {
     "symbols_with_doc": 5768,

--- a/cmd/callees.go
+++ b/cmd/callees.go
@@ -160,6 +160,13 @@ func runCallees(cmd *cobra.Command, args []string) error {
 	// Deduplicate degraded messages
 	degraded = uniqueStrings(degraded)
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
 	// If summary mode, return condensed output
 	if summary {
 		summaryData := output.BuildSummary(results)
@@ -181,6 +188,12 @@ func runCallees(cmd *cobra.Command, args []string) error {
 		return w.WriteResponse(summaryResp)
 	}
 
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
 	resp := output.Response[output.Result]{
 		Results: results,
 		Meta: output.Meta{
@@ -193,7 +206,7 @@ func runCallees(cmd *cobra.Command, args []string) error {
 			Total:         len(results),
 			Offset:        off,
 			Limit:         lim,
-			Truncated:     len(results) >= lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 		},
 	}

--- a/cmd/callers.go
+++ b/cmd/callers.go
@@ -159,6 +159,13 @@ func runCallers(cmd *cobra.Command, args []string) error {
 	// Deduplicate degraded messages
 	degraded = uniqueStrings(degraded)
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
 	// If summary mode, return condensed output
 	if summary {
 		summaryData := output.BuildSummary(results)
@@ -180,6 +187,12 @@ func runCallers(cmd *cobra.Command, args []string) error {
 		return w.WriteResponse(summaryResp)
 	}
 
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
 	resp := output.Response[output.Result]{
 		Results: results,
 		Meta: output.Meta{
@@ -192,7 +205,7 @@ func runCallers(cmd *cobra.Command, args []string) error {
 			Total:         len(results),
 			Offset:        off,
 			Limit:         lim,
-			Truncated:     len(results) >= lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 		},
 	}

--- a/cmd/importers.go
+++ b/cmd/importers.go
@@ -96,6 +96,19 @@ func runImporters(cmd *cobra.Command, args []string) error {
 		tokenEstimate += output.EstimateTokens(imp.FilePath)
 	}
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
 	resp := output.Response[output.Result]{
 		Results: results,
 		Meta: output.Meta{
@@ -105,7 +118,7 @@ func runImporters(cmd *cobra.Command, args []string) error {
 			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         len(results),
-			Truncated:     len(results) >= lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 			Offset:        offset,
 			Limit:         lim,

--- a/cmd/imports.go
+++ b/cmd/imports.go
@@ -97,6 +97,19 @@ func runImports(cmd *cobra.Command, args []string) error {
 		tokenEstimate += output.EstimateTokens(imp.PkgPath)
 	}
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
 	resp := output.Response[output.Result]{
 		Results: results,
 		Meta: output.Meta{
@@ -106,7 +119,7 @@ func runImports(cmd *cobra.Command, args []string) error {
 			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         len(results),
-			Truncated:     len(results) >= lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 			Offset:        offset,
 			Limit:         lim,

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -200,6 +200,13 @@ func runRefs(cmd *cobra.Command, args []string) error {
 	// Deduplicate degraded messages
 	degraded = uniqueStrings(degraded)
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
 	// If summary mode, return condensed output
 	if summary {
 		summaryData := output.BuildSummary(results)
@@ -221,6 +228,12 @@ func runRefs(cmd *cobra.Command, args []string) error {
 		return w.WriteResponse(summaryResp)
 	}
 
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
 	resp := output.Response[output.Result]{
 		Results: results,
 		Meta: output.Meta{
@@ -233,7 +246,7 @@ func runRefs(cmd *cobra.Command, args []string) error {
 			Total:         len(results),
 			Offset:        off,
 			Limit:         lim,
-			Truncated:     len(results) >= lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	withBody     bool
 	withSiblings bool
 	summaryOnly  bool
+	maxTokens    int
 
 	// loadedConfig holds the merged config (loaded lazily)
 	loadedConfig *config.Config
@@ -69,11 +70,17 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&withBody, "with-body", false, "Include full enclosing function body")
 	rootCmd.PersistentFlags().BoolVar(&withSiblings, "with-siblings", false, "Include sibling declarations in same file")
 	rootCmd.PersistentFlags().BoolVar(&summaryOnly, "summary", false, "Show summary stats only (counts per file)")
+	rootCmd.PersistentFlags().IntVar(&maxTokens, "max-tokens", 0, "Maximum tokens in output (0 = unlimited)")
 }
 
 // GetOutputConfig returns the current output configuration
 func GetOutputConfig() (json bool, human bool, lim int, off int, ctx int, body bool, siblings bool, summary bool) {
 	return jsonOutput, humanOutput, limit, offset, contextLines, withBody, withSiblings, summaryOnly
+}
+
+// GetMaxTokens returns the max-tokens flag value (0 = unlimited)
+func GetMaxTokens() int {
+	return maxTokens
 }
 
 // uniqueStrings removes duplicates from a string slice, preserving order.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -46,10 +46,17 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		})
 	}
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
 	// Estimate tokens
 	tokenEstimate := 0
-	for _, r := range results {
-		tokenEstimate += output.EstimateTokens(r.Match)
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
 	}
 
 	resp := output.Response[output.Result]{
@@ -61,7 +68,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			Degraded:      []string{"no_index"},
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         len(results),
-			Truncated:     len(results) >= lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 		},
 	}

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -170,6 +170,13 @@ func runSim(cmd *cobra.Command, args []string) error {
 
 	degraded = uniqueStrings(degraded)
 
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
 	if summary {
 		summaryData := output.BuildSummary(results)
 		summaryResp := output.Response[output.Summary]{
@@ -190,6 +197,12 @@ func runSim(cmd *cobra.Command, args []string) error {
 		return w.WriteResponse(summaryResp)
 	}
 
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
 	resp := output.Response[output.Result]{
 		Results: results,
 		Meta: output.Meta{
@@ -202,7 +215,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 			Total:         len(results),
 			Offset:        off,
 			Limit:         lim,
-			Truncated:     len(matches) >= lim,
+			Truncated:     len(matches) >= lim || tokenTruncated,
 			TokenEstimate: tokenEstimate,
 		},
 	}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -135,6 +135,61 @@ func EstimateTokens(s string) int {
 	return (len(s) + 3) / 4
 }
 
+// EstimateResultTokens estimates token count for a single result.
+func EstimateResultTokens(r *Result) int {
+	tokens := EstimateTokens(r.Name)
+	tokens += EstimateTokens(r.File)
+	tokens += EstimateTokens(r.Match)
+	if r.Body != "" {
+		tokens += EstimateTokens(r.Body)
+	}
+	if r.Context != nil {
+		for _, line := range r.Context.Before {
+			tokens += EstimateTokens(line)
+		}
+		for _, line := range r.Context.After {
+			tokens += EstimateTokens(line)
+		}
+	}
+	if r.Enclosing != nil {
+		tokens += EstimateTokens(r.Enclosing.Signature)
+	}
+	// Add overhead for JSON structure (~50 tokens per result)
+	tokens += 50
+	return tokens
+}
+
+// TruncateToTokenBudget truncates results to fit within a token budget.
+// Returns the truncated slice and whether truncation occurred.
+// If maxTokens is 0, returns the original slice unchanged.
+func TruncateToTokenBudget(results []Result, maxTokens int) ([]Result, bool) {
+	if maxTokens <= 0 {
+		return results, false
+	}
+
+	// Reserve tokens for response wrapper (meta, error fields, etc.)
+	const overhead = 200
+	budget := maxTokens - overhead
+	if budget <= 0 {
+		return nil, len(results) > 0
+	}
+
+	var truncated []Result
+	totalTokens := 0
+
+	for i := range results {
+		resultTokens := EstimateResultTokens(&results[i])
+		if totalTokens+resultTokens > budget && len(truncated) > 0 {
+			// Would exceed budget and we have at least one result
+			return truncated, true
+		}
+		totalTokens += resultTokens
+		truncated = append(truncated, results[i])
+	}
+
+	return truncated, false
+}
+
 // FormatEditTarget formats a range as an edit target string.
 // If hash is non-empty, appends it for change detection: file:L:C-L:C@hash
 func FormatEditTarget(file string, r Range, hash string) string {

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -217,3 +217,76 @@ func TestAmbiguousSymbolDeterminism(t *testing.T) {
 		t.Error("NewAmbiguousError should produce deterministic output")
 	}
 }
+
+func TestTruncateToTokenBudget(t *testing.T) {
+	// Create test results
+	results := []Result{
+		{Name: "foo", File: "a.go", Match: "func foo()"},
+		{Name: "bar", File: "b.go", Match: "func bar()"},
+		{Name: "baz", File: "c.go", Match: "func baz()"},
+	}
+
+	t.Run("zero budget means no truncation", func(t *testing.T) {
+		got, truncated := TruncateToTokenBudget(results, 0)
+		if truncated {
+			t.Error("should not be truncated with 0 budget")
+		}
+		if len(got) != len(results) {
+			t.Errorf("got %d results, want %d", len(got), len(results))
+		}
+	})
+
+	t.Run("large budget keeps all results", func(t *testing.T) {
+		got, truncated := TruncateToTokenBudget(results, 10000)
+		if truncated {
+			t.Error("should not be truncated with large budget")
+		}
+		if len(got) != len(results) {
+			t.Errorf("got %d results, want %d", len(got), len(results))
+		}
+	})
+
+	t.Run("small budget truncates results", func(t *testing.T) {
+		// Very small budget should still return at least one result
+		got, truncated := TruncateToTokenBudget(results, 300)
+		if !truncated {
+			t.Error("should be truncated with small budget")
+		}
+		if len(got) == 0 {
+			t.Error("should return at least one result")
+		}
+		if len(got) >= len(results) {
+			t.Error("should have fewer results than input")
+		}
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		got, truncated := TruncateToTokenBudget(nil, 1000)
+		if truncated {
+			t.Error("should not be truncated with empty input")
+		}
+		if len(got) != 0 {
+			t.Error("should return empty slice")
+		}
+	})
+}
+
+func TestEstimateResultTokens(t *testing.T) {
+	result := Result{
+		Name:  "ProcessOrder",
+		File:  "order/handler.go",
+		Match: "func ProcessOrder(ctx context.Context, order *Order) error",
+	}
+
+	tokens := EstimateResultTokens(&result)
+	if tokens < 50 {
+		t.Errorf("tokens = %d, expected at least 50 (includes overhead)", tokens)
+	}
+
+	// Adding body should increase token count
+	result.Body = "func ProcessOrder(ctx context.Context, order *Order) error {\n\treturn nil\n}"
+	tokensWithBody := EstimateResultTokens(&result)
+	if tokensWithBody <= tokens {
+		t.Errorf("tokens with body (%d) should be greater than without (%d)", tokensWithBody, tokens)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--max-tokens` global flag for LLM output budget management
- Implements token estimation (~4 chars per token heuristic)
- Adds `TruncateToTokenBudget()` to truncate result sets intelligently
- Updates all multi-result commands: refs, search, callers, callees, imports, importers, sim

## Test plan
- [ ] Verify `snipe refs --max-tokens 1000` truncates results appropriately
- [ ] Verify truncation adds `truncated: true` to response meta
- [ ] Verify zero/negative values disable truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements token-budgeted output with a new global flag and shared utilities, then wires it into all multi-result commands.
> 
> - Adds `--max-tokens` global flag and `GetMaxTokens()` in `cmd/root.go`; propagates truncation state to `meta.truncated`
> - Introduces `EstimateResultTokens()` and `TruncateToTokenBudget()` in `internal/output/json.go` (reserves overhead, per-result token heuristic) and comprehensive tests in `internal/output/types_test.go`
> - Applies truncation + post-truncation token re-estimation to `refs`, `search`, `callers`, `callees`, `imports`, `importers`, `sim`; updates `TokenEstimate` and `Truncated` logic
> - Minor baseline metrics updated in `BASELINE*.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef68c5b01ba70bb93f1bef9c41a3eb5262b364d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->