### PR TITLE
feat: add semantic truncation for body content

### DIFF
--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -349,3 +349,126 @@ func AddBody(result *Result) error {
 	result.Body = body
 	return nil
 }
+
+// TruncateBodySemantic truncates the Body field at a semantic boundary
+// (complete statement or declaration) to fit within maxLines.
+// Returns true if truncation occurred.
+func TruncateBodySemantic(result *Result, maxLines int) bool {
+	if result.Body == "" || maxLines <= 0 {
+		return false
+	}
+
+	lines := strings.Split(result.Body, "\n")
+	if len(lines) <= maxLines {
+		return false
+	}
+
+	// Find the best truncation point at a statement boundary
+	truncateAt := findSemanticBoundary(lines, maxLines)
+	if truncateAt <= 0 {
+		truncateAt = maxLines // Fallback to hard limit
+	}
+
+	result.Body = strings.Join(lines[:truncateAt], "\n") + "\n// ... truncated"
+	return true
+}
+
+// findSemanticBoundary finds the best line to truncate at, looking for
+// statement boundaries (lines ending with ; or } or { at appropriate nesting).
+// Returns 0 if no good boundary found before maxLines.
+func findSemanticBoundary(lines []string, maxLines int) int {
+	bestLine := 0
+	braceDepth := 0
+
+	for i := 0; i < maxLines && i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+
+		// Track brace depth
+		braceDepth += strings.Count(line, "{") - strings.Count(line, "}")
+
+		// Good truncation points: complete statements at depth 0 or 1
+		if braceDepth <= 1 {
+			// Line ends with semicolon (statement end)
+			if strings.HasSuffix(line, ";") {
+				bestLine = i + 1
+			}
+			// Line ends with closing brace (block end)
+			if strings.HasSuffix(line, "}") {
+				bestLine = i + 1
+			}
+			// Line ends with opening brace (start of block - include it)
+			if strings.HasSuffix(line, "{") && i < maxLines-1 {
+				bestLine = i + 1
+			}
+		}
+	}
+
+	return bestLine
+}
+
+// TruncateResultsSemantic truncates results to fit within a token budget,
+// preferring to keep complete results and truncating bodies at semantic boundaries.
+// Returns the truncated slice, whether truncation occurred, and the estimated token count.
+func TruncateResultsSemantic(results []Result, maxTokens int, maxBodyLines int) ([]Result, bool, int) {
+	if maxTokens <= 0 {
+		total := 0
+		for i := range results {
+			total += EstimateResultTokens(&results[i])
+		}
+		return results, false, total
+	}
+
+	// Reserve tokens for response wrapper
+	const overhead = 200
+	budget := maxTokens - overhead
+	if budget <= 0 {
+		return nil, len(results) > 0, 0
+	}
+
+	var truncated []Result
+	totalTokens := 0
+	didTruncate := false
+
+	for i := range results {
+		result := results[i] // Copy to allow modification
+
+		// First, try to fit the full result
+		resultTokens := EstimateResultTokens(&result)
+
+		if totalTokens+resultTokens <= budget {
+			totalTokens += resultTokens
+			truncated = append(truncated, result)
+			continue
+		}
+
+		// Result doesn't fit - try truncating its body
+		if result.Body != "" && maxBodyLines > 0 {
+			if TruncateBodySemantic(&result, maxBodyLines) {
+				didTruncate = true
+				resultTokens = EstimateResultTokens(&result)
+				if totalTokens+resultTokens <= budget {
+					totalTokens += resultTokens
+					truncated = append(truncated, result)
+					continue
+				}
+			}
+		}
+
+		// Still doesn't fit - stop adding results
+		if len(truncated) > 0 {
+			didTruncate = true
+			break
+		}
+
+		// First result must be included even if over budget
+		totalTokens += resultTokens
+		truncated = append(truncated, result)
+		didTruncate = true
+		break
+	}
+
+	return truncated, didTruncate, totalTokens
+}

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -316,4 +317,149 @@ func TestEstimateResultTokens(t *testing.T) {
 	if tokensWithBody <= tokens {
 		t.Errorf("tokens with body (%d) should be greater than without (%d)", tokensWithBody, tokens)
 	}
+}
+
+func TestTruncateBodySemantic(t *testing.T) {
+	t.Run("no truncation needed", func(t *testing.T) {
+		result := Result{Body: "line1\nline2\nline3"}
+		truncated := TruncateBodySemantic(&result, 5)
+		if truncated {
+			t.Error("should not truncate when lines fit")
+		}
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		result := Result{Body: ""}
+		truncated := TruncateBodySemantic(&result, 5)
+		if truncated {
+			t.Error("should not truncate empty body")
+		}
+	})
+
+	t.Run("truncate at statement boundary", func(t *testing.T) {
+		body := `func foo() {
+	x := 1;
+	y := 2;
+	z := 3;
+	return x + y + z;
+}`
+		result := Result{Body: body}
+		truncated := TruncateBodySemantic(&result, 4)
+		if !truncated {
+			t.Error("should truncate")
+		}
+		if !strings.Contains(result.Body, "// ... truncated") {
+			t.Error("should contain truncation marker")
+		}
+		// Should end at a statement boundary (semicolon)
+		lines := strings.Split(result.Body, "\n")
+		lastContentLine := ""
+		for i := len(lines) - 1; i >= 0; i-- {
+			if !strings.Contains(lines[i], "truncated") && strings.TrimSpace(lines[i]) != "" {
+				lastContentLine = strings.TrimSpace(lines[i])
+				break
+			}
+		}
+		if !strings.HasSuffix(lastContentLine, ";") && !strings.HasSuffix(lastContentLine, "{") {
+			t.Errorf("should end at statement boundary, got %q", lastContentLine)
+		}
+	})
+
+	t.Run("truncate at closing brace", func(t *testing.T) {
+		body := `func foo() {
+	if x > 0 {
+		return x
+	}
+	return 0
+}`
+		result := Result{Body: body}
+		truncated := TruncateBodySemantic(&result, 5)
+		if !truncated {
+			t.Error("should truncate")
+		}
+	})
+}
+
+func TestFindSemanticBoundary(t *testing.T) {
+	tests := []struct {
+		name     string
+		lines    []string
+		maxLines int
+		want     int
+	}{
+		{
+			name:     "statement with semicolon",
+			lines:    []string{"x := 1;", "y := 2;", "z := 3;"},
+			maxLines: 2,
+			want:     2,
+		},
+		{
+			name:     "closing brace",
+			lines:    []string{"if x {", "  return", "}", "next"},
+			maxLines: 3,
+			want:     3,
+		},
+		{
+			name:     "opening brace",
+			lines:    []string{"func foo() {", "  x := 1", "  return x"},
+			maxLines: 2,
+			want:     1,
+		},
+		{
+			name:     "no good boundary",
+			lines:    []string{"partial", "statement", "here"},
+			maxLines: 2,
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findSemanticBoundary(tt.lines, tt.maxLines)
+			if got != tt.want {
+				t.Errorf("findSemanticBoundary() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateResultsSemantic(t *testing.T) {
+	results := []Result{
+		{Name: "foo", File: "a.go", Match: "func foo()", Body: "func foo() {\n\treturn\n}"},
+		{Name: "bar", File: "b.go", Match: "func bar()", Body: "func bar() {\n\treturn\n}"},
+		{Name: "baz", File: "c.go", Match: "func baz()"},
+	}
+
+	t.Run("zero budget returns all", func(t *testing.T) {
+		got, truncated, _ := TruncateResultsSemantic(results, 0, 10)
+		if truncated {
+			t.Error("should not truncate with zero budget")
+		}
+		if len(got) != len(results) {
+			t.Errorf("got %d results, want %d", len(got), len(results))
+		}
+	})
+
+	t.Run("large budget keeps all", func(t *testing.T) {
+		got, truncated, tokens := TruncateResultsSemantic(results, 10000, 10)
+		if truncated {
+			t.Error("should not truncate with large budget")
+		}
+		if len(got) != len(results) {
+			t.Errorf("got %d results, want %d", len(got), len(results))
+		}
+		if tokens == 0 {
+			t.Error("tokens should be non-zero")
+		}
+	})
+
+	t.Run("small budget truncates", func(t *testing.T) {
+		got, truncated, _ := TruncateResultsSemantic(results, 300, 5)
+		if !truncated {
+			t.Error("should truncate with small budget")
+		}
+		if len(got) == 0 {
+			t.Error("should return at least one result")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Adds `TruncateBodySemantic()` to truncate code bodies at statement boundaries
- Adds `TruncateResultsSemantic()` for token-budget-aware truncation with semantic boundaries
- Truncates at semicolons, closing braces, rather than mid-line
- Cleaner output for LLM consumption

## Test plan
- [ ] Verify body truncation ends at statement boundaries
- [ ] Verify `// ... truncated` marker is added
- [ ] Verify token budget is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)