### PR TITLE
feat: add --output-nug flag for Orca nugget export

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	contextFormat string
-	contextFull   bool
-	contextBoot   bool
+	contextFormat    string
+	contextFull      bool
+	contextBoot      bool
+	contextOutputNug bool
 )
 
 var contextCmd = &cobra.Command{
@@ -46,6 +47,7 @@ func init() {
 	contextCmd.Flags().StringVar(&contextFormat, "format", "json", "Output format: json or yaml")
 	contextCmd.Flags().BoolVar(&contextFull, "full", false, "Include all symbols, not just key ones")
 	contextCmd.Flags().BoolVar(&contextBoot, "boot", false, "Minimal context for LLM boot (~2000 tokens)")
+	contextCmd.Flags().BoolVar(&contextOutputNug, "output-nug", false, "Output as Orca nugget YAML (for save_nug)")
 	rootCmd.AddCommand(contextCmd)
 }
 
@@ -86,26 +88,39 @@ func runContext(cmd *cobra.Command, args []string) error {
 		Full:     contextFull,
 	}
 
-	var output interface{}
-
 	if contextBoot {
 		// Generate minimal boot context
 		bootCtx, err := context.GenerateBoot(cfg)
 		if err != nil {
 			return fmt.Errorf("generate boot context: %w", err)
 		}
-		output = bootCtx
-	} else {
-		// Generate full context
-		ctx, err := context.Generate(cfg)
-		if err != nil {
-			return fmt.Errorf("generate context: %w", err)
+
+		// Output as nuggets if requested
+		if contextOutputNug {
+			nugs := bootCtx.ToNuggets()
+			return outputNuggets(nugs)
 		}
-		output = ctx
+
+		return outputContext(bootCtx, contextFormat)
 	}
 
-	// Output in requested format
-	switch contextFormat {
+	// Generate full context
+	ctx, err := context.Generate(cfg)
+	if err != nil {
+		return fmt.Errorf("generate context: %w", err)
+	}
+
+	// Output as nuggets if requested
+	if contextOutputNug {
+		nugs := ctx.ToNuggets()
+		return outputNuggets(nugs)
+	}
+
+	return outputContext(ctx, contextFormat)
+}
+
+func outputContext(output interface{}, format string) error {
+	switch format {
 	case "yaml":
 		enc := yaml.NewEncoder(os.Stdout)
 		enc.SetIndent(2)
@@ -119,8 +134,19 @@ func runContext(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("encode json: %w", err)
 		}
 	default:
-		return fmt.Errorf("unsupported format: %s (use json or yaml)", contextFormat)
+		return fmt.Errorf("unsupported format: %s (use json or yaml)", format)
 	}
+	return nil
+}
 
+func outputNuggets(nugs []context.Nugget) error {
+	enc := yaml.NewEncoder(os.Stdout)
+	enc.SetIndent(2)
+	for _, nug := range nugs {
+		if err := enc.Encode(nug); err != nil {
+			return fmt.Errorf("encode nug yaml: %w", err)
+		}
+		fmt.Println("---")
+	}
 	return nil
 }

--- a/internal/context/nug.go
+++ b/internal/context/nug.go
@@ -1,0 +1,158 @@
+package context
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Nugget represents an Orca knowledge graph nugget for save_nug.
+type Nugget struct {
+	ID   string   `yaml:"id"`
+	K    string   `yaml:"k"`
+	B    string   `yaml:"b"`
+	Tags []string `yaml:"tags,omitempty"`
+}
+
+// ToNuggets converts BootContext to Orca nuggets.
+func (b *BootContext) ToNuggets() []Nugget {
+	projectSlug := slugify(b.Project)
+
+	// Build the body content
+	var body strings.Builder
+	body.WriteString(fmt.Sprintf("lang: %s\n", b.Lang))
+	body.WriteString(fmt.Sprintf("build: %s\n", b.Build))
+	body.WriteString(fmt.Sprintf("test: %s\n", b.Test))
+
+	if len(b.EntryPoints) > 0 {
+		body.WriteString("entry_points:\n")
+		for _, ep := range b.EntryPoints {
+			body.WriteString(fmt.Sprintf("  - %s\n", ep))
+		}
+	}
+
+	if len(b.KeySymbols) > 0 {
+		body.WriteString("key_symbols:\n")
+		for _, sym := range b.KeySymbols {
+			body.WriteString(fmt.Sprintf("  - %s (%s:%d)\n", sym.Name, sym.File, sym.Line))
+		}
+	}
+
+	if b.Commit != "" {
+		body.WriteString(fmt.Sprintf("commit: %s\n", b.Commit))
+	}
+
+	return []Nugget{
+		{
+			ID:   fmt.Sprintf("n:project:%s", projectSlug),
+			K:    "project",
+			B:    body.String(),
+			Tags: []string{projectSlug, "boot-context"},
+		},
+	}
+}
+
+// ToNuggets converts ProjectContext to Orca nuggets.
+func (p *ProjectContext) ToNuggets() []Nugget {
+	projectSlug := slugify(p.Project.Name)
+	var nugs []Nugget
+
+	// Project overview nugget
+	var projBody strings.Builder
+	projBody.WriteString(fmt.Sprintf("name: %s\n", p.Project.Name))
+	projBody.WriteString(fmt.Sprintf("root: %s\n", p.Project.Root))
+	if len(p.Project.Lang) > 0 {
+		projBody.WriteString(fmt.Sprintf("lang: %s\n", strings.Join(p.Project.Lang, ", ")))
+	}
+	if p.Project.Build != "" {
+		projBody.WriteString(fmt.Sprintf("build: %s\n", p.Project.Build))
+	}
+	if p.Project.Test != "" {
+		projBody.WriteString(fmt.Sprintf("test: %s\n", p.Project.Test))
+	}
+
+	nugs = append(nugs, Nugget{
+		ID:   fmt.Sprintf("n:project:%s", projectSlug),
+		K:    "project",
+		B:    projBody.String(),
+		Tags: []string{projectSlug},
+	})
+
+	// Architecture nugget
+	if len(p.Architecture.Components) > 0 {
+		var archBody strings.Builder
+		archBody.WriteString("components:\n")
+		for _, comp := range p.Architecture.Components {
+			archBody.WriteString(fmt.Sprintf("  %s:\n", comp.Name))
+			archBody.WriteString(fmt.Sprintf("    purpose: %s\n", comp.Purpose))
+			if comp.Entry != "" {
+				archBody.WriteString(fmt.Sprintf("    entry: %s\n", comp.Entry))
+			}
+			if len(comp.KeyFiles) > 0 {
+				archBody.WriteString("    key_files:\n")
+				for _, f := range comp.KeyFiles {
+					archBody.WriteString(fmt.Sprintf("      - %s\n", f))
+				}
+			}
+		}
+
+		if len(p.Architecture.DataFlows) > 0 {
+			archBody.WriteString("data_flows:\n")
+			for _, df := range p.Architecture.DataFlows {
+				archBody.WriteString(fmt.Sprintf("  - %s\n", df))
+			}
+		}
+
+		nugs = append(nugs, Nugget{
+			ID:   fmt.Sprintf("n:map:%s-arch", projectSlug),
+			K:    "map",
+			B:    archBody.String(),
+			Tags: []string{projectSlug, "architecture"},
+		})
+	}
+
+	// Key symbols nugget
+	if len(p.Symbols.Types) > 0 || len(p.Symbols.Functions) > 0 {
+		var symBody strings.Builder
+		if len(p.Symbols.Types) > 0 {
+			symBody.WriteString("types:\n")
+			for _, t := range p.Symbols.Types {
+				symBody.WriteString(fmt.Sprintf("  - %s (%s:%d)\n", t.Name, t.File, t.Line))
+			}
+		}
+		if len(p.Symbols.Functions) > 0 {
+			symBody.WriteString("functions:\n")
+			for _, f := range p.Symbols.Functions {
+				symBody.WriteString(fmt.Sprintf("  - %s (%s:%d)\n", f.Name, f.File, f.Line))
+			}
+		}
+
+		nugs = append(nugs, Nugget{
+			ID:   fmt.Sprintf("n:map:%s-symbols", projectSlug),
+			K:    "map",
+			B:    symBody.String(),
+			Tags: []string{projectSlug, "symbols"},
+		})
+	}
+
+	return nugs
+}
+
+// slugify converts a string to a slug suitable for nugget IDs.
+func slugify(s string) string {
+	// Get base name if it's a path
+	s = filepath.Base(s)
+	// Convert to lowercase
+	s = strings.ToLower(s)
+	// Replace spaces and underscores with hyphens
+	s = strings.ReplaceAll(s, " ", "-")
+	s = strings.ReplaceAll(s, "_", "-")
+	// Remove any characters that aren't alphanumeric or hyphens
+	var result strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}


### PR DESCRIPTION
## Summary
Stream B feature for KG integration:

- **--output-nug flag**: outputs context as Orca nuggets
- **Nugget type**: structured format for save_nug
- **ToNuggets() methods**: convert BootContext and ProjectContext to nuggets
- **Multi-document YAML**: separated by `---` for piping to Orca

## Output structure
- `n:project:{slug}` - project overview (lang, build, test)
- `n:map:{slug}-arch` - architecture components and data flows  
- `n:map:{slug}-symbols` - key types and functions

## Test plan
- [ ] Verify `snipe context --boot --output-nug` outputs valid YAML
- [ ] Verify nuggets have correct IDs (n:project:, n:map:)
- [ ] Verify tags include project slug

## Example usage
```bash
# Generate and save to Orca KG
snipe context --boot --output-nug | orca save_nug

# Preview nugget output
snipe context --output-nug | head -30
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)