### PR TITLE
feat: navigation - impl and pkg commands

### DIFF
--- a/cmd/impl.go
+++ b/cmd/impl.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+var implCmd = &cobra.Command{
+	Use:   "impl [interface]",
+	Short: "Find types implementing an interface",
+	Long: `Finds types that potentially implement a given interface.
+
+Since Go uses structural typing, this command finds types that reference
+the interface in the same file, which often indicates implementation.
+
+Examples:
+  snipe impl Reader              # Find types implementing Reader
+  snipe impl --id abc123         # Find implementers by interface ID
+  snipe impl io.Writer           # Qualified interface name`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runImpl,
+}
+
+var implID string
+
+func init() {
+	implCmd.Flags().StringVar(&implID, "id", "", "Interface ID to look up")
+	rootCmd.AddCommand(implCmd)
+}
+
+func runImpl(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+
+	_, human, lim, off, contextLines, withBody, _, summary := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, human)
+
+	if len(args) == 0 && implID == "" {
+		return w.WriteError("impl", &output.Error{
+			Code:    output.ErrInternal,
+			Message: "provide an interface name or --id",
+		})
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return w.WriteError("impl", &output.Error{
+			Code:    output.ErrInternal,
+			Message: "failed to get working directory: " + err.Error(),
+		})
+	}
+
+	dbPath := store.DefaultIndexPath(dir)
+	if !store.Exists(dbPath) {
+		return w.WriteError("impl", output.NewMissingIndexError())
+	}
+
+	s, err := store.Open(dbPath)
+	if err != nil {
+		return w.WriteError("impl", &output.Error{
+			Code:    output.ErrInternal,
+			Message: "failed to open index: " + err.Error(),
+		})
+	}
+	defer s.Close()
+
+	var interfaceID string
+	var queryInfo map[string]string
+
+	if implID != "" {
+		interfaceID = implID
+		queryInfo = map[string]string{"id": implID}
+	} else {
+		name := args[0]
+		symbols, err := query.LookupByName(s.DB(), name)
+		if err != nil {
+			return w.WriteError("impl", &output.Error{
+				Code:    output.ErrInternal,
+				Message: err.Error(),
+			})
+		}
+
+		if len(symbols) == 0 {
+			return w.WriteError("impl", output.NewNotFoundError(name))
+		}
+
+		// Filter to interfaces only
+		var interfaces []query.SymbolRow
+		for _, sym := range symbols {
+			if sym.Kind == "interface" {
+				interfaces = append(interfaces, sym)
+			}
+		}
+
+		if len(interfaces) == 0 {
+			return w.WriteError("impl", &output.Error{
+				Code:    output.ErrNotFound,
+				Message: name + " is not an interface",
+			})
+		}
+
+		if len(interfaces) > 1 {
+			candidates := make([]output.Candidate, len(interfaces))
+			for i, sym := range interfaces {
+				candidates[i] = sym.ToCandidate()
+			}
+			return w.WriteError("impl", output.NewAmbiguousError(name, candidates))
+		}
+
+		interfaceID = interfaces[0].ID
+		queryInfo = map[string]string{"interface": name}
+	}
+
+	// Find implementers
+	implementers, err := query.FindImplementers(s.DB(), interfaceID, lim, off)
+	if err != nil {
+		return w.WriteError("impl", &output.Error{
+			Code:    output.ErrInternal,
+			Message: err.Error(),
+		})
+	}
+
+	// Convert to results
+	results := make([]output.Result, len(implementers))
+	tokenEstimate := 0
+	var degraded []string
+
+	for i, impl := range implementers {
+		result := impl.ToResult()
+
+		// Add body if requested
+		if withBody {
+			if err := output.AddBody(&result); err != nil {
+				degraded = append(degraded, "body_extraction_failed")
+			}
+		}
+
+		// Add context lines if requested (only if not showing full body)
+		if contextLines > 0 && !withBody {
+			if err := output.AddContext(&result, contextLines); err != nil {
+				degraded = append(degraded, "context_extraction_failed")
+			}
+		}
+
+		results[i] = result
+		tokenEstimate += output.EstimateTokens(impl.Signature.String)
+		if result.Body != "" {
+			tokenEstimate = output.EstimateTokens(result.Body)
+		}
+	}
+
+	// Deduplicate degraded messages
+	degraded = uniqueStrings(degraded)
+
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
+	// If summary mode, return condensed output
+	if summary {
+		summaryData := output.BuildSummary(results)
+		summaryResp := output.Response[output.Summary]{
+			Results: []output.Summary{summaryData},
+			Meta: output.Meta{
+				Command:    "impl",
+				Query:      queryInfo,
+				RepoRoot:   dir,
+				IndexState: query.CheckIndexState(s.DB(), dir, Version),
+				Degraded:   degraded,
+				Ms:         time.Since(start).Milliseconds(),
+				Total:      summaryData.Total,
+				Offset:     off,
+				Limit:      lim,
+				Truncated:  len(results) >= lim,
+			},
+		}
+		return w.WriteResponse(summaryResp)
+	}
+
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
+	resp := output.Response[output.Result]{
+		Results: results,
+		Meta: output.Meta{
+			Command:       "impl",
+			Query:         queryInfo,
+			RepoRoot:      dir,
+			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			Degraded:      degraded,
+			Ms:            time.Since(start).Milliseconds(),
+			Total:         len(results),
+			Offset:        off,
+			Limit:         lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
+			TokenEstimate: tokenEstimate,
+		},
+	}
+
+	return w.WriteResponse(resp)
+}

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+var pkgCmd = &cobra.Command{
+	Use:   "pkg <name>",
+	Short: "Show package overview with exported symbols",
+	Long: `Shows an overview of a package including its exported symbols.
+
+Displays all exported types, functions, constants, and variables in a package,
+organized by kind for easy navigation.
+
+Examples:
+  snipe pkg store              # Show exported symbols in store package
+  snipe pkg internal/query     # Show exported symbols in internal/query
+  snipe pkg output             # Show exported symbols matching 'output'`,
+	Args: cobra.ExactArgs(1),
+	RunE: runPkg,
+}
+
+func init() {
+	rootCmd.AddCommand(pkgCmd)
+}
+
+func runPkg(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+
+	_, human, lim, off, contextLines, withBody, _, summary := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, human)
+
+	pkgPattern := args[0]
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return w.WriteError("pkg", &output.Error{
+			Code:    output.ErrInternal,
+			Message: "failed to get working directory: " + err.Error(),
+		})
+	}
+
+	dbPath := store.DefaultIndexPath(dir)
+	if !store.Exists(dbPath) {
+		return w.WriteError("pkg", output.NewMissingIndexError())
+	}
+
+	s, err := store.Open(dbPath)
+	if err != nil {
+		return w.WriteError("pkg", &output.Error{
+			Code:    output.ErrInternal,
+			Message: "failed to open index: " + err.Error(),
+		})
+	}
+	defer s.Close()
+
+	queryInfo := map[string]string{"package": pkgPattern}
+
+	// Find package symbols
+	symbols, err := query.FindPackageSymbols(s.DB(), pkgPattern, lim, off)
+	if err != nil {
+		return w.WriteError("pkg", &output.Error{
+			Code:    output.ErrInternal,
+			Message: err.Error(),
+		})
+	}
+
+	if len(symbols) == 0 {
+		return w.WriteError("pkg", &output.Error{
+			Code:    output.ErrNotFound,
+			Message: "no exported symbols found in package matching: " + pkgPattern,
+		})
+	}
+
+	// Convert to results
+	results := make([]output.Result, len(symbols))
+	tokenEstimate := 0
+	var degraded []string
+
+	for i, sym := range symbols {
+		result := sym.ToResult()
+
+		// Add body if requested
+		if withBody {
+			if err := output.AddBody(&result); err != nil {
+				degraded = append(degraded, "body_extraction_failed")
+			}
+		}
+
+		// Add context lines if requested (only if not showing full body)
+		if contextLines > 0 && !withBody {
+			if err := output.AddContext(&result, contextLines); err != nil {
+				degraded = append(degraded, "context_extraction_failed")
+			}
+		}
+
+		results[i] = result
+		tokenEstimate += output.EstimateTokens(sym.Signature.String)
+		if result.Body != "" {
+			tokenEstimate = output.EstimateTokens(result.Body)
+		}
+	}
+
+	// Deduplicate degraded messages
+	degraded = uniqueStrings(degraded)
+
+	// Apply token budget truncation if specified
+	maxTok := GetMaxTokens()
+	tokenTruncated := false
+	if maxTok > 0 {
+		results, tokenTruncated = output.TruncateToTokenBudget(results, maxTok)
+	}
+
+	// If summary mode, return condensed output
+	if summary {
+		summaryData := output.BuildSummary(results)
+		summaryResp := output.Response[output.Summary]{
+			Results: []output.Summary{summaryData},
+			Meta: output.Meta{
+				Command:    "pkg",
+				Query:      queryInfo,
+				RepoRoot:   dir,
+				IndexState: query.CheckIndexState(s.DB(), dir, Version),
+				Degraded:   degraded,
+				Ms:         time.Since(start).Milliseconds(),
+				Total:      summaryData.Total,
+				Offset:     off,
+				Limit:      lim,
+				Truncated:  len(results) >= lim,
+			},
+		}
+		return w.WriteResponse(summaryResp)
+	}
+
+	// Recalculate token estimate after truncation
+	tokenEstimate = 0
+	for i := range results {
+		tokenEstimate += output.EstimateResultTokens(&results[i])
+	}
+
+	resp := output.Response[output.Result]{
+		Results: results,
+		Meta: output.Meta{
+			Command:       "pkg",
+			Query:         queryInfo,
+			RepoRoot:      dir,
+			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			Degraded:      degraded,
+			Ms:            time.Since(start).Milliseconds(),
+			Total:         len(results),
+			Offset:        off,
+			Limit:         lim,
+			Truncated:     len(results) >= lim || tokenTruncated,
+			TokenEstimate: tokenEstimate,
+		},
+	}
+
+	return w.WriteResponse(resp)
+}

--- a/internal/query/lookup.go
+++ b/internal/query/lookup.go
@@ -398,3 +398,92 @@ func FindCallees(db *sql.DB, symbolID string, limit, offset int) ([]CallRow, err
 	}
 	return results, rows.Err()
 }
+
+// FindImplementers finds types that potentially implement an interface.
+// Since Go uses structural typing, we look for types that have methods
+// matching the interface's required methods.
+func FindImplementers(db *sql.DB, interfaceID string, limit, offset int) ([]SymbolRow, error) {
+	// For now, we use a simpler heuristic: find struct/type symbols that reference this interface
+	rows, err := db.Query(`
+		SELECT DISTINCT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.line_start, s.col_start, s.line_end, s.col_end,
+		       s.signature, s.doc, s.receiver, f.hash
+		FROM symbols s
+		LEFT JOIN files f ON s.file_path = f.path
+		WHERE s.kind IN ('struct', 'type')
+		  AND EXISTS (
+		    SELECT 1 FROM refs r
+		    WHERE r.symbol_id = ?
+		      AND r.file_path = s.file_path
+		  )
+		ORDER BY s.file_path, s.name
+		LIMIT ? OFFSET ?
+	`, interfaceID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query implementers: %w", err)
+	}
+	defer rows.Close()
+
+	return scanSymbolRows(rows)
+}
+
+// FindPackageSymbols finds all exported symbols in files matching a package path pattern.
+// It filters to exported symbols only (those starting with uppercase).
+func FindPackageSymbols(db *sql.DB, pkgPattern string, limit, offset int) ([]SymbolRow, error) {
+	// Match package pattern as a directory component in file paths
+	pattern := "%" + pkgPattern + "/%"
+
+	rows, err := db.Query(`
+		SELECT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.line_start, s.col_start, s.line_end, s.col_end,
+		       s.signature, s.doc, s.receiver, f.hash
+		FROM symbols s
+		LEFT JOIN files f ON s.file_path = f.path
+		WHERE (s.file_path_rel LIKE ? OR s.file_path LIKE ?)
+		  AND s.name GLOB '[A-Z]*'
+		  AND s.kind NOT IN ('field')
+		ORDER BY s.kind, s.name
+		LIMIT ? OFFSET ?
+	`, pattern, pattern, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query package symbols: %w", err)
+	}
+	defer rows.Close()
+
+	return scanSymbolRows(rows)
+}
+
+// FindSymbolsByKind finds symbols of a specific kind, optionally filtered by file path pattern.
+func FindSymbolsByKind(db *sql.DB, kind string, filePattern string, limit, offset int) ([]SymbolRow, error) {
+	var rows *sql.Rows
+	var err error
+
+	if filePattern != "" {
+		pattern := "%" + filePattern + "%"
+		rows, err = db.Query(`
+			SELECT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.line_start, s.col_start, s.line_end, s.col_end,
+			       s.signature, s.doc, s.receiver, f.hash
+			FROM symbols s
+			LEFT JOIN files f ON s.file_path = f.path
+			WHERE s.kind = ?
+			  AND (s.file_path_rel LIKE ? OR s.file_path LIKE ?)
+			ORDER BY s.file_path, s.line_start
+			LIMIT ? OFFSET ?
+		`, kind, pattern, pattern, limit, offset)
+	} else {
+		rows, err = db.Query(`
+			SELECT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.line_start, s.col_start, s.line_end, s.col_end,
+			       s.signature, s.doc, s.receiver, f.hash
+			FROM symbols s
+			LEFT JOIN files f ON s.file_path = f.path
+			WHERE s.kind = ?
+			ORDER BY s.file_path, s.line_start
+			LIMIT ? OFFSET ?
+		`, kind, limit, offset)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("query symbols by kind: %w", err)
+	}
+	defer rows.Close()
+
+	return scanSymbolRows(rows)
+}


### PR DESCRIPTION
## Summary
- Add `snipe impl <interface>` command to find types implementing an interface
- Add `snipe pkg <name>` command to show package overview with exported symbols
- Add supporting query functions: FindImplementers, FindPackageSymbols, FindSymbolsByKind

## Details

### `snipe impl <interface>`
Finds types that potentially implement a given interface. Since Go uses structural typing, this command finds struct/type symbols that reference the interface in the same file, which often indicates implementation.

Examples:
```bash
snipe impl Reader              # Find types implementing Reader
snipe impl --id abc123         # Find implementers by interface ID
snipe impl io.Writer           # Qualified interface name
```

### `snipe pkg <name>`
Shows an overview of a package including its exported symbols. Displays all exported types, functions, constants, and variables, organized by kind for easy navigation.

Examples:
```bash
snipe pkg store              # Show exported symbols in store package
snipe pkg internal/query     # Show exported symbols in internal/query
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual testing with actual indexed codebase

Generated with [Claude Code](https://claude.com/claude-code)