### PR TITLE
fix: correctness - position resolution and exclusion matching

### DIFF
--- a/internal/index/loader.go
+++ b/internal/index/loader.go
@@ -192,7 +192,6 @@ func filterPackages(pkgs []*packages.Package, exclude []string) []*packages.Pack
 	for _, pkg := range pkgs {
 		excluded := false
 		for _, pattern := range exclude {
-			// Simple substring match for now
 			if matchesExclude(pkg.PkgPath, pattern) {
 				excluded = true
 				break
@@ -206,7 +205,31 @@ func filterPackages(pkgs []*packages.Package, exclude []string) []*packages.Pack
 }
 
 func matchesExclude(pkgPath, pattern string) bool {
-	// Split by "/" to get path components (package paths use forward slashes)
+	if pattern == "" {
+		return false
+	}
+
+	// If pattern contains "/", it's a multi-component pattern
+	// Match it as a contiguous path segment
+	if strings.Contains(pattern, "/") {
+		// Check if pattern appears as a complete segment (not partial match)
+		// Pattern must be at start, end, or surrounded by "/"
+		if pkgPath == pattern {
+			return true
+		}
+		if strings.HasPrefix(pkgPath, pattern+"/") {
+			return true
+		}
+		if strings.HasSuffix(pkgPath, "/"+pattern) {
+			return true
+		}
+		if strings.Contains(pkgPath, "/"+pattern+"/") {
+			return true
+		}
+		return false
+	}
+
+	// Single component pattern: split by "/" and match exactly
 	for _, component := range strings.Split(pkgPath, "/") {
 		if component == pattern {
 			return true

--- a/internal/index/loader_test.go
+++ b/internal/index/loader_test.go
@@ -90,6 +90,44 @@ func TestMatchesExclude(t *testing.T) {
 			pattern: "",
 			want:    false,
 		},
+
+		// Multi-component pattern tests
+		{
+			name:    "multi-component at start",
+			pkgPath: "vendor/v2/pkg",
+			pattern: "vendor/v2",
+			want:    true,
+		},
+		{
+			name:    "multi-component in middle",
+			pkgPath: "example.com/vendor/v2/pkg",
+			pattern: "vendor/v2",
+			want:    true,
+		},
+		{
+			name:    "multi-component at end",
+			pkgPath: "example.com/vendor/v2",
+			pattern: "vendor/v2",
+			want:    true,
+		},
+		{
+			name:    "multi-component exact match",
+			pkgPath: "vendor/v2",
+			pattern: "vendor/v2",
+			want:    true,
+		},
+		{
+			name:    "multi-component partial no match",
+			pkgPath: "example.com/myvendor/v2/pkg",
+			pattern: "vendor/v2",
+			want:    false,
+		},
+		{
+			name:    "multi-component suffix no match",
+			pkgPath: "example.com/vendor/v2beta/pkg",
+			pattern: "vendor/v2",
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/query/position.go
+++ b/internal/query/position.go
@@ -75,7 +75,24 @@ func ParsePosition(s string) (*PositionQuery, error) {
 // Note: pos.File should be an absolute path for optimal index usage.
 // Callers should resolve relative paths before calling this function.
 func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error) {
-	// First, try to find a reference at exactly this position
+	// First, try to find a symbol definition at exactly this position
+	// Check the identifier position (name_line/name_col) which is where users typically click
+	// This handles clicking directly on the symbol name in a definition
+	err = db.QueryRow(`
+		SELECT id FROM symbols
+		WHERE file_path = ? AND name_line = ? AND name_col = ?
+		LIMIT 1
+	`, pos.File, pos.Line, pos.Col).Scan(&symbolID)
+
+	if err == nil {
+		return symbolID, nil
+	}
+
+	if err != sql.ErrNoRows {
+		return "", fmt.Errorf("query symbols by name position: %w", err)
+	}
+
+	// Try to find a reference at exactly this position
 	// Uses idx_refs_position composite index for O(1) lookup
 	err = db.QueryRow(`
 		SELECT symbol_id FROM refs
@@ -89,6 +106,22 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 
 	if err != sql.ErrNoRows {
 		return "", fmt.Errorf("query refs: %w", err)
+	}
+
+	// Try to find a symbol whose identifier is on this line, closest to the column
+	err = db.QueryRow(`
+		SELECT id FROM symbols
+		WHERE file_path = ? AND name_line = ?
+		ORDER BY ABS(name_col - ?)
+		LIMIT 1
+	`, pos.File, pos.Line, pos.Col).Scan(&symbolID)
+
+	if err == nil {
+		return symbolID, nil
+	}
+
+	if err != sql.ErrNoRows {
+		return "", fmt.Errorf("query symbols by name line: %w", err)
 	}
 
 	// Try to find a reference on this line, closest to the column
@@ -107,7 +140,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		return "", fmt.Errorf("query refs by line: %w", err)
 	}
 
-	// Try to find a symbol definition at this position
+	// Try to find a symbol definition whose display range contains this position
 	// Uses idx_symbols_position composite index
 	err = db.QueryRow(`
 		SELECT id FROM symbols

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const schemaVersion = 9
+const schemaVersion = 10
 
 // migration represents a database migration.
 type migration struct {
@@ -162,6 +162,18 @@ var migrations = []migration{
 
 		-- Composite index on symbols for relative path + line lookups
 		CREATE INDEX IF NOT EXISTS idx_symbols_pathrel_linestart ON symbols(file_path_rel, line_start);
+		`,
+	},
+	{
+		version: 10,
+		name:    "name_position_indexes",
+		up: `
+		-- Composite index on symbols for identifier position lookups
+		-- Optimizes: def --at file:line:col when cursor is on symbol identifier
+		CREATE INDEX IF NOT EXISTS idx_symbols_name_position ON symbols(file_path, name_line, name_col);
+
+		-- Index for name_line only, for line-based closest match queries
+		CREATE INDEX IF NOT EXISTS idx_symbols_name_line ON symbols(file_path, name_line);
 		`,
 	},
 }


### PR DESCRIPTION
## Summary

- **Position resolution fix**: `ResolvePosition` now checks symbol `name_line`/`name_col` before searching refs, fixing the `--at` position resolution bug where clicking on a symbol definition could return wrong results
- **Exclusion matching enhancement**: `matchesExclude` now handles multi-component patterns like `vendor/v2` correctly
- **New schema migration (v10)**: Adds composite indexes on `(file_path, name_line, name_col)` and `(file_path, name_line)` to optimize the new position queries

## Test plan

- [x] All existing tests pass
- [x] New tests added for multi-component exclusion patterns
- [x] `go build ./...` succeeds
- [x] Manual verification: position resolution queries use new indexes

Generated with [Claude Code](https://claude.com/claude-code)