### PR TITLE
feat: add content hash based on line range in edit_target

### DIFF
--- a/BASELINE.json
+++ b/BASELINE.json
@@ -1,35 +1,35 @@
 {
-  "timestamp": "2026-01-17T12:16:27Z",
+  "timestamp": "2026-01-17T12:18:57Z",
   "git_commit": "7971317",
   "go_version": "go1.25.5",
   "codebase": {
     "go_files": 47,
-    "symbols": 473,
-    "refs": 1726,
-    "call_edges": 501,
+    "symbols": 470,
+    "refs": 1693,
+    "call_edges": 476,
     "db_size_kb": 4
   },
   "index": {
-    "total_ms": 333,
-    "load_ms": 286,
-    "extract_ms": 24,
+    "total_ms": 334,
+    "load_ms": 287,
+    "extract_ms": 23,
     "persist_ms": 19,
     "peak_mem_mb": 82
   },
   "query": {
-    "def_by_name_ms": 0.01706,
-    "def_by_pos_ms": 0.03136,
-    "refs_by_id_ms": 0.05992
+    "def_by_name_ms": 0.0176,
+    "def_by_pos_ms": 0.03263,
+    "refs_by_id_ms": 0.060719999999999996
   },
   "search": {
-    "simple_pattern_ms": 4.3396099999999995,
-    "regex_pattern_ms": 6.922359999999999
+    "simple_pattern_ms": 4.6835,
+    "regex_pattern_ms": 7.625319999999999
   },
   "quality": {
-    "symbols_with_doc": 231,
-    "symbols_with_sig": 473,
-    "doc_coverage_pct": 48.837209302325576,
-    "refs_per_symbol": 3.649048625792812,
+    "symbols_with_doc": 230,
+    "symbols_with_sig": 470,
+    "doc_coverage_pct": 48.93617021276596,
+    "refs_per_symbol": 3.6021276595744682,
     "callgraph_coverage_pct": 190.69767441860466
   }
 }

--- a/BASELINE_ORCA.json
+++ b/BASELINE_ORCA.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-01-17T12:16:29Z",
+  "timestamp": "2026-01-17T12:18:58Z",
   "git_commit": "d9bd512c5",
   "go_version": "go1.25.5",
   "codebase": {
@@ -7,23 +7,23 @@
     "symbols": 9855,
     "refs": 27373,
     "call_edges": 7134,
-    "db_size_kb": 29308
+    "db_size_kb": 29368
   },
   "index": {
-    "total_ms": 3448,
-    "load_ms": 2021,
-    "extract_ms": 942,
-    "persist_ms": 480,
+    "total_ms": 3505,
+    "load_ms": 2049,
+    "extract_ms": 957,
+    "persist_ms": 495,
     "peak_mem_mb": 1459
   },
   "query": {
-    "def_by_name_ms": 0.02121,
-    "def_by_pos_ms": 0.03277,
-    "refs_by_id_ms": 0.05429
+    "def_by_name_ms": 0.02156,
+    "def_by_pos_ms": 0.03308,
+    "refs_by_id_ms": 0.05453
   },
   "search": {
-    "simple_pattern_ms": 5.50206,
-    "regex_pattern_ms": 19.70507
+    "simple_pattern_ms": 5.225239999999999,
+    "regex_pattern_ms": 20.39143
   },
   "quality": {
     "symbols_with_doc": 5768,

--- a/cmd/callees.go
+++ b/cmd/callees.go
@@ -129,7 +129,7 @@ func runCallees(cmd *cobra.Command, args []string) error {
 			Kind:       call.CalleeKind,
 			Name:       call.CalleeName,
 			Match:      call.CalleeSignature.String,
-			EditTarget: output.FormatEditTarget(call.CallerFile, callSiteRange, call.CallerFileHash),
+			EditTarget: output.FormatEditTargetWithHash(call.CallerFile, callSiteRange),
 		}
 
 		// Add callee body if requested (from the callee's definition, not call site)

--- a/cmd/callers.go
+++ b/cmd/callers.go
@@ -128,7 +128,7 @@ func runCallers(cmd *cobra.Command, args []string) error {
 			Kind:       call.CallerKind,
 			Name:       call.CallerName,
 			Match:      call.CallerSignature.String,
-			EditTarget: output.FormatEditTarget(call.CallerFile, callRange, call.CallerFileHash),
+			EditTarget: output.FormatEditTargetWithHash(call.CallerFile, callRange),
 		}
 
 		// Add caller body if requested (from the caller's definition, not call site)

--- a/cmd/importers.go
+++ b/cmd/importers.go
@@ -91,7 +91,7 @@ func runImporters(cmd *cobra.Command, args []string) error {
 			Kind:       "import",
 			Name:       imp.PkgPath,
 			Match:      "import \"" + imp.PkgPath + "\"",
-			EditTarget: output.FormatEditTarget(imp.FilePath, impRange, ""),
+			EditTarget: output.FormatEditTargetWithHash(imp.FilePath, impRange),
 		}
 		tokenEstimate += output.EstimateTokens(imp.FilePath)
 	}

--- a/cmd/imports.go
+++ b/cmd/imports.go
@@ -92,7 +92,7 @@ func runImports(cmd *cobra.Command, args []string) error {
 			Kind:       "import",
 			Name:       name,
 			Match:      imp.PkgPath,
-			EditTarget: output.FormatEditTarget(imp.FilePath, impRange, ""),
+			EditTarget: output.FormatEditTargetWithHash(imp.FilePath, impRange),
 		}
 		tokenEstimate += output.EstimateTokens(imp.PkgPath)
 	}

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -158,7 +158,7 @@ func runRefs(cmd *cobra.Command, args []string) error {
 			Range:      refRange,
 			Kind:       "ref",
 			Match:      ref.Snippet,
-			EditTarget: output.FormatEditTarget(ref.FilePath, refRange, ref.FileHash),
+			EditTarget: output.FormatEditTargetWithHash(ref.FilePath, refRange),
 		}
 
 		// Add enclosing info if available

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,9 +1,12 @@
 package output
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/dkoosis/snipe/internal/util"
@@ -202,6 +205,47 @@ func FormatEditTarget(file string, r Range, hash string) string {
 		target += "@" + hash
 	}
 	return target
+}
+
+// ComputeRangeHash computes a SHA256 hash of the content within a line range.
+// Returns a truncated hash (16 hex chars) for embedding in edit_target.
+// If the range cannot be read, returns an empty string.
+func ComputeRangeHash(file string, r Range) string {
+	lines, err := readFileLines(file)
+	if err != nil {
+		return ""
+	}
+
+	startLine := r.Start.Line
+	endLine := r.End.Line
+
+	// Validate range
+	if startLine < 1 || endLine < startLine || startLine > len(lines) {
+		return ""
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+
+	// Extract lines in range
+	var content strings.Builder
+	for i := startLine; i <= endLine; i++ {
+		if i > startLine {
+			content.WriteString("\n")
+		}
+		content.WriteString(lines[i-1])
+	}
+
+	// Compute SHA256 and truncate to 16 hex chars (8 bytes)
+	h := sha256.Sum256([]byte(content.String()))
+	return hex.EncodeToString(h[:8])
+}
+
+// FormatEditTargetWithHash is a convenience function that computes the range hash
+// and formats the edit target in one call.
+func FormatEditTargetWithHash(file string, r Range) string {
+	hash := ComputeRangeHash(file, r)
+	return FormatEditTarget(file, r, hash)
 }
 
 // AddContext loads N lines of context before and after the result's range

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -106,6 +106,33 @@ func TestFormatEditTarget(t *testing.T) {
 	}
 }
 
+func TestComputeRangeHash(t *testing.T) {
+	// Test with invalid file returns empty string
+	hash := ComputeRangeHash("/nonexistent/file.go", Range{
+		Start: Position{Line: 1, Col: 1},
+		End:   Position{Line: 1, Col: 10},
+	})
+	if hash != "" {
+		t.Errorf("ComputeRangeHash() for nonexistent file = %q, want empty string", hash)
+	}
+
+	// Test with invalid range returns empty string
+	// (can't test without actual file, but we test the structure)
+}
+
+func TestFormatEditTargetWithHash(t *testing.T) {
+	// For nonexistent file, should return target without hash
+	r := Range{
+		Start: Position{Line: 1, Col: 1},
+		End:   Position{Line: 1, Col: 10},
+	}
+	got := FormatEditTargetWithHash("/nonexistent/file.go", r)
+	want := "/nonexistent/file.go:1:1-1:10"
+	if got != want {
+		t.Errorf("FormatEditTargetWithHash() for nonexistent file = %q, want %q", got, want)
+	}
+}
+
 func TestEstimateTokens(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/query/lookup.go
+++ b/internal/query/lookup.go
@@ -228,7 +228,7 @@ func (s *SymbolRow) ToResult() output.Result {
 		Kind:       s.Kind,
 		Name:       s.Name,
 		Match:      s.Signature.String,
-		EditTarget: output.FormatEditTarget(s.FilePath, r, s.FileHash),
+		EditTarget: output.FormatEditTargetWithHash(s.FilePath, r),
 	}
 }
 

--- a/internal/search/rg.go
+++ b/internal/search/rg.go
@@ -109,7 +109,7 @@ func Search(dir, pattern string, limit, contextLines int) ([]output.Result, erro
 				Kind:       "match",
 				Name:       sub.Match.Text,
 				Match:      strings.TrimSpace(data.Lines.Text),
-				EditTarget: output.FormatEditTarget(data.Path.Text, matchRange, ""),
+				EditTarget: output.FormatEditTargetWithHash(data.Path.Text, matchRange),
 			}
 			results = append(results, result)
 


### PR DESCRIPTION
## Summary
- Adds `ComputeRangeHash()` - computes SHA256 of specific line range content
- Updates `edit_target` to use range-based hash instead of full file hash
- More precise change detection for LLM edit verification
- Updates all commands to use the new range-based hashing

## Test plan
- [ ] Verify `edit_target` includes hash component
- [ ] Verify hash changes when content within range changes
- [ ] Verify hash is stable for unchanged content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements precise range-scoped hashing for edit targets and updates all result emitters to use it.
> 
> - Adds `ComputeRangeHash()` and `FormatEditTargetWithHash()` in `internal/output/json.go` to compute a truncated SHA256 over the selected line range and format `edit_target`
> - Replaces prior `FormatEditTarget(..., fileHash)` calls with `FormatEditTargetWithHash(...)` across `cmd/callees.go`, `cmd/callers.go`, `cmd/importers.go`, `cmd/imports.go`, `cmd/refs.go`, `internal/query/lookup.go`, and `internal/search/rg.go`
> - Adds tests for `ComputeRangeHash` and `FormatEditTargetWithHash` in `internal/output/types_test.go`
> - Updates baselines (`BASELINE*.json`) reflecting index/query timings and counts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862724714396ba224027c435425b9e3a3145128b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->