### PR TITLE
feat: add session tracking for active work context

### DIFF
--- a/cmd/callees.go
+++ b/cmd/callees.go
@@ -105,6 +105,11 @@ func runCallees(cmd *cobra.Command, args []string) error {
 
 findCallees:
 
+	// Record query in session for active work tracking
+	if sym, err := query.LookupByID(s.DB(), symbolID); err == nil && sym != nil {
+		recordSessionQuery(dir, sym.Name, sym.FilePathRel, sym.LineStart, sym.Kind, "callees")
+	}
+
 	// Find callees
 	calls, err := query.FindCallees(s.DB(), symbolID, lim, off)
 	if err != nil {

--- a/cmd/callers.go
+++ b/cmd/callers.go
@@ -105,6 +105,11 @@ func runCallers(cmd *cobra.Command, args []string) error {
 
 findCallers:
 
+	// Record query in session for active work tracking
+	if sym, err := query.LookupByID(s.DB(), symbolID); err == nil && sym != nil {
+		recordSessionQuery(dir, sym.Name, sym.FilePathRel, sym.LineStart, sym.Kind, "callers")
+	}
+
 	// Find callers
 	calls, err := query.FindCallers(s.DB(), symbolID, lim, off)
 	if err != nil {

--- a/cmd/def.go
+++ b/cmd/def.go
@@ -187,6 +187,9 @@ lookup:
 	result := sym.ToResultWithHints(s.DB())
 	var degraded []string
 
+	// Record query in session for active work tracking
+	recordSessionQuery(dir, sym.Name, sym.FilePathRel, sym.LineStart, sym.Kind, "def")
+
 	// Add full body if requested
 	if withBody {
 		if err := output.AddBody(&result); err != nil {

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -119,6 +119,8 @@ func runRefs(cmd *cobra.Command, args []string) error {
 	symbolName := ""
 	if sym, err := query.LookupByID(s.DB(), symbolID); err == nil && sym != nil {
 		symbolName = sym.Name
+		// Record query in session for active work tracking
+		recordSessionQuery(dir, sym.Name, sym.FilePathRel, sym.LineStart, sym.Kind, "refs")
 	}
 	nameLen := len(symbolName)
 	if nameLen == 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/dkoosis/snipe/internal/config"
+	ctxpkg "github.com/dkoosis/snipe/internal/context"
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/store"
 )
@@ -280,4 +281,15 @@ func OpenStore(w *output.Writer, cmdName string) (*store.Store, string, error) {
 	}
 
 	return s, dir, nil
+}
+
+// recordSessionQuery records a symbol query in the session for active work tracking.
+// This is a best-effort operation - errors are silently ignored to not affect command execution.
+func recordSessionQuery(projectRoot, symbol, file string, line int, kind, command string) {
+	session, err := ctxpkg.LoadSession(projectRoot)
+	if err != nil {
+		return
+	}
+	session.RecordQuery(symbol, file, line, kind, command)
+	_ = ctxpkg.SaveSession(session)
 }

--- a/cmd/sym.go
+++ b/cmd/sym.go
@@ -188,6 +188,9 @@ lookup:
 
 	var degraded []string
 
+	// Record query in session for active work tracking
+	recordSessionQuery(dir, sym.Name, sym.FilePathRel, sym.LineStart, sym.Kind, "sym")
+
 	// Build definition result
 	defResult := sym.ToResultWithHints(s.DB())
 

--- a/internal/context/generate.go
+++ b/internal/context/generate.go
@@ -55,6 +55,13 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 	// Get top symbols by reference count (most referenced = most important)
 	keySymbols := getKeySymbolsByRefCount(cfg.DB, cfg.RepoRoot, 10)
 
+	// Load session for active work context
+	var activeWork *ActiveWork
+	session, err := LoadSession(cfg.RepoRoot)
+	if err == nil && session != nil {
+		activeWork = session.GetActiveWork()
+	}
+
 	lang := "go"
 	if len(proj.Lang) > 0 {
 		lang = proj.Lang[0]
@@ -67,6 +74,7 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 		Test:        proj.Test,
 		EntryPoints: entryPoints,
 		KeySymbols:  keySymbols,
+		ActiveWork:  activeWork,
 		Commit:      meta.GitCommit,
 	}, nil
 }

--- a/internal/context/session.go
+++ b/internal/context/session.go
@@ -1,0 +1,178 @@
+// Package context provides session tracking for active work context.
+package context
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Session tracks recently queried symbols for active work context.
+type Session struct {
+	Project   string        `json:"project"`           // Project root path
+	Branch    string        `json:"branch"`            // Git branch when session started
+	Queries   []QueryRecord `json:"queries,omitempty"` // Recent queries (newest first)
+	UpdatedAt string        `json:"updated_at"`        // Last update timestamp
+}
+
+// QueryRecord tracks a single symbol query.
+type QueryRecord struct {
+	Symbol    string `json:"symbol"`         // Symbol name
+	File      string `json:"file"`           // File path (relative)
+	Line      int    `json:"line,omitempty"` // Line number
+	Kind      string `json:"kind,omitempty"` // Symbol kind (func, type, etc.)
+	Command   string `json:"command"`        // Command used (def, refs, callers)
+	Timestamp string `json:"timestamp"`      // When queried
+}
+
+// ActiveWork represents the active work section for boot context.
+type ActiveWork struct {
+	RecentSymbols []SymbolRef `json:"recent_symbols,omitempty" yaml:"recent_symbols,omitempty"`
+	Branch        string      `json:"branch,omitempty" yaml:"branch,omitempty"`
+}
+
+const (
+	maxQueries  = 20 // Keep last N queries
+	sessionDir  = ".snipe"
+	sessionFile = "session.json"
+)
+
+// sessionPath returns the path to the session file for a project.
+func sessionPath(projectRoot string) string {
+	return filepath.Join(projectRoot, sessionDir, sessionFile)
+}
+
+// LoadSession loads the session for a project, returning empty session if none exists.
+func LoadSession(projectRoot string) (*Session, error) {
+	path := sessionPath(projectRoot)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Session{Project: projectRoot}, nil
+		}
+		return nil, err
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		// Corrupted session file, start fresh (intentionally ignoring parse error)
+		return &Session{Project: projectRoot}, nil //nolint:nilerr // Intentional: recover from corrupt file
+	}
+
+	// Check if branch changed - if so, clear session
+	currentBranch := getCurrentBranch(projectRoot)
+	if session.Branch != "" && session.Branch != currentBranch {
+		// Branch changed, start fresh session
+		return &Session{
+			Project: projectRoot,
+			Branch:  currentBranch,
+		}, nil
+	}
+
+	session.Branch = currentBranch
+	return &session, nil
+}
+
+// SaveSession saves the session to disk.
+func SaveSession(session *Session) error {
+	if session.Project == "" {
+		return nil // No project, nothing to save
+	}
+
+	session.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	// Ensure directory exists
+	dir := filepath.Join(session.Project, sessionDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(sessionPath(session.Project), data, 0644)
+}
+
+// RecordQuery adds a query to the session.
+func (s *Session) RecordQuery(symbol, file string, line int, kind, command string) {
+	// Ensure branch is current
+	if s.Project != "" {
+		s.Branch = getCurrentBranch(s.Project)
+	}
+
+	// Convert absolute path to relative if needed
+	relFile := file
+	if s.Project != "" && strings.HasPrefix(file, s.Project) {
+		relFile = strings.TrimPrefix(file, s.Project+"/")
+	}
+
+	record := QueryRecord{
+		Symbol:    symbol,
+		File:      relFile,
+		Line:      line,
+		Kind:      kind,
+		Command:   command,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Remove any existing query for the same symbol (dedup using relative path)
+	filtered := make([]QueryRecord, 0, len(s.Queries))
+	for _, q := range s.Queries {
+		if q.Symbol != symbol || q.File != relFile {
+			filtered = append(filtered, q)
+		}
+	}
+
+	// Add new query at the front
+	s.Queries = append([]QueryRecord{record}, filtered...)
+
+	// Trim to max size
+	if len(s.Queries) > maxQueries {
+		s.Queries = s.Queries[:maxQueries]
+	}
+}
+
+// GetActiveWork returns the ActiveWork structure for boot context.
+func (s *Session) GetActiveWork() *ActiveWork {
+	if len(s.Queries) == 0 {
+		return nil
+	}
+
+	// Convert recent queries to SymbolRefs (top 10)
+	limit := 10
+	if len(s.Queries) < limit {
+		limit = len(s.Queries)
+	}
+
+	symbols := make([]SymbolRef, limit)
+	for i := 0; i < limit; i++ {
+		q := s.Queries[i]
+		symbols[i] = SymbolRef{
+			Name: q.Symbol,
+			File: q.File,
+			Line: q.Line,
+		}
+	}
+
+	return &ActiveWork{
+		RecentSymbols: symbols,
+		Branch:        s.Branch,
+	}
+}
+
+// getCurrentBranch returns the current git branch for a directory.
+func getCurrentBranch(dir string) string {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/context/session_test.go
+++ b/internal/context/session_test.go
@@ -1,0 +1,128 @@
+package context
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSessionRecordQuery(t *testing.T) {
+	// Create a temp directory for testing
+	tmpDir, err := os.MkdirTemp("", "snipe-session-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	session := &Session{Project: tmpDir}
+
+	// Record some queries
+	session.RecordQuery("Foo", "pkg/foo.go", 10, "func", "def")
+	session.RecordQuery("Bar", "pkg/bar.go", 20, "type", "refs")
+	session.RecordQuery("Baz", "pkg/baz.go", 30, "method", "callers")
+
+	if len(session.Queries) != 3 {
+		t.Errorf("expected 3 queries, got %d", len(session.Queries))
+	}
+
+	// Most recent should be first
+	if session.Queries[0].Symbol != "Baz" {
+		t.Errorf("expected most recent query to be Baz, got %s", session.Queries[0].Symbol)
+	}
+
+	// Record duplicate query - should update, not add
+	session.RecordQuery("Foo", "pkg/foo.go", 10, "func", "def")
+	if len(session.Queries) != 3 {
+		t.Errorf("expected 3 queries after duplicate, got %d", len(session.Queries))
+	}
+
+	// Foo should now be first (most recent)
+	if session.Queries[0].Symbol != "Foo" {
+		t.Errorf("expected Foo to be first after re-query, got %s", session.Queries[0].Symbol)
+	}
+}
+
+func TestSessionActiveWork(t *testing.T) {
+	session := &Session{
+		Project: "/test",
+		Branch:  "main",
+	}
+
+	// Empty session should return nil
+	aw := session.GetActiveWork()
+	if aw != nil {
+		t.Error("expected nil active work for empty session")
+	}
+
+	// Add some queries
+	session.RecordQuery("Foo", "foo.go", 1, "func", "def")
+	session.RecordQuery("Bar", "bar.go", 2, "type", "refs")
+
+	aw = session.GetActiveWork()
+	if aw == nil {
+		t.Fatal("expected active work, got nil")
+	}
+
+	if len(aw.RecentSymbols) != 2 {
+		t.Errorf("expected 2 recent symbols, got %d", len(aw.RecentSymbols))
+	}
+
+	// First symbol should be most recent (Bar)
+	if aw.RecentSymbols[0].Name != "Bar" {
+		t.Errorf("expected Bar first, got %s", aw.RecentSymbols[0].Name)
+	}
+}
+
+func TestSessionPersistence(t *testing.T) {
+	// Create a temp directory for testing
+	tmpDir, err := os.MkdirTemp("", "snipe-session-persist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create session and add queries
+	session := &Session{
+		Project: tmpDir,
+		Branch:  "test-branch",
+	}
+	session.RecordQuery("Foo", "foo.go", 10, "func", "def")
+
+	// Save
+	if err := SaveSession(session); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	// Check file exists
+	sessionPath := filepath.Join(tmpDir, ".snipe", "session.json")
+	if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
+		t.Error("session file not created")
+	}
+
+	// Load and verify
+	loaded, err := LoadSession(tmpDir)
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+
+	if len(loaded.Queries) != 1 {
+		t.Errorf("expected 1 query, got %d", len(loaded.Queries))
+	}
+
+	if loaded.Queries[0].Symbol != "Foo" {
+		t.Errorf("expected Foo, got %s", loaded.Queries[0].Symbol)
+	}
+}
+
+func TestSessionMaxQueries(t *testing.T) {
+	session := &Session{Project: "/test"}
+
+	// Add more than maxQueries
+	for i := 0; i < 30; i++ {
+		session.RecordQuery("Sym"+string(rune('A'+i)), "file.go", i, "func", "def")
+	}
+
+	if len(session.Queries) > maxQueries {
+		t.Errorf("expected max %d queries, got %d", maxQueries, len(session.Queries))
+	}
+}

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -18,6 +18,7 @@ type BootContext struct {
 	Test        string      `json:"test" yaml:"test"`
 	EntryPoints []string    `json:"entry_points" yaml:"entry_points"`
 	KeySymbols  []SymbolRef `json:"key_symbols" yaml:"key_symbols"`
+	ActiveWork  *ActiveWork `json:"active_work,omitempty" yaml:"active_work,omitempty"`
 	Commit      string      `json:"commit" yaml:"commit"`
 }
 


### PR DESCRIPTION
## Summary
- Track recently queried symbols in `.snipe/session.json`
- Include `active_work` section in `snipe context --boot` output
- Auto-clear session when git branch changes

## Features
- **Session tracking**: Records def, refs, callers, callees, sym queries
- **Active work in boot**: Shows top 10 recent symbols + current branch
- **Branch awareness**: Clears session on branch switch for clean context
- **Deduplication**: Updates existing queries rather than duplicating

## Test plan
- [x] Unit tests for session CRUD operations
- [x] Manual testing of query tracking
- [x] Verified `context --boot` includes active_work
- [x] `mage qa` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)