### PR TITLE
feat: add KG hints integration for Orca knowledge graph

### DIFF
--- a/cmd/def.go
+++ b/cmd/def.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dkoosis/snipe/internal/kg"
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/query"
 )
@@ -217,6 +218,26 @@ lookup:
 			degraded = append(degraded, "callers_preview_failed")
 		} else if len(callers) > 0 {
 			result.CallersPreview = callers
+		}
+	}
+
+	// Add KG hints if requested
+	if GetWithKGHints() {
+		hints := kg.GetHints(kg.Config{
+			File:    sym.FilePathRel,
+			Symbol:  sym.Name,
+			Package: sym.PkgPath,
+		})
+		if len(hints) > 0 {
+			result.KGHints = make([]output.KGHint, len(hints))
+			for i, h := range hints {
+				result.KGHints[i] = output.KGHint{
+					ID:       h.ID,
+					Kind:     h.Kind,
+					Severity: h.Severity,
+					Summary:  h.Summary,
+				}
+			}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,10 +173,12 @@ func ApplyFormatOverrides(format ResponseFormat, baseBody, baseSiblings bool, ba
 	case FormatSummary:
 		// Summary: no body needed (just counts)
 		return false, false, 0
-	default:
+	case FormatDefault:
 		// Default: use base values
 		return baseBody, baseSiblings, baseContext
 	}
+	// Unreachable, but satisfies exhaustive check
+	return baseBody, baseSiblings, baseContext
 }
 
 // GetWithKGHints returns whether KG hints should be included.

--- a/internal/kg/hints.go
+++ b/internal/kg/hints.go
@@ -1,0 +1,115 @@
+// Package kg provides integration with Orca knowledge graph for contextual hints.
+package kg
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Config specifies what to query for hints.
+type Config struct {
+	File    string // File path (relative)
+	Symbol  string // Symbol name
+	Package string // Package path
+}
+
+// Hint represents a knowledge graph hint.
+type Hint struct {
+	ID       string
+	Kind     string // trap, pattern, map, etc.
+	Severity string // h, m, l for traps
+	Summary  string
+}
+
+// GetHints queries the Orca KG for hints related to the given config.
+// Returns empty slice if Orca is not available or no hints found.
+func GetHints(cfg Config) []Hint {
+	// Check if orca CLI is available
+	orcaPath, err := exec.LookPath("orca")
+	if err != nil {
+		return nil
+	}
+
+	// Build query: look for traps/patterns related to file or symbol
+	var hints []Hint
+
+	// Query for file-anchored hints
+	if cfg.File != "" {
+		fileHints := queryOrcaHints(orcaPath, "file:"+cfg.File)
+		hints = append(hints, fileHints...)
+	}
+
+	// Query for symbol-specific hints
+	if cfg.Symbol != "" {
+		symHints := queryOrcaHints(orcaPath, "sym:"+cfg.Symbol)
+		hints = append(hints, symHints...)
+	}
+
+	// Query for package-related hints
+	if cfg.Package != "" {
+		// Extract last component of package path
+		parts := strings.Split(cfg.Package, "/")
+		if len(parts) > 0 {
+			pkgHints := queryOrcaHints(orcaPath, "pkg:"+parts[len(parts)-1])
+			hints = append(hints, pkgHints...)
+		}
+	}
+
+	return hints
+}
+
+// queryOrcaHints runs orca search_nugs and parses results.
+func queryOrcaHints(orcaPath, query string) []Hint {
+	// Use environment to pass query to orca
+	// Format: orca search_nugs --query <query> --format json
+	cmd := exec.Command(orcaPath, "search_nugs", "--query", query, "--limit", "3", "--format", "oneline")
+	cmd.Env = append(os.Environ(), "ORCA_QUIET=1")
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	return parseOrcaOutput(string(output))
+}
+
+// parseOrcaOutput parses orca search_nugs output.
+// Expected format: ID | KIND | SUMMARY (one per line)
+func parseOrcaOutput(output string) []Hint {
+	var hints []Hint
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Parse pipe-separated format: id | kind | summary
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) < 3 {
+			continue
+		}
+
+		id := strings.TrimSpace(parts[0])
+		kind := strings.TrimSpace(parts[1])
+		summary := strings.TrimSpace(parts[2])
+
+		// Extract severity from kind if present (e.g., "trap:h")
+		var severity string
+		if idx := strings.Index(kind, ":"); idx >= 0 {
+			severity = kind[idx+1:]
+			kind = kind[:idx]
+		}
+
+		hints = append(hints, Hint{
+			ID:       id,
+			Kind:     kind,
+			Severity: severity,
+			Summary:  summary,
+		})
+	}
+
+	return hints
+}

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -77,10 +77,10 @@ type Result struct {
 	Match          string          `json:"match,omitempty"`
 	Body           string          `json:"body,omitempty"`
 	Score          float64         `json:"score,omitempty"`
-	RefCount       int             `json:"ref_count"`                    // Number of references to this symbol (-1 = unavailable)
-	Hints          []string        `json:"hints,omitempty"`              // Static analysis hints: deprecated, unused, etc.
-	CallersPreview []CallerPreview `json:"callers_preview,omitempty"`    // Top callers for func/method
-	KGHints        []KGHint        `json:"kg_hints,omitempty"`           // Knowledge graph hints from Orca
+	RefCount       int             `json:"ref_count"`                 // Number of references to this symbol (-1 = unavailable)
+	Hints          []string        `json:"hints,omitempty"`           // Static analysis hints: deprecated, unused, etc.
+	CallersPreview []CallerPreview `json:"callers_preview,omitempty"` // Top callers for func/method
+	KGHints        []KGHint        `json:"kg_hints,omitempty"`        // Knowledge graph hints from Orca
 	Enclosing      *Enclosing      `json:"enclosing,omitempty"`
 	Context        *Context        `json:"context,omitempty"`
 	Siblings       []Sibling       `json:"siblings,omitempty"`


### PR DESCRIPTION
## Summary
Stream D feature for KG integration:

- **internal/kg package**: new package for Orca KG queries
- **GetHints function**: queries Orca CLI for file/symbol/package hints
- **Graceful degradation**: returns empty if Orca not available
- **def command integration**: includes kg_hints in output when --kg-hints set

## Dependencies
This PR is based on #65 (response_format modes) which adds the --kg-hints flag.

## How it works
1. When --kg-hints is set, snipe calls `orca search_nugs` with queries for:
   - File path (file:internal/query/lookup.go)
   - Symbol name (sym:Execute)
   - Package name (pkg:query)
2. Parses Orca's oneline format output
3. Converts to KGHint structs in result

## Test plan
- [ ] Verify `snipe def Execute --kg-hints` works without Orca (empty hints)
- [ ] Verify with Orca available, hints are populated
- [ ] Verify kg_hints format matches output.KGHint structure

## Example output
```json
{
  "results": [{
    "name": "Execute",
    "kg_hints": [
      {"id": "n:trap:gopls-delay", "kind": "trap", "severity": "m", "summary": "gopls can be slow on large repos"}
    ]
  }]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)