### PR TITLE
feat: quick wins - output improvements

### DIFF
--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -163,6 +163,7 @@ func runRefs(cmd *cobra.Command, args []string) error {
 			FileAbs:    ref.FilePath,
 			Range:      refRange,
 			Kind:       "ref",
+			Name:       symbolName,
 			Match:      ref.Snippet,
 			EditTarget: output.FormatEditTargetWithHash(filePath, ref.FilePath, refRange),
 		}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -64,7 +64,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		Meta: output.Meta{
 			Command:       "search",
 			Query:         map[string]string{"pattern": pattern},
-			IndexState:    output.IndexMissing, // search doesn't use index
+			IndexState:    output.IndexNotUsed, // search doesn't use index
 			Degraded:      []string{"no_index"},
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         len(results),

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -38,6 +38,7 @@ const (
 	IndexFresh   IndexState = "fresh"
 	IndexStale   IndexState = "stale"
 	IndexMissing IndexState = "missing"
+	IndexNotUsed IndexState = "not_used"
 )
 
 // Error represents an error response
@@ -59,23 +60,24 @@ type Candidate struct {
 	Name string `json:"name"`
 	File string `json:"file"`
 	Kind string `json:"kind"`
+	Doc  string `json:"doc,omitempty"`
 }
 
 // Result represents a single navigation result
 type Result struct {
 	ID         string     `json:"id"`
-	File       string     `json:"file"`                // Relative path (for output)
-	FileAbs    string     `json:"-"`                   // Absolute path (for file operations, not exported)
+	File       string     `json:"file"`                  // Relative path (for output)
+	FileAbs    string     `json:"-"`                     // Absolute path (for file operations, not exported)
 	Range      Range      `json:"range"`
-	Kind       string     `json:"kind"`
-	Name       string     `json:"name"`
-	Match      string     `json:"match"`
+	Kind       string     `json:"kind,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	Match      string     `json:"match,omitempty"`
 	Body       string     `json:"body,omitempty"`
 	Score      float64    `json:"score,omitempty"`
 	Enclosing  *Enclosing `json:"enclosing,omitempty"`
 	Context    *Context   `json:"context,omitempty"`
 	Siblings   []Sibling  `json:"siblings,omitempty"`
-	EditTarget string     `json:"edit_target"`
+	EditTarget string     `json:"edit_target,omitempty"`
 }
 
 // Sibling represents another declaration of the same kind in the same file
@@ -136,12 +138,36 @@ const (
 	ErrInternal        = "INTERNAL_ERROR"
 )
 
-// NewNotFoundError creates a NOT_FOUND error
-func NewNotFoundError(symbol string) *Error {
+// NewNotFoundError creates a NOT_FOUND error with optional similar symbol suggestions.
+func NewNotFoundError(symbol string, suggestions ...string) *Error {
+	msg := "Symbol not found: " + symbol
+	if len(suggestions) > 0 {
+		msg += ". Did you mean: " + joinSuggestions(suggestions)
+	}
 	return &Error{
 		Code:    ErrNotFound,
-		Message: "Symbol not found: " + symbol,
+		Message: msg,
 	}
+}
+
+// joinSuggestions formats a list of suggestions for display.
+func joinSuggestions(suggestions []string) string {
+	if len(suggestions) == 0 {
+		return ""
+	}
+	if len(suggestions) == 1 {
+		return suggestions[0] + "?"
+	}
+	// Join all but the last with commas, then add "or" before the last
+	result := ""
+	for i, s := range suggestions[:len(suggestions)-1] {
+		if i > 0 {
+			result += ", "
+		}
+		result += s
+	}
+	result += ", or " + suggestions[len(suggestions)-1] + "?"
+	return result
 }
 
 // NewAmbiguousError creates an AMBIGUOUS_SYMBOL error

--- a/internal/query/lookup.go
+++ b/internal/query/lookup.go
@@ -250,11 +250,23 @@ func (s *SymbolRow) ToCandidate() output.Candidate {
 	if filePath == "" {
 		filePath = s.FilePath // Fallback to absolute if relative not available
 	}
+	// Extract a short doc snippet (first line, truncated to 80 chars)
+	docSnippet := ""
+	if s.Doc.Valid && s.Doc.String != "" {
+		docSnippet = s.Doc.String
+		if idx := strings.Index(docSnippet, "\n"); idx != -1 {
+			docSnippet = docSnippet[:idx]
+		}
+		if len(docSnippet) > 80 {
+			docSnippet = docSnippet[:77] + "..."
+		}
+	}
 	return output.Candidate{
 		ID:   s.ID,
 		Name: s.Name,
 		File: filePath,
 		Kind: s.Kind,
+		Doc:  docSnippet,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change search `index_state` from `"missing"` to `"not_used"` for semantic clarity - search doesn't use the index, so "missing" was misleading
- Populate refs results with referenced symbol `name` field for better context
- Add `omitempty` to Result fields that may be empty (`kind`, `name`, `match`, `edit_target`) to reduce JSON payload size
- Include doc snippet in `AMBIGUOUS_SYMBOL` candidate output to help users distinguish between similarly-named symbols

## Test plan
- [x] `snipe search foo` shows `"index_state": "not_used"`
- [x] `snipe refs Symbol` results have populated `name` field
- [x] No `"field": ""` or `"field": null` in JSON output (verified with `jq`)
- [x] AMBIGUOUS_SYMBOL candidates include doc snippet when available
- [x] `go test ./...` passes
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)