### PR TITLE
feat: dx - fuzzy symbol suggestions

### DIFF
--- a/cmd/def.go
+++ b/cmd/def.go
@@ -111,7 +111,14 @@ func runDef(cmd *cobra.Command, args []string) error {
 		}
 
 		if len(symbols) == 0 {
-			return w.WriteError("def", output.NewNotFoundError(name))
+			// Try to find similar symbols for helpful suggestions
+			maxDist := query.DefaultMaxDistance(name)
+			suggestions, err := query.FindSimilarSymbols(s.DB(), name, maxDist, 3)
+			if err != nil {
+				// If fuzzy search fails, just return the basic error
+				return w.WriteError("def", output.NewNotFoundError(name))
+			}
+			return w.WriteError("def", output.NewNotFoundError(name, suggestions...))
 		}
 
 		if len(symbols) > 1 {

--- a/internal/query/fuzzy.go
+++ b/internal/query/fuzzy.go
@@ -1,0 +1,162 @@
+package query
+
+import (
+	"database/sql"
+	"sort"
+	"strings"
+)
+
+// FuzzyMatch represents a fuzzy match result with its distance score.
+type FuzzyMatch struct {
+	Name     string
+	Distance int
+}
+
+// LevenshteinDistance computes the edit distance between two strings.
+// This is the minimum number of single-character edits (insertions,
+// deletions, or substitutions) required to transform s1 into s2.
+func LevenshteinDistance(s1, s2 string) int {
+	// Convert to lowercase for case-insensitive comparison
+	s1 = strings.ToLower(s1)
+	s2 = strings.ToLower(s2)
+
+	if len(s1) == 0 {
+		return len(s2)
+	}
+	if len(s2) == 0 {
+		return len(s1)
+	}
+
+	// Create two rows for the DP matrix (space optimization)
+	prev := make([]int, len(s2)+1)
+	curr := make([]int, len(s2)+1)
+
+	// Initialize first row
+	for j := range prev {
+		prev[j] = j
+	}
+
+	// Fill in the matrix
+	for i := 1; i <= len(s1); i++ {
+		curr[0] = i
+		for j := 1; j <= len(s2); j++ {
+			cost := 1
+			if s1[i-1] == s2[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[len(s2)]
+}
+
+// FindSimilarSymbols queries the database for symbols similar to the given name.
+// It returns up to maxResults symbols with Levenshtein distance <= maxDistance.
+func FindSimilarSymbols(db *sql.DB, name string, maxDistance, maxResults int) ([]string, error) {
+	// Query all symbol names from the database
+	// We limit to a reasonable set by first checking prefix matches and substring matches
+	rows, err := db.Query(`
+		SELECT DISTINCT name FROM symbols
+		WHERE name LIKE ? OR name LIKE ? OR name LIKE ?
+		LIMIT 1000
+	`, name+"%", "%"+name+"%", strings.ToLower(name)+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var matches []FuzzyMatch
+	for rows.Next() {
+		var symName string
+		if err := rows.Scan(&symName); err != nil {
+			return nil, err
+		}
+
+		dist := LevenshteinDistance(name, symName)
+		if dist <= maxDistance && dist > 0 { // Exclude exact matches (dist == 0)
+			matches = append(matches, FuzzyMatch{Name: symName, Distance: dist})
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// If we didn't find enough matches with the prefix/substring approach,
+	// do a broader search
+	if len(matches) < maxResults {
+		rows2, err := db.Query(`
+			SELECT DISTINCT name FROM symbols
+			LIMIT 5000
+		`)
+		if err != nil {
+			return nil, err
+		}
+		defer rows2.Close()
+
+		seen := make(map[string]bool)
+		for _, m := range matches {
+			seen[m.Name] = true
+		}
+
+		for rows2.Next() {
+			var symName string
+			if err := rows2.Scan(&symName); err != nil {
+				return nil, err
+			}
+
+			if seen[symName] {
+				continue
+			}
+
+			dist := LevenshteinDistance(name, symName)
+			if dist <= maxDistance && dist > 0 {
+				matches = append(matches, FuzzyMatch{Name: symName, Distance: dist})
+				seen[symName] = true
+			}
+		}
+
+		if err := rows2.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort by distance (closest matches first)
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Distance != matches[j].Distance {
+			return matches[i].Distance < matches[j].Distance
+		}
+		// Secondary sort by name length (prefer shorter names)
+		return len(matches[i].Name) < len(matches[j].Name)
+	})
+
+	// Return top results
+	result := make([]string, 0, maxResults)
+	for i := 0; i < len(matches) && i < maxResults; i++ {
+		result = append(result, matches[i].Name)
+	}
+
+	return result, nil
+}
+
+// DefaultMaxDistance returns a reasonable max distance based on the query length.
+// Shorter queries allow fewer edits, longer queries allow more.
+func DefaultMaxDistance(query string) int {
+	length := len(query)
+	switch {
+	case length <= 3:
+		return 1
+	case length <= 6:
+		return 2
+	case length <= 12:
+		return 3
+	default:
+		return 4
+	}
+}

--- a/internal/query/fuzzy_test.go
+++ b/internal/query/fuzzy_test.go
@@ -1,0 +1,305 @@
+package query
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		s1, s2 string
+		want   int
+	}{
+		// Identical strings
+		{"", "", 0},
+		{"a", "a", 0},
+		{"hello", "hello", 0},
+
+		// Empty string cases
+		{"", "abc", 3},
+		{"abc", "", 3},
+
+		// Single character changes
+		{"cat", "hat", 1},  // substitution
+		{"cat", "cats", 1}, // insertion
+		{"cats", "cat", 1}, // deletion
+
+		// Multiple changes
+		{"kitten", "sitting", 3},
+		{"saturday", "sunday", 3},
+
+		// Case insensitivity
+		{"Hello", "hello", 0},
+		{"WORLD", "world", 0},
+		{"GoLang", "golang", 0},
+
+		// Common typos
+		{"handler", "Handler", 0},
+		{"hanlder", "handler", 2}, // transposition = 2 edits
+		{"hnadler", "handler", 2},
+		{"proces", "process", 1},
+		{"proccess", "process", 1},
+
+		// Symbol name variations
+		{"ProcessOrder", "processorder", 0},
+		{"ProcessOrdr", "ProcessOrder", 1},
+		{"ProccessOrder", "ProcessOrder", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.s1+"_"+tt.s2, func(t *testing.T) {
+			got := LevenshteinDistance(tt.s1, tt.s2)
+			if got != tt.want {
+				t.Errorf("LevenshteinDistance(%q, %q) = %d, want %d", tt.s1, tt.s2, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultMaxDistance(t *testing.T) {
+	tests := []struct {
+		query string
+		want  int
+	}{
+		{"ab", 1},
+		{"abc", 1},
+		{"abcd", 2},
+		{"abcdef", 2},
+		{"abcdefg", 3},
+		{"abcdefghijkl", 3},
+		{"abcdefghijklm", 4},
+		{"abcdefghijklmnop", 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got := DefaultMaxDistance(tt.query)
+			if got != tt.want {
+				t.Errorf("DefaultMaxDistance(%q) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindSimilarSymbols(t *testing.T) {
+	// Create an in-memory SQLite database for testing
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create the symbols table
+	_, err = db.Exec(`
+		CREATE TABLE symbols (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			kind TEXT,
+			file_path TEXT,
+			file_path_rel TEXT,
+			line_start INTEGER,
+			col_start INTEGER,
+			line_end INTEGER,
+			col_end INTEGER,
+			signature TEXT,
+			doc TEXT,
+			receiver TEXT
+		);
+		CREATE INDEX idx_symbols_name ON symbols(name);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert test symbols
+	symbols := []string{
+		"ProcessOrder",
+		"ProcessPayment",
+		"ProcessRefund",
+		"HandleRequest",
+		"HandleResponse",
+		"ValidateInput",
+		"ValidateOutput",
+		"CreateUser",
+		"DeleteUser",
+		"UpdateUser",
+	}
+
+	for i, name := range symbols {
+		_, err = db.Exec(`
+			INSERT INTO symbols (id, name, kind, file_path, line_start, col_start, line_end, col_end)
+			VALUES (?, ?, 'func', 'test.go', 1, 1, 10, 1)
+		`, i, name)
+		if err != nil {
+			t.Fatalf("Failed to insert symbol: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		query       string
+		maxDist     int
+		maxResults  int
+		wantContain []string
+		wantExclude []string
+	}{
+		{
+			name:        "typo in ProcessOrder",
+			query:       "ProccessOrder",
+			maxDist:     2,
+			maxResults:  3,
+			wantContain: []string{"ProcessOrder"},
+		},
+		{
+			name:        "missing letter",
+			query:       "ProcessOrdr",
+			maxDist:     2,
+			maxResults:  3,
+			wantContain: []string{"ProcessOrder"},
+		},
+		{
+			name:        "partial match Process",
+			query:       "Process",
+			maxDist:     3,
+			maxResults:  5,
+			wantContain: []string{}, // "Process" is a prefix, not within edit distance of full names
+		},
+		{
+			name:        "typo in Handle",
+			query:       "Hanle",
+			maxDist:     2,
+			maxResults:  3,
+			wantContain: []string{}, // Edit distance to HandleRequest/HandleResponse is > 2
+		},
+		{
+			name:        "close match CreateUser",
+			query:       "CreatUser",
+			maxDist:     2,
+			maxResults:  3,
+			wantContain: []string{"CreateUser"},
+		},
+		{
+			name:       "no matches for completely different",
+			query:      "XyzAbc",
+			maxDist:    2,
+			maxResults: 3,
+			// Should return nothing as no symbols are within distance 2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FindSimilarSymbols(db, tt.query, tt.maxDist, tt.maxResults)
+			if err != nil {
+				t.Fatalf("FindSimilarSymbols() error = %v", err)
+			}
+
+			// Check that expected symbols are present
+			for _, want := range tt.wantContain {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("FindSimilarSymbols() missing expected %q, got %v", want, got)
+				}
+			}
+
+			// Check that excluded symbols are not present
+			for _, exclude := range tt.wantExclude {
+				for _, g := range got {
+					if g == exclude {
+						t.Errorf("FindSimilarSymbols() should not contain %q, got %v", exclude, got)
+					}
+				}
+			}
+
+			// Check max results limit
+			if len(got) > tt.maxResults {
+				t.Errorf("FindSimilarSymbols() returned %d results, want at most %d", len(got), tt.maxResults)
+			}
+		})
+	}
+}
+
+func TestFindSimilarSymbols_SortedByDistance(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE symbols (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			kind TEXT,
+			file_path TEXT,
+			file_path_rel TEXT,
+			line_start INTEGER,
+			col_start INTEGER,
+			line_end INTEGER,
+			col_end INTEGER,
+			signature TEXT,
+			doc TEXT,
+			receiver TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert symbols with varying distances from "Handler"
+	symbols := []string{
+		"Handler",   // distance 0 (exact, should be excluded)
+		"Handlers",  // distance 1
+		"HandlerX",  // distance 1
+		"Handlery",  // distance 1
+		"Hndler",    // distance 1
+		"Handlerss", // distance 2
+		"Haandler",  // distance 1
+	}
+
+	for i, name := range symbols {
+		_, err = db.Exec(`
+			INSERT INTO symbols (id, name, kind, file_path, line_start, col_start, line_end, col_end)
+			VALUES (?, ?, 'func', 'test.go', 1, 1, 10, 1)
+		`, i, name)
+		if err != nil {
+			t.Fatalf("Failed to insert symbol: %v", err)
+		}
+	}
+
+	got, err := FindSimilarSymbols(db, "Handler", 2, 10)
+	if err != nil {
+		t.Fatalf("FindSimilarSymbols() error = %v", err)
+	}
+
+	// Should not include exact match
+	for _, g := range got {
+		if g == "Handler" {
+			t.Errorf("FindSimilarSymbols() should not include exact match 'Handler'")
+		}
+	}
+
+	// Verify results are sorted by distance
+	prevDist := 0
+	for _, g := range got {
+		dist := LevenshteinDistance("Handler", g)
+		if dist < prevDist {
+			t.Errorf("Results not sorted by distance: %v", got)
+			break
+		}
+		prevDist = dist
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary
- Add Levenshtein distance-based fuzzy matching for symbol suggestions
- When `snipe def` cannot find a symbol, it now suggests similar symbols
- Helps users recover from typos (e.g., `ProccessOrder` -> `ProcessOrder?`)

## Changes
- `internal/query/fuzzy.go`: Levenshtein distance algorithm and `FindSimilarSymbols` function
- `cmd/def.go`: Integration with NOT_FOUND error handling
- `internal/query/fuzzy_test.go`: Comprehensive tests for fuzzy matching

## Test plan
- [x] Unit tests for Levenshtein distance (various edge cases)
- [x] Unit tests for `FindSimilarSymbols` with in-memory SQLite
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

## Example output
```json
{
  "error": {
    "code": "NOT_FOUND",
    "message": "Symbol not found: ProccessOrder. Did you mean: ProcessOrder?"
  }
}
```