### PR TITLE
docs: add SQLite durability and maintenance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ snipe show --id abc123         # Expand previous result
         └─────────────────┘
 ```
 
+## SQLite durability and maintenance notes
+
+The index database is opened with WAL and `synchronous=NORMAL` to balance
+durability and latency for short-lived indexing and query workloads. If you
+need maximum durability (e.g., running in environments with frequent power
+loss), consider profiling with `synchronous=FULL` before changing defaults,
+as it can materially increase write latency. Use `ANALYZE` after large schema
+changes or bulk reindexing to refresh SQLite statistics. Periodic `VACUUM`
+is only recommended if you observe unbounded database growth after deletes,
+since it rewrites the entire file and can be I/O intensive.
+
 ## Output Example
 
 ```json


### PR DESCRIPTION
### Motivation
- Document the repository's SQLite defaults and maintenance guidance so operators understand WAL and `synchronous` trade-offs and when to run `ANALYZE`/`VACUUM`.

### Description
- Added a new "SQLite durability and maintenance notes" section to `README.md` describing the use of WAL, `synchronous=NORMAL`, when to consider `synchronous=FULL`, and guidance for running `ANALYZE` and `VACUUM`.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb731e1e88325854291adcebfffe5)