### PR TITLE
Review context enrichment plan documentation

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dkoosis/snipe/internal/context"
 	"github.com/dkoosis/snipe/internal/embed"
 	"github.com/dkoosis/snipe/internal/index"
 	"github.com/dkoosis/snipe/internal/output"
@@ -38,8 +39,10 @@ const (
 )
 
 var (
-	withEmbed bool   // Legacy flag, kept for compatibility
-	embedMode string // New flag: auto, batch, realtime, off
+	withEmbed   bool   // Legacy flag, kept for compatibility
+	embedMode   string // New flag: auto, batch, realtime, off
+	withEnrich  bool   // Generate LLM-based symbol purposes
+	enrichModel string // LLM model for enrichment
 )
 
 func init() {
@@ -47,6 +50,8 @@ func init() {
 	defaultEmbed := embed.HasCredentials()
 	indexCmd.Flags().BoolVar(&withEmbed, "embed", defaultEmbed, "Generate embeddings (deprecated: use --embed-mode)")
 	indexCmd.Flags().StringVar(&embedMode, "embed-mode", "auto", "Embedding mode: auto, batch, realtime, off")
+	indexCmd.Flags().BoolVar(&withEnrich, "enrich", false, "Generate LLM-based symbol purposes (requires API key)")
+	indexCmd.Flags().StringVar(&enrichModel, "enrich-model", "claude-3-5-haiku", "LLM model for enrichment")
 	rootCmd.AddCommand(indexCmd)
 }
 
@@ -221,6 +226,24 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Generated %d embeddings\n", embedCount)
 	} else if embedStatus == "batch_started" {
 		fmt.Fprintf(os.Stderr, "Batch embedding started (async). Use 'snipe embed-status' to check progress.\n")
+	}
+
+	// Run LLM enrichment if requested
+	if withEnrich {
+		fmt.Fprintf(os.Stderr, "Enriching symbols with LLM-generated purposes...\n")
+		enrichCfg := context.EnrichConfig{
+			DB:       s.DB(),
+			RepoRoot: absDir,
+			Model:    enrichModel,
+		}
+		enrichCount, err := context.EnrichSymbols(enrichCfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: enrichment failed: %v\n", err)
+		} else if enrichCount > 0 {
+			fmt.Fprintf(os.Stderr, "Enriched %d symbols\n", enrichCount)
+		} else {
+			fmt.Fprintf(os.Stderr, "No symbols needed enrichment\n")
+		}
 	}
 
 	return w.WriteResponse(resp)

--- a/internal/context/architecture.go
+++ b/internal/context/architecture.go
@@ -1,0 +1,376 @@
+package context
+
+import (
+	"database/sql"
+	"sort"
+	"strings"
+)
+
+// GenerateArchitectureSummary creates a high-level architecture overview from the snipe index.
+// It analyzes call graph data to produce:
+// - Spine: primary call flows from entry points
+// - Components: packages with their inferred purposes
+// - Edges: top cross-package call relationships
+// - Description: placeholder for LLM-generated prose
+//
+// Performance: Uses batch SQL queries with no queries in loops. Total queries <= 5.
+func GenerateArchitectureSummary(db *sql.DB, repoRoot string) (*ArchSummary, error) {
+	// Query 1-3: Get primary flows (reuses batch queries from flows.go)
+	spine, err := ExtractPrimaryFlows(db, repoRoot, 5)
+	if err != nil {
+		// Non-fatal: continue with empty spine
+		spine = nil
+	}
+
+	// Query 4: Get package purposes in a single batch query
+	components, err := getPackagePurposes(db, repoRoot)
+	if err != nil {
+		// Non-fatal: continue with empty components
+		components = nil
+	}
+
+	// Query 5: Get cross-package call edges in a single batch query
+	edges, err := getCrossPackageEdges(db, repoRoot)
+	if err != nil {
+		// Non-fatal: continue with empty edges
+		edges = nil
+	}
+
+	// Build description placeholder
+	description := "[Architecture description pending LLM enrichment]"
+
+	return &ArchSummary{
+		Spine:       spine,
+		Components:  components,
+		Edges:       edges,
+		Description: description,
+	}, nil
+}
+
+// getPackagePurposes returns all packages with their inferred purposes.
+// Uses a single batch query to extract distinct packages from the index.
+func getPackagePurposes(db *sql.DB, repoRoot string) ([]PackagePurpose, error) {
+	// Query distinct package paths and group by top-level directory
+	rows, err := db.Query(`
+		SELECT DISTINCT
+			CASE
+				WHEN pkg_path LIKE '%/internal/%' THEN
+					SUBSTR(pkg_path, INSTR(pkg_path, '/internal/') + 1,
+						CASE
+							WHEN INSTR(SUBSTR(pkg_path, INSTR(pkg_path, '/internal/') + 10), '/') > 0
+							THEN INSTR(SUBSTR(pkg_path, INSTR(pkg_path, '/internal/') + 10), '/') + 8
+							ELSE LENGTH(pkg_path)
+						END
+					)
+				WHEN pkg_path LIKE '%/cmd/%' THEN 'cmd'
+				WHEN pkg_path LIKE '%/cmd' THEN 'cmd'
+				ELSE
+					CASE
+						WHEN INSTR(SUBSTR(pkg_path, 1), '/') > 0
+						THEN SUBSTR(pkg_path, LENGTH(pkg_path) - INSTR(REVERSE(pkg_path), '/') + 2)
+						ELSE pkg_path
+					END
+			END as pkg_short
+		FROM symbols
+		WHERE file_path LIKE ? || '/%'
+		  AND pkg_path IS NOT NULL
+		  AND pkg_path != ''
+		GROUP BY pkg_short
+		ORDER BY pkg_short
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Collect unique packages
+	seen := make(map[string]bool)
+	var components []PackagePurpose
+
+	for rows.Next() {
+		var pkgShort sql.NullString
+		if err := rows.Scan(&pkgShort); err != nil {
+			continue
+		}
+		if !pkgShort.Valid || pkgShort.String == "" {
+			continue
+		}
+
+		name := normalizePackageName(pkgShort.String)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		// Infer purpose from package name
+		purpose := inferPackagePurpose(name)
+		components = append(components, PackagePurpose{
+			Name:    name,
+			Purpose: purpose,
+		})
+	}
+
+	return components, rows.Err()
+}
+
+// normalizePackageName cleans up package names for display.
+func normalizePackageName(name string) string {
+	// Remove leading/trailing slashes
+	name = strings.Trim(name, "/")
+
+	// Skip empty or test-only packages
+	if name == "" || name == "_test" {
+		return ""
+	}
+
+	return name
+}
+
+// inferPackagePurpose determines a package's purpose from its name.
+// This reuses the same logic as inferPurpose in generate.go but with full paths.
+func inferPackagePurpose(pkg string) string {
+	// Map of package patterns to purposes
+	purposes := map[string]string{
+		"cmd":              "CLI commands and entry points",
+		"internal/store":   "SQLite persistence and database operations",
+		"internal/query":   "Symbol lookup and reference queries",
+		"internal/index":   "Go package loading and symbol extraction",
+		"internal/output":  "JSON/human output formatting",
+		"internal/config":  "Configuration management",
+		"internal/search":  "Ripgrep integration and search",
+		"internal/embed":   "Vector embeddings and similarity",
+		"internal/context": "Boot context and LLM summaries",
+		"internal/analyze": "Function analysis and diagnostics",
+		"pkg":              "Public library packages",
+		"api":              "API definitions and handlers",
+		"test":             "Test utilities and fixtures",
+	}
+
+	// Check for exact match first
+	if purpose, ok := purposes[pkg]; ok {
+		return purpose
+	}
+
+	// Check for prefix matches
+	for pattern, purpose := range purposes {
+		if strings.HasPrefix(pkg, pattern) {
+			return purpose
+		}
+	}
+
+	// Infer from last segment of package path
+	parts := strings.Split(pkg, "/")
+	lastPart := parts[len(parts)-1]
+
+	segmentPurposes := map[string]string{
+		"store":    "Data storage and persistence",
+		"query":    "Query execution",
+		"index":    "Indexing operations",
+		"output":   "Output formatting",
+		"config":   "Configuration",
+		"search":   "Search functionality",
+		"embed":    "Embeddings",
+		"context":  "Context generation",
+		"analyze":  "Analysis",
+		"util":     "Utility functions",
+		"utils":    "Utility functions",
+		"internal": "Internal implementation",
+	}
+
+	if purpose, ok := segmentPurposes[lastPart]; ok {
+		return purpose
+	}
+
+	return "Application logic"
+}
+
+// getCrossPackageEdges returns the top cross-package call relationships.
+// Uses a single batch query with aggregation.
+func getCrossPackageEdges(db *sql.DB, repoRoot string) ([]CrossPackageEdge, error) {
+	// Query cross-package calls grouped by caller/callee package
+	rows, err := db.Query(`
+		WITH PackageCalls AS (
+			SELECT
+				caller.pkg_path as caller_pkg,
+				callee.pkg_path as callee_pkg,
+				COUNT(*) as call_count
+			FROM call_graph cg
+			JOIN symbols caller ON cg.caller_id = caller.id
+			JOIN symbols callee ON cg.callee_id = callee.id
+			WHERE caller.file_path LIKE ? || '/%'
+			  AND callee.file_path LIKE ? || '/%'
+			  AND caller.pkg_path IS NOT NULL
+			  AND callee.pkg_path IS NOT NULL
+			  AND caller.pkg_path != callee.pkg_path
+			GROUP BY caller.pkg_path, callee.pkg_path
+			HAVING call_count >= 2
+		)
+		SELECT caller_pkg, callee_pkg, call_count
+		FROM PackageCalls
+		ORDER BY call_count DESC
+		LIMIT 15
+	`, repoRoot, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var edges []CrossPackageEdge
+	for rows.Next() {
+		var callerPkg, calleePkg string
+		var count int
+		if err := rows.Scan(&callerPkg, &calleePkg, &count); err != nil {
+			continue
+		}
+
+		// Shorten package paths for display
+		fromShort := shortenPackagePath(callerPkg)
+		toShort := shortenPackagePath(calleePkg)
+
+		edges = append(edges, CrossPackageEdge{
+			From:  fromShort,
+			To:    toShort,
+			Count: count,
+		})
+	}
+
+	return edges, rows.Err()
+}
+
+// shortenPackagePath extracts the short form of a package path.
+// Example: "github.com/user/snipe/internal/store" -> "internal/store"
+func shortenPackagePath(pkgPath string) string {
+	// Find /internal/ or /cmd/ and take from there
+	if idx := strings.Index(pkgPath, "/internal/"); idx != -1 {
+		return pkgPath[idx+1:]
+	}
+	if idx := strings.Index(pkgPath, "/cmd/"); idx != -1 {
+		return pkgPath[idx+1:]
+	}
+	if strings.HasSuffix(pkgPath, "/cmd") {
+		return "cmd"
+	}
+
+	// Take last two segments
+	parts := strings.Split(pkgPath, "/")
+	if len(parts) >= 2 {
+		return strings.Join(parts[len(parts)-2:], "/")
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+
+	return pkgPath
+}
+
+// FormatArchSummary formats an ArchSummary as a human-readable string.
+// Useful for debugging and display purposes.
+func FormatArchSummary(summary *ArchSummary) string {
+	if summary == nil {
+		return "No architecture summary available"
+	}
+
+	var sb strings.Builder
+
+	// Spine (primary flows)
+	if len(summary.Spine) > 0 {
+		sb.WriteString("Primary Flows:\n")
+		for _, flow := range summary.Spine {
+			sb.WriteString("  ")
+			sb.WriteString(flow)
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Components
+	if len(summary.Components) > 0 {
+		sb.WriteString("Components:\n")
+		for _, comp := range summary.Components {
+			sb.WriteString("  ")
+			sb.WriteString(comp.Name)
+			sb.WriteString(": ")
+			sb.WriteString(comp.Purpose)
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Edges (sorted by count for readability)
+	if len(summary.Edges) > 0 {
+		sb.WriteString("Cross-Package Calls:\n")
+		// Sort by count descending
+		sorted := make([]CrossPackageEdge, len(summary.Edges))
+		copy(sorted, summary.Edges)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Count > sorted[j].Count
+		})
+		for _, edge := range sorted {
+			sb.WriteString("  ")
+			sb.WriteString(edge.From)
+			sb.WriteString(" -> ")
+			sb.WriteString(edge.To)
+			sb.WriteString(" (")
+			sb.WriteString(strings.Repeat("x", min(edge.Count/5, 10))) // Visual indicator
+			if edge.Count > 50 {
+				sb.WriteString("...")
+			}
+			sb.WriteString(" ")
+			sb.WriteString(formatCount(edge.Count))
+			sb.WriteString(")\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Description
+	if summary.Description != "" {
+		sb.WriteString("Description:\n  ")
+		sb.WriteString(summary.Description)
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// formatCount formats a count for display.
+func formatCount(count int) string {
+	if count == 1 {
+		return "1 call"
+	}
+	return strings.Replace(
+		strings.Replace(
+			"N calls",
+			"N",
+			intToString(count),
+			1,
+		),
+		"calls",
+		"calls",
+		1,
+	)
+}
+
+// intToString converts an integer to string without fmt import overhead.
+func intToString(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + intToString(-n)
+	}
+
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+// min returns the smaller of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/context/enrich.go
+++ b/internal/context/enrich.go
@@ -1,0 +1,269 @@
+package context
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// EnrichConfig configures symbol enrichment.
+type EnrichConfig struct {
+	// DB is the snipe index database
+	DB *sql.DB
+	// RepoRoot is the absolute path to the repository root
+	RepoRoot string
+	// Model is the LLM model to use (default "claude-3-5-haiku")
+	Model string
+	// Force re-enriches even if content hash matches
+	Force bool
+}
+
+// SymbolInfo contains symbol information for enrichment.
+type SymbolInfo struct {
+	ID        string
+	Name      string
+	Kind      string
+	Signature string
+	Body      string // Truncated to 100 lines
+}
+
+// purposePromptTemplate is the prompt template for generating symbol purposes.
+const purposePromptTemplate = `Given this Go symbol, provide a 1-line purpose (max 10 words).
+Do not start with "This function" or similar. Be terse.
+
+Symbol: %s
+Kind: %s
+Signature: %s
+Body:
+` + "```go\n%s\n```" + `
+
+Purpose:`
+
+// EnrichSymbols enriches symbols without doc comments using LLM-generated purposes.
+// It returns the count of symbols enriched and any error encountered.
+func EnrichSymbols(cfg EnrichConfig) (int, error) {
+	if cfg.Model == "" {
+		cfg.Model = "claude-3-5-haiku"
+	}
+
+	// Ensure symbol_purposes table exists
+	if err := ensurePurposesTable(cfg.DB); err != nil {
+		return 0, fmt.Errorf("create purposes table: %w", err)
+	}
+
+	// Query symbols without doc comments
+	symbols, err := getUndocumentedSymbols(cfg.DB, cfg.RepoRoot)
+	if err != nil {
+		return 0, fmt.Errorf("query undocumented symbols: %w", err)
+	}
+
+	enrichedCount := 0
+	for _, sym := range symbols {
+		// Load symbol body from source file
+		body, err := loadSymbolBody(cfg.DB, sym.ID)
+		if err != nil {
+			// Skip symbols we can't load
+			continue
+		}
+		sym.Body = truncateBody(body, 100)
+
+		// Calculate content hash
+		contentHash := calculateContentHash(sym.Signature, sym.Body)
+
+		// Check if we already have a purpose with matching hash
+		if !cfg.Force {
+			existingHash, err := getStoredHash(cfg.DB, sym.ID)
+			if err == nil && existingHash == contentHash {
+				// Hash matches, skip enrichment
+				continue
+			}
+		}
+
+		// Generate purpose (placeholder for now)
+		purpose, err := generatePurpose(sym)
+		if err != nil {
+			continue
+		}
+
+		// Store the purpose
+		if err := storePurpose(cfg.DB, sym.ID, purpose, contentHash, cfg.Model); err != nil {
+			continue
+		}
+
+		enrichedCount++
+	}
+
+	return enrichedCount, nil
+}
+
+// ensurePurposesTable creates the symbol_purposes table if it doesn't exist.
+func ensurePurposesTable(db *sql.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS symbol_purposes (
+			symbol_id TEXT PRIMARY KEY,
+			purpose TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
+			model TEXT NOT NULL,
+			generated_at TEXT NOT NULL,
+			FOREIGN KEY (symbol_id) REFERENCES symbols(id)
+		)
+	`)
+	if err != nil {
+		return err
+	}
+
+	// Create index for content hash lookups
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_purposes_hash ON symbol_purposes(content_hash)`)
+	return err
+}
+
+// getUndocumentedSymbols queries symbols without doc comments.
+func getUndocumentedSymbols(db *sql.DB, repoRoot string) ([]SymbolInfo, error) {
+	rows, err := db.Query(`
+		SELECT s.id, s.name, s.kind, s.signature
+		FROM symbols s
+		WHERE s.file_path LIKE ? || '/%'
+		  AND s.kind IN ('func', 'method', 'type', 'interface', 'struct')
+		  AND (s.doc IS NULL OR s.doc = '')
+		  AND s.name GLOB '[A-Z]*'
+		ORDER BY s.file_path, s.line_start
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var symbols []SymbolInfo
+	for rows.Next() {
+		var sym SymbolInfo
+		var sig sql.NullString
+		if err := rows.Scan(&sym.ID, &sym.Name, &sym.Kind, &sig); err != nil {
+			continue
+		}
+		if sig.Valid {
+			sym.Signature = sig.String
+		}
+		symbols = append(symbols, sym)
+	}
+
+	return symbols, rows.Err()
+}
+
+// loadSymbolBody loads the source code body for a symbol by ID.
+func loadSymbolBody(db *sql.DB, symbolID string) (string, error) {
+	var filePath string
+	var lineStart, lineEnd int
+
+	err := db.QueryRow(`
+		SELECT file_path, line_start, line_end
+		FROM symbols
+		WHERE id = ?
+	`, symbolID).Scan(&filePath, &lineStart, &lineEnd)
+	if err != nil {
+		return "", fmt.Errorf("query symbol position: %w", err)
+	}
+
+	// Read the lines from the file
+	file, err := os.Open(filePath) // #nosec G304 -- filePath from trusted index
+	if err != nil {
+		return "", fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		if lineNum >= lineStart && lineNum <= lineEnd {
+			lines = append(lines, scanner.Text())
+		}
+		if lineNum > lineEnd {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read file: %w", err)
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+// truncateBody truncates the body to the specified number of lines.
+func truncateBody(body string, maxLines int) string {
+	lines := strings.Split(body, "\n")
+	if len(lines) <= maxLines {
+		return body
+	}
+	return strings.Join(lines[:maxLines], "\n") + "\n// ... truncated"
+}
+
+// calculateContentHash computes SHA256 hash of signature and body.
+func calculateContentHash(signature, body string) string {
+	content := signature + "\n" + body
+	hash := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(hash[:])
+}
+
+// getStoredHash retrieves the stored content hash for a symbol.
+func getStoredHash(db *sql.DB, symbolID string) (string, error) {
+	var hash string
+	err := db.QueryRow(`
+		SELECT content_hash FROM symbol_purposes WHERE symbol_id = ?
+	`, symbolID).Scan(&hash)
+	return hash, err
+}
+
+// generatePurpose generates a 1-line purpose for a symbol.
+// NOTE: This is a placeholder. Actual LLM integration will be added later.
+func generatePurpose(sym SymbolInfo) (string, error) {
+	// TODO: Implement actual LLM API call here.
+	// The call should:
+	// 1. Format the prompt using purposePromptTemplate with sym.Name, sym.Kind, sym.Signature, sym.Body
+	// 2. Call the LLM API (e.g., Anthropic Claude API)
+	// 3. Parse the response to extract the purpose line
+	// 4. Return the purpose (max 10 words)
+	//
+	// Example prompt that would be sent:
+	// prompt := fmt.Sprintf(purposePromptTemplate, sym.Name, sym.Kind, sym.Signature, sym.Body)
+	//
+	// For now, return a placeholder indicating enrichment is pending.
+	_ = fmt.Sprintf(purposePromptTemplate, sym.Name, sym.Kind, sym.Signature, sym.Body)
+	return "[LLM enrichment pending]", nil
+}
+
+// storePurpose stores the generated purpose in the database.
+func storePurpose(db *sql.DB, symbolID, purpose, contentHash, model string) error {
+	_, err := db.Exec(`
+		INSERT OR REPLACE INTO symbol_purposes (symbol_id, purpose, content_hash, model, generated_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, symbolID, purpose, contentHash, model, time.Now().UTC().Format(time.RFC3339))
+	return err
+}
+
+// GetPurpose retrieves the stored purpose for a symbol.
+func GetPurpose(db *sql.DB, symbolID string) (string, error) {
+	var purpose string
+	err := db.QueryRow(`
+		SELECT purpose FROM symbol_purposes WHERE symbol_id = ?
+	`, symbolID).Scan(&purpose)
+	return purpose, err
+}
+
+// PruneOrphanedPurposes removes purposes for symbols that no longer exist.
+func PruneOrphanedPurposes(db *sql.DB) (int64, error) {
+	result, err := db.Exec(`
+		DELETE FROM symbol_purposes
+		WHERE symbol_id NOT IN (SELECT id FROM symbols)
+	`)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/context/flows.go
+++ b/internal/context/flows.go
@@ -1,0 +1,416 @@
+package context
+
+import (
+	"database/sql"
+	"strings"
+)
+
+// flowNode represents a symbol in the call flow graph.
+type flowNode struct {
+	id       string
+	name     string
+	receiver string
+}
+
+// ExtractPrimaryFlows traces call paths from entry points and returns flow strings.
+// It finds main, Execute, RunE functions and traces their call paths.
+// Returns flow strings like "main -> Execute -> Store.Open -> WriteIndex"
+// Performance: Uses batch queries - no queries in loops.
+func ExtractPrimaryFlows(db *sql.DB, repoRoot string, maxDepth int) ([]string, error) {
+	if maxDepth <= 0 {
+		maxDepth = 5
+	}
+
+	// Query 1: Get all entry points (main, Execute, RunE, init)
+	entryPoints, err := queryEntryPointSymbols(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(entryPoints) == 0 {
+		return nil, nil
+	}
+
+	// Query 2: Pre-fetch call graph data for all symbols up to maxDepth
+	// We batch-load the entire relevant portion of the call graph
+	callGraph, err := queryCallGraphBatch(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Query 3: Pre-fetch symbol names for all symbols in the call graph
+	symbolNames, err := querySymbolNamesBatch(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build flows in memory (no more DB queries)
+	var flows []string
+	maxFlows := 10 // Limit total flows for performance
+
+	for _, ep := range entryPoints {
+		if len(flows) >= maxFlows {
+			break
+		}
+
+		// Build flow from this entry point
+		flow := buildFlowPath(ep.id, ep.name, ep.receiver, callGraph, symbolNames, maxDepth)
+		if flow != "" {
+			flows = append(flows, flow)
+		}
+	}
+
+	return flows, nil
+}
+
+// queryEntryPointSymbols returns symbols that are entry points.
+func queryEntryPointSymbols(db *sql.DB, repoRoot string) ([]flowNode, error) {
+	rows, err := db.Query(`
+		SELECT id, name, COALESCE(receiver, '') as receiver
+		FROM symbols
+		WHERE file_path LIKE ? || '/%'
+		  AND kind IN ('func', 'method')
+		  AND (
+		      name = 'main'
+		      OR name = 'Execute'
+		      OR name = 'RunE'
+		      OR name = 'init'
+		  )
+		ORDER BY
+		  CASE name
+		    WHEN 'main' THEN 1
+		    WHEN 'Execute' THEN 2
+		    WHEN 'RunE' THEN 3
+		    WHEN 'init' THEN 4
+		  END
+		LIMIT 20
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []flowNode
+	for rows.Next() {
+		var n flowNode
+		if err := rows.Scan(&n.id, &n.name, &n.receiver); err != nil {
+			continue
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// queryCallGraphBatch fetches the entire call graph for the repo in one query.
+// Returns map[caller_id][]callee_id
+func queryCallGraphBatch(db *sql.DB, repoRoot string) (map[string][]string, error) {
+	rows, err := db.Query(`
+		SELECT cg.caller_id, cg.callee_id
+		FROM call_graph cg
+		JOIN symbols caller ON cg.caller_id = caller.id
+		JOIN symbols callee ON cg.callee_id = callee.id
+		WHERE caller.file_path LIKE ? || '/%'
+		  AND callee.file_path LIKE ? || '/%'
+	`, repoRoot, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	graph := make(map[string][]string)
+	for rows.Next() {
+		var callerID, calleeID string
+		if err := rows.Scan(&callerID, &calleeID); err != nil {
+			continue
+		}
+		graph[callerID] = append(graph[callerID], calleeID)
+	}
+	return graph, rows.Err()
+}
+
+// querySymbolNamesBatch fetches all symbol names in one query.
+// Returns map[symbol_id]displayName where displayName is "Receiver.Name" or just "Name"
+func querySymbolNamesBatch(db *sql.DB, repoRoot string) (map[string]string, error) {
+	rows, err := db.Query(`
+		SELECT id, name, COALESCE(receiver, '') as receiver
+		FROM symbols
+		WHERE file_path LIKE ? || '/%'
+		  AND kind IN ('func', 'method')
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	names := make(map[string]string)
+	for rows.Next() {
+		var id, name, receiver string
+		if err := rows.Scan(&id, &name, &receiver); err != nil {
+			continue
+		}
+		if receiver != "" {
+			// Extract type name from receiver like "*Store" -> "Store"
+			typeName := strings.TrimPrefix(receiver, "*")
+			names[id] = typeName + "." + name
+		} else {
+			names[id] = name
+		}
+	}
+	return names, rows.Err()
+}
+
+// buildFlowPath constructs a flow string from an entry point using pre-fetched data.
+func buildFlowPath(startID, startName, startReceiver string, callGraph map[string][]string, symbolNames map[string]string, maxDepth int) string {
+	var path []string
+
+	// Add entry point
+	displayName := startName
+	if startReceiver != "" {
+		typeName := strings.TrimPrefix(startReceiver, "*")
+		displayName = typeName + "." + startName
+	}
+	path = append(path, displayName)
+
+	// Traverse call graph (BFS-style, but only following first callee at each level)
+	visited := make(map[string]bool)
+	visited[startID] = true
+	currentID := startID
+
+	for depth := 1; depth < maxDepth; depth++ {
+		callees := callGraph[currentID]
+		if len(callees) == 0 {
+			break
+		}
+
+		// Pick the first unvisited callee (prioritize important-looking names)
+		var nextID string
+		for _, calleeID := range callees {
+			if !visited[calleeID] {
+				name := symbolNames[calleeID]
+				// Skip internal/utility functions in flow display
+				if name != "" && !strings.HasPrefix(name, "fmt.") && !strings.HasPrefix(name, "log.") {
+					nextID = calleeID
+					break
+				}
+			}
+		}
+
+		if nextID == "" {
+			break
+		}
+
+		visited[nextID] = true
+		name := symbolNames[nextID]
+		if name != "" {
+			path = append(path, name)
+		}
+		currentID = nextID
+	}
+
+	// Only return flows with at least 2 nodes
+	if len(path) < 2 {
+		return ""
+	}
+
+	return strings.Join(path, " -> ")
+}
+
+// GetChangeBoundaries identifies key packages by concern and returns top exported symbols.
+// Categories: persistence (store), cli (cmd), output (output), query (query)
+// Performance: Uses batch query with GROUP BY instead of per-package queries.
+func GetChangeBoundaries(db *sql.DB, repoRoot string) (map[string][]string, error) {
+	// Single query that groups symbols by concern based on package path
+	// and returns top 5 exported symbols per concern
+	rows, err := db.Query(`
+		WITH ConcernSymbols AS (
+			SELECT
+				s.name,
+				s.pkg_path,
+				CASE
+					WHEN s.pkg_path LIKE '%/store%' OR s.pkg_path LIKE '%store' THEN 'persistence'
+					WHEN s.pkg_path LIKE '%/cmd%' OR s.pkg_path LIKE '%cmd' THEN 'cli'
+					WHEN s.pkg_path LIKE '%/output%' OR s.pkg_path LIKE '%output' THEN 'output'
+					WHEN s.pkg_path LIKE '%/query%' OR s.pkg_path LIKE '%query' THEN 'query'
+					ELSE NULL
+				END as concern,
+				COUNT(r.id) as ref_count
+			FROM symbols s
+			LEFT JOIN refs r ON s.id = r.symbol_id
+			WHERE s.file_path LIKE ? || '/%'
+			  AND s.kind IN ('func', 'method', 'type', 'interface', 'struct')
+			  AND s.name GLOB '[A-Z]*'
+			GROUP BY s.id
+		),
+		RankedSymbols AS (
+			SELECT
+				name,
+				concern,
+				ref_count,
+				ROW_NUMBER() OVER (PARTITION BY concern ORDER BY ref_count DESC) as rank
+			FROM ConcernSymbols
+			WHERE concern IS NOT NULL
+		)
+		SELECT concern, name
+		FROM RankedSymbols
+		WHERE rank <= 5
+		ORDER BY concern, rank
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	boundaries := make(map[string][]string)
+	for rows.Next() {
+		var concern, name string
+		if err := rows.Scan(&concern, &name); err != nil {
+			continue
+		}
+		boundaries[concern] = append(boundaries[concern], name)
+	}
+
+	return boundaries, rows.Err()
+}
+
+// GetEntryPointDetails returns entry points with their doc comment and immediate callees.
+// Uses the EntryPointRef type from types.go.
+// Performance: Uses 2 batch queries (entry points, then callees) instead of N+1.
+func GetEntryPointDetails(db *sql.DB, repoRoot string) ([]EntryPointRef, error) {
+	// Query 1: Get entry points with their details
+	rows, err := db.Query(`
+		SELECT
+			s.id,
+			s.name,
+			COALESCE(s.receiver, '') as receiver,
+			s.file_path,
+			s.line_start,
+			COALESCE(s.doc, '') as doc
+		FROM symbols s
+		WHERE s.file_path LIKE ? || '/%'
+		  AND s.kind IN ('func', 'method')
+		  AND (
+		      s.name = 'main'
+		      OR s.name = 'Execute'
+		      OR s.name = 'RunE'
+		      OR s.name = 'init'
+		  )
+		ORDER BY
+		  CASE s.name
+		    WHEN 'main' THEN 1
+		    WHEN 'Execute' THEN 2
+		    WHEN 'RunE' THEN 3
+		    WHEN 'init' THEN 4
+		  END
+		LIMIT 20
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect entry points and their IDs for callee lookup
+	type epWithID struct {
+		id  string
+		ref EntryPointRef
+	}
+	var entryPoints []epWithID
+
+	for rows.Next() {
+		var ep epWithID
+		var receiver, doc string
+		if err := rows.Scan(&ep.id, &ep.ref.Name, &receiver, &ep.ref.File, &ep.ref.Line, &doc); err != nil {
+			continue
+		}
+
+		// Format display name with receiver
+		if receiver != "" {
+			typeName := strings.TrimPrefix(receiver, "*")
+			ep.ref.Name = typeName + "." + ep.ref.Name
+		}
+
+		// Make file path relative
+		ep.ref.File = strings.TrimPrefix(ep.ref.File, repoRoot+"/")
+
+		// Extract first sentence of doc comment as purpose
+		if doc != "" {
+			ep.ref.Purpose = extractFirstSentence(doc)
+		}
+
+		entryPoints = append(entryPoints, ep)
+	}
+	_ = rows.Close()
+
+	if len(entryPoints) == 0 {
+		return nil, nil
+	}
+
+	// Query 2: Batch fetch callees for all entry points
+	// Build a single query with IN clause for all entry point IDs
+	ids := make([]string, len(entryPoints))
+	for i, ep := range entryPoints {
+		ids[i] = ep.id
+	}
+
+	// Use a CTE to rank callees and limit to 5 per caller
+	calleeQuery := `
+		WITH RankedCallees AS (
+			SELECT
+				cg.caller_id,
+				callee.name,
+				COALESCE(callee.receiver, '') as receiver,
+				ROW_NUMBER() OVER (PARTITION BY cg.caller_id ORDER BY cg.line, cg.col) as rank
+			FROM call_graph cg
+			JOIN symbols callee ON cg.callee_id = callee.id
+			WHERE cg.caller_id IN (` + placeholders(len(ids)) + `)
+			  AND callee.file_path LIKE ? || '/%'
+		)
+		SELECT caller_id, name, receiver
+		FROM RankedCallees
+		WHERE rank <= 5
+		ORDER BY caller_id, rank
+	`
+
+	// Build args: IDs first, then repoRoot for LIKE clause
+	args := make([]interface{}, len(ids)+1)
+	for i, id := range ids {
+		args[i] = id
+	}
+	args[len(ids)] = repoRoot
+
+	calleeRows, err := db.Query(calleeQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer calleeRows.Close()
+
+	// Build callee map
+	calleeMap := make(map[string][]string)
+	for calleeRows.Next() {
+		var callerID, name, receiver string
+		if err := calleeRows.Scan(&callerID, &name, &receiver); err != nil {
+			continue
+		}
+		displayName := name
+		if receiver != "" {
+			typeName := strings.TrimPrefix(receiver, "*")
+			displayName = typeName + "." + name
+		}
+		calleeMap[callerID] = append(calleeMap[callerID], displayName)
+	}
+
+	// Build final result
+	var results []EntryPointRef
+	for _, ep := range entryPoints {
+		ep.ref.Callees = calleeMap[ep.id]
+		results = append(results, ep.ref)
+	}
+
+	return results, nil
+}
+
+// placeholders generates SQL placeholders like "?,?,?" for IN clauses.
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat("?,", n-1) + "?"
+}

--- a/internal/context/generate.go
+++ b/internal/context/generate.go
@@ -25,6 +25,8 @@ type GenerateConfig struct {
 	Full bool
 	// MaxSymbols is the maximum number of symbols to include per category (default: 20)
 	MaxSymbols int
+	// IncludeArchSummary includes architecture summary in boot context (Phase 4)
+	IncludeArchSummary bool
 }
 
 // Generate creates a ProjectContext from the snipe index.
@@ -49,11 +51,22 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 	proj := generateProject(cfg.RepoRoot)
 	meta := generateMeta(cfg.DB)
 
-	// Get entry points (cmd/* main.go files)
+	// Get entry points (cmd/* main.go files) - backward compatible
 	entryPoints := getEntryPoints(cfg.DB, cfg.RepoRoot)
 
-	// Get top symbols by reference count (most referenced = most important)
-	keySymbols := getKeySymbolsByRefCount(cfg.DB, cfg.RepoRoot, 10)
+	// Get top symbols by role-weighted ranking
+	rankedSymbols, err := RankSymbols(cfg.DB, cfg.RepoRoot, 15)
+	if err != nil {
+		// Fall back to ref-count based ranking if ranking fails
+		rankedSymbols = nil
+	}
+
+	// Convert ranked symbols to SymbolRef
+	keySymbols := rankedToSymbolRefs(rankedSymbols, cfg.RepoRoot)
+	if len(keySymbols) == 0 {
+		// Fall back to ref-count based if ranking produced no results
+		keySymbols = getKeySymbolsByRefCount(cfg.DB, cfg.RepoRoot, 10)
+	}
 
 	// Load session for active work context
 	var activeWork *ActiveWork
@@ -67,6 +80,15 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 		lang = proj.Lang[0]
 	}
 
+	// Build boot views (Phase 2 enrichment)
+	bootViews := generateBootViews(cfg.DB, cfg.RepoRoot)
+
+	// Build architecture summary (Phase 4 enrichment) - only if explicitly requested
+	var archSummary *ArchSummary
+	if cfg.IncludeArchSummary {
+		archSummary, _ = GenerateArchitectureSummary(cfg.DB, cfg.RepoRoot)
+	}
+
 	return &BootContext{
 		Project:     proj.Name,
 		Lang:        lang,
@@ -76,7 +98,47 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 		KeySymbols:  keySymbols,
 		ActiveWork:  activeWork,
 		Commit:      meta.GitCommit,
+		BootViews:   bootViews,
+		ArchSummary: archSummary,
 	}, nil
+}
+
+// generateBootViews creates the three orientation views for boot context.
+func generateBootViews(db *sql.DB, repoRoot string) *BootViews {
+	// Get entry point details using batch queries
+	entryPointDetails, _ := GetEntryPointDetails(db, repoRoot)
+
+	// Get primary flows using batch queries
+	primaryFlows, _ := ExtractPrimaryFlows(db, repoRoot, 4)
+
+	// Get change boundaries using batch query
+	changeBoundaries, _ := GetChangeBoundaries(db, repoRoot)
+
+	// Only return BootViews if we have meaningful content
+	if len(entryPointDetails) == 0 && len(primaryFlows) == 0 && len(changeBoundaries) == 0 {
+		return nil
+	}
+
+	return &BootViews{
+		EntryPointDetails: entryPointDetails,
+		PrimaryFlows:      primaryFlows,
+		ChangeBoundaries:  changeBoundaries,
+	}
+}
+
+// rankedToSymbolRefs converts ranked symbols to SymbolRef with role information.
+func rankedToSymbolRefs(ranked []RankedSymbol, repoRoot string) []SymbolRef {
+	refs := make([]SymbolRef, 0, len(ranked))
+	for _, rs := range ranked {
+		ref := SymbolRef{
+			Name: rs.Name,
+			File: strings.TrimPrefix(rs.File, repoRoot+"/"),
+			Line: rs.Line,
+			Role: rs.Role,
+		}
+		refs = append(refs, ref)
+	}
+	return refs
 }
 
 // getEntryPoints finds main.go files in cmd/ directory

--- a/internal/context/interfaces.go
+++ b/internal/context/interfaces.go
@@ -1,0 +1,231 @@
+// Package context provides interface signal detection for symbols.
+package context
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// Interface-specific role constants for standard library implementations.
+// These extend the Role constants in roles.go.
+const (
+	// RoleErrorType indicates a type that implements the error interface.
+	RoleErrorType Role = "error_type"
+	// RoleStringer indicates a type that implements fmt.Stringer.
+	RoleStringer Role = "stringer"
+	// RoleSortable indicates a type that implements sort.Interface.
+	RoleSortable Role = "sortable"
+)
+
+// interfaceSignature maps a method name to its signature pattern and role.
+type interfaceSignature struct {
+	methodName string
+	// sigPattern is a substring that must appear in the signature.
+	// Empty string means any signature matches.
+	sigPattern string
+	role       Role
+}
+
+// knownInterfaces maps method signatures to their interface roles.
+// Methods are grouped by the interface they implement.
+var knownInterfaces = []interfaceSignature{
+	// http.Handler: ServeHTTP(http.ResponseWriter, *http.Request)
+	{methodName: "ServeHTTP", sigPattern: "ResponseWriter", role: RoleHTTPHandler},
+
+	// io.Reader: Read([]byte) (int, error)
+	{methodName: "Read", sigPattern: "[]byte", role: RoleIO},
+
+	// io.Writer: Write([]byte) (int, error)
+	{methodName: "Write", sigPattern: "[]byte", role: RoleIO},
+
+	// io.Closer: Close() error
+	{methodName: "Close", sigPattern: "error", role: RoleIO},
+
+	// error: Error() string
+	{methodName: "Error", sigPattern: "string", role: RoleErrorType},
+
+	// fmt.Stringer: String() string
+	{methodName: "String", sigPattern: "string", role: RoleStringer},
+}
+
+// sortInterfaceMethods lists the methods required for sort.Interface.
+// A type must implement all three to be considered sortable.
+var sortInterfaceMethods = []string{"Len", "Less", "Swap"}
+
+// DetectInterfaceSignals scans the symbol database for methods that implement
+// known standard library interfaces and returns a map of symbol IDs to role hints.
+//
+// The function detects:
+//   - http.Handler (ServeHTTP method) -> handler
+//   - io.Reader/Writer/Closer (Read/Write/Close methods) -> io_primitive
+//   - error interface (Error method) -> error_type
+//   - fmt.Stringer (String method) -> stringer
+//   - sort.Interface (Len, Less, Swap methods) -> sortable
+func DetectInterfaceSignals(db *sql.DB, repoRoot string) (map[string]string, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is nil")
+	}
+
+	signals := make(map[string]string)
+
+	// Detect single-method interfaces
+	if err := detectSingleMethodInterfaces(db, repoRoot, signals); err != nil {
+		return nil, fmt.Errorf("detect single-method interfaces: %w", err)
+	}
+
+	// Detect sort.Interface (requires all three methods)
+	if err := detectSortInterface(db, repoRoot, signals); err != nil {
+		return nil, fmt.Errorf("detect sort.Interface: %w", err)
+	}
+
+	return signals, nil
+}
+
+// detectSingleMethodInterfaces finds methods matching known interface signatures.
+func detectSingleMethodInterfaces(db *sql.DB, repoRoot string, signals map[string]string) error {
+	for _, sig := range knownInterfaces {
+		query := `
+			SELECT id, name, signature, receiver
+			FROM symbols
+			WHERE kind = 'method'
+			  AND name = ?
+			  AND file_path LIKE ? || '/%'
+		`
+
+		rows, err := db.Query(query, sig.methodName, repoRoot)
+		if err != nil {
+			return fmt.Errorf("query methods for %s: %w", sig.methodName, err)
+		}
+
+		if err := processMethodRows(rows, sig, signals); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// processMethodRows processes query results and matches signatures.
+func processMethodRows(rows *sql.Rows, sig interfaceSignature, signals map[string]string) error {
+	defer rows.Close()
+
+	for rows.Next() {
+		var id, name string
+		var signature, receiver sql.NullString
+
+		if err := rows.Scan(&id, &name, &signature, &receiver); err != nil {
+			return fmt.Errorf("scan method row: %w", err)
+		}
+
+		// Check if signature matches the pattern
+		if matchesSignature(signature.String, sig) {
+			signals[id] = string(sig.role)
+		}
+	}
+
+	return rows.Err()
+}
+
+// matchesSignature checks if a method signature matches an interface pattern.
+func matchesSignature(signature string, sig interfaceSignature) bool {
+	// If no pattern specified, any signature matches
+	if sig.sigPattern == "" {
+		return true
+	}
+
+	// Check if signature contains the required pattern
+	return strings.Contains(signature, sig.sigPattern)
+}
+
+// detectSortInterface finds types that implement sort.Interface.
+// A type must have all three methods: Len() int, Less(i, j int) bool, Swap(i, j int).
+func detectSortInterface(db *sql.DB, repoRoot string, signals map[string]string) error {
+	// Query to find all receivers that have methods matching sort.Interface names
+	query := `
+		SELECT receiver, GROUP_CONCAT(name) as methods, GROUP_CONCAT(id) as ids
+		FROM symbols
+		WHERE kind = 'method'
+		  AND name IN ('Len', 'Less', 'Swap')
+		  AND receiver IS NOT NULL
+		  AND receiver != ''
+		  AND file_path LIKE ? || '/%'
+		GROUP BY receiver
+	`
+
+	rows, err := db.Query(query, repoRoot)
+	if err != nil {
+		return fmt.Errorf("query sort.Interface methods: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var receiver, methodsConcat, idsConcat string
+		if err := rows.Scan(&receiver, &methodsConcat, &idsConcat); err != nil {
+			return fmt.Errorf("scan sort.Interface row: %w", err)
+		}
+
+		// Check if all three methods are present
+		methods := strings.Split(methodsConcat, ",")
+		if hasSortInterfaceMethods(methods) {
+			// Mark all three method symbols as sortable
+			ids := strings.Split(idsConcat, ",")
+			for _, id := range ids {
+				id = strings.TrimSpace(id)
+				if id != "" {
+					signals[id] = string(RoleSortable)
+				}
+			}
+		}
+	}
+
+	return rows.Err()
+}
+
+// hasSortInterfaceMethods checks if a slice of method names contains all sort.Interface methods.
+func hasSortInterfaceMethods(methods []string) bool {
+	found := make(map[string]bool)
+	for _, m := range methods {
+		m = strings.TrimSpace(m)
+		found[m] = true
+	}
+
+	for _, required := range sortInterfaceMethods {
+		if !found[required] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// GetReceiverTypeID looks up the type symbol ID for a given receiver.
+// This is useful for propagating role hints from methods to their types.
+func GetReceiverTypeID(db *sql.DB, receiver string, repoRoot string) (string, error) {
+	if receiver == "" {
+		return "", nil
+	}
+
+	// Extract type name from receiver (e.g., "*MyType" -> "MyType", "MyType" -> "MyType")
+	typeName := strings.TrimPrefix(receiver, "*")
+	typeName = strings.TrimSpace(typeName)
+
+	var id string
+	err := db.QueryRow(`
+		SELECT id
+		FROM symbols
+		WHERE name = ?
+		  AND kind IN ('type', 'struct', 'interface')
+		  AND file_path LIKE ? || '/%'
+		LIMIT 1
+	`, typeName, repoRoot).Scan(&id)
+
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("query receiver type: %w", err)
+	}
+
+	return id, nil
+}

--- a/internal/context/ranking.go
+++ b/internal/context/ranking.go
@@ -1,0 +1,191 @@
+// Package context provides role-weighted symbol ranking for boot context generation.
+package context
+
+import (
+	"database/sql"
+	"math"
+	"sort"
+)
+
+// roleWeights defines priority multipliers for each architectural role.
+// Higher weights indicate more architecturally significant symbols.
+var roleWeights = map[Role]float64{
+	RoleEntryPoint:  10,
+	RoleAPIBoundary: 5,
+	RolePersistence: 5,
+	RoleHTTPHandler: 5,
+	RoleFactory:     3,
+	RoleIO:          3,
+	RoleInternal:    1,
+}
+
+// RankedSymbol represents a symbol with its calculated priority score.
+type RankedSymbol struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Line     int     `json:"line"`
+	RefCount int     `json:"ref_count"`
+	Role     string  `json:"role"`
+	Priority float64 `json:"priority"`
+}
+
+// CalculatePriority computes the priority score for a symbol.
+// Formula: priority = (log(ref_count) + 1) * role_weight
+// This balances reference count with architectural importance.
+func CalculatePriority(refCount int, role Role) float64 {
+	weight, ok := roleWeights[role]
+	if !ok {
+		weight = 1 // Default to internal weight
+	}
+
+	// Use log(ref_count + 1) to handle zero refs and dampen high ref counts
+	// Adding 1 ensures log is never negative for ref_count >= 0
+	logRefs := math.Log(float64(refCount) + 1)
+	return (logRefs + 1) * weight
+}
+
+// RankSymbols queries symbols from the database, infers their roles,
+// calculates priority scores, and returns them sorted by priority.
+// Performance optimizations:
+// - Single batch query for symbols and ref counts (no loop queries)
+// - In-memory role lookup using map built from InferRoles
+// - Early limiting via SQL ORDER BY + LIMIT after scoring
+func RankSymbols(db *sql.DB, repoRoot string, limit int) ([]RankedSymbol, error) {
+	// Step 1: Infer roles for all symbols in one batch
+	// This builds the role map upfront to avoid per-symbol queries
+	symbolRoles, err := InferRoles(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build role lookup map by symbol ID for O(1) access
+	roleMap := make(map[string]Role, len(symbolRoles))
+	for _, sr := range symbolRoles {
+		roleMap[sr.SymbolID] = sr.Role
+	}
+
+	// Step 2: Query all symbols with their ref counts in a single batch query
+	// This avoids N+1 query problem by using a LEFT JOIN with COUNT
+	rows, err := db.Query(`
+		SELECT
+			s.id,
+			s.name,
+			s.file_path,
+			s.line_start,
+			COUNT(r.id) as ref_count
+		FROM symbols s
+		LEFT JOIN refs r ON r.symbol_id = s.id
+		WHERE s.kind IN ('func', 'method', 'type', 'interface')
+		  AND s.file_path LIKE ? || '/%'
+		GROUP BY s.id
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Step 3: Calculate priorities and collect results
+	var results []RankedSymbol
+	for rows.Next() {
+		var rs RankedSymbol
+		if err := rows.Scan(&rs.ID, &rs.Name, &rs.File, &rs.Line, &rs.RefCount); err != nil {
+			continue // Skip malformed rows
+		}
+
+		// Look up role from pre-built map (O(1))
+		role, ok := roleMap[rs.ID]
+		if !ok {
+			// Default based on name casing if not in role map
+			role = RoleInternal
+			if len(rs.Name) > 0 && rs.Name[0] >= 'A' && rs.Name[0] <= 'Z' {
+				role = RoleAPIBoundary
+			}
+		}
+		rs.Role = string(role)
+		rs.Priority = CalculatePriority(rs.RefCount, role)
+
+		results = append(results, rs)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Step 4: Sort by priority descending
+	sort.Slice(results, func(i, j int) bool {
+		// Primary sort by priority (descending)
+		if results[i].Priority != results[j].Priority {
+			return results[i].Priority > results[j].Priority
+		}
+		// Secondary sort by ref count (descending) for equal priorities
+		if results[i].RefCount != results[j].RefCount {
+			return results[i].RefCount > results[j].RefCount
+		}
+		// Tertiary sort by name (ascending) for stability
+		return results[i].Name < results[j].Name
+	})
+
+	// Step 5: Apply limit
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results, nil
+}
+
+// RankSymbolsByPackage returns ranked symbols grouped by package.
+// This is useful for the package-level views in boot context.
+func RankSymbolsByPackage(db *sql.DB, repoRoot string, topPerPackage int) (map[string][]RankedSymbol, error) {
+	// Get all ranked symbols without limit
+	allSymbols, err := RankSymbols(db, repoRoot, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group by package (extracted from file path)
+	byPackage := make(map[string][]RankedSymbol)
+	for _, rs := range allSymbols {
+		// Extract package from file path
+		pkg := extractPackage(rs.File, repoRoot)
+		byPackage[pkg] = append(byPackage[pkg], rs)
+	}
+
+	// Limit each package to topPerPackage symbols
+	if topPerPackage > 0 {
+		for pkg, symbols := range byPackage {
+			if len(symbols) > topPerPackage {
+				byPackage[pkg] = symbols[:topPerPackage]
+			}
+		}
+	}
+
+	return byPackage, nil
+}
+
+// extractPackage derives the package path from a file path.
+func extractPackage(filePath, repoRoot string) string {
+	// Remove repo root prefix
+	if len(filePath) > len(repoRoot) && filePath[:len(repoRoot)] == repoRoot {
+		filePath = filePath[len(repoRoot):]
+		if len(filePath) > 0 && filePath[0] == '/' {
+			filePath = filePath[1:]
+		}
+	}
+
+	// Extract directory as package
+	for i := len(filePath) - 1; i >= 0; i-- {
+		if filePath[i] == '/' {
+			return filePath[:i]
+		}
+	}
+	return filePath
+}
+
+// GetRoleWeight returns the weight for a given role.
+// This is useful for external callers that need to understand the weighting.
+func GetRoleWeight(role Role) float64 {
+	if weight, ok := roleWeights[role]; ok {
+		return weight
+	}
+	return 1 // Default weight
+}

--- a/internal/context/roles.go
+++ b/internal/context/roles.go
@@ -1,0 +1,423 @@
+// Package context provides role inference for symbols.
+package context
+
+import (
+	"database/sql"
+	"strings"
+	"unicode"
+)
+
+// Role represents an architectural role classification for a symbol.
+// This is distinct from RoleHint which focuses on interface implementations.
+type Role string
+
+// Role constants define the architectural classification categories.
+const (
+	// RoleEntryPoint indicates a symbol that is called by main/init, is main, or is cobra.Command.RunE.
+	RoleEntryPoint Role = "entry_point"
+	// RoleAPIBoundary indicates an exported symbol that has callers from other packages.
+	RoleAPIBoundary Role = "api_boundary"
+	// RolePersistence indicates a symbol in a store package or that calls sql.DB methods.
+	RolePersistence Role = "persistence"
+	// RoleHTTPHandler indicates a symbol that implements http.Handler or matches http handler signature.
+	RoleHTTPHandler Role = "handler"
+	// RoleIO indicates a symbol that implements io.Reader, io.Writer, or io.Closer.
+	RoleIO Role = "io_primitive"
+	// RoleFactory indicates a symbol whose name starts with "New" and returns a pointer.
+	RoleFactory Role = "factory"
+	// RoleInternal indicates an unexported symbol or one only called within its package.
+	RoleInternal Role = "internal"
+)
+
+// Visibility represents the export status of a symbol.
+type Visibility string
+
+// Visibility constants.
+const (
+	// VisibilityExported indicates a symbol that starts with uppercase (exported).
+	VisibilityExported Visibility = "exported"
+	// VisibilityPackagePrivate indicates a symbol that starts with lowercase (unexported).
+	VisibilityPackagePrivate Visibility = "package_private"
+)
+
+// SymbolRole contains the inferred role and visibility for a symbol.
+type SymbolRole struct {
+	SymbolID   string     `json:"symbol_id"`
+	Name       string     `json:"name"`
+	Role       Role       `json:"role"`
+	Visibility Visibility `json:"visibility"`
+	PkgPath    string     `json:"pkg_path,omitempty"`
+}
+
+// InferRoles analyzes symbols in the database and classifies them by architectural role.
+// It queries the symbols, refs, call_graph, and imports tables to determine each symbol's role.
+func InferRoles(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
+	var results []SymbolRole
+
+	// Query all functions and methods with their metadata
+	rows, err := db.Query(`
+		SELECT id, name, kind, signature, pkg_path, file_path
+		FROM symbols
+		WHERE kind IN ('func', 'method')
+		  AND file_path LIKE ? || '/%'
+	`, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Collect symbols for processing
+	type symbolInfo struct {
+		id        string
+		name      string
+		kind      string
+		signature sql.NullString
+		pkgPath   sql.NullString
+		filePath  string
+	}
+	var symbols []symbolInfo
+
+	for rows.Next() {
+		var s symbolInfo
+		if err := rows.Scan(&s.id, &s.name, &s.kind, &s.signature, &s.pkgPath, &s.filePath); err != nil {
+			continue
+		}
+		symbols = append(symbols, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Process each symbol to determine its role
+	for _, s := range symbols {
+		sr := SymbolRole{
+			SymbolID:   s.id,
+			Name:       s.name,
+			Visibility: inferVisibility(s.name),
+		}
+		if s.pkgPath.Valid {
+			sr.PkgPath = s.pkgPath.String
+		}
+
+		// Determine role (check in priority order)
+		role := inferRole(db, s.id, s.name, s.kind, s.signature.String, s.pkgPath.String)
+		sr.Role = role
+
+		results = append(results, sr)
+	}
+
+	return results, nil
+}
+
+// inferVisibility determines if a symbol is exported based on its name.
+func inferVisibility(name string) Visibility {
+	if len(name) == 0 {
+		return VisibilityPackagePrivate
+	}
+	// Check first rune for uppercase
+	r := []rune(name)[0]
+	if unicode.IsUpper(r) {
+		return VisibilityExported
+	}
+	return VisibilityPackagePrivate
+}
+
+// inferRole determines the architectural role of a symbol.
+func inferRole(db *sql.DB, symbolID, name, kind, signature, pkgPath string) Role {
+	// Check entry_point: is main, or is cobra.Command.RunE, or called by main/init
+	if isEntryPoint(db, symbolID, name, kind, pkgPath) {
+		return RoleEntryPoint
+	}
+
+	// Check handler: implements http.Handler or matches http handler signature
+	if isHandler(signature) {
+		return RoleHTTPHandler
+	}
+
+	// Check io_primitive: implements io.Reader, io.Writer, io.Closer
+	if isIOPrimitive(signature) {
+		return RoleIO
+	}
+
+	// Check factory: name starts with New and returns pointer
+	if isFactory(name, signature) {
+		return RoleFactory
+	}
+
+	// Check persistence: pkg_path contains "store" or calls sql.DB methods
+	if isPersistence(db, symbolID, pkgPath) {
+		return RolePersistence
+	}
+
+	// Check api_boundary: exported AND has callers from other packages
+	if isAPIBoundary(db, symbolID, name, pkgPath) {
+		return RoleAPIBoundary
+	}
+
+	// Check internal: unexported or only called within package
+	if isInternal(db, symbolID, name, pkgPath) {
+		return RoleInternal
+	}
+
+	// Default to internal for unexported, api_boundary for exported
+	if inferVisibility(name) == VisibilityPackagePrivate {
+		return RoleInternal
+	}
+	return RoleAPIBoundary
+}
+
+// isEntryPoint checks if a symbol is an entry point:
+// - is named "main" in a main package
+// - is a cobra.Command.RunE method
+// - is called by main or init functions
+func isEntryPoint(db *sql.DB, symbolID, name, kind, pkgPath string) bool {
+	// Check if this is main function
+	if name == "main" && strings.HasSuffix(pkgPath, "/main") {
+		return true
+	}
+
+	// Check if this is a RunE method (cobra command)
+	if name == "RunE" && kind == "method" {
+		return true
+	}
+
+	// Check if this is an init function
+	if name == "init" {
+		return true
+	}
+
+	// Check if called by main or init functions
+	var callerCount int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM call_graph cg
+		JOIN symbols caller ON cg.caller_id = caller.id
+		WHERE cg.callee_id = ?
+		  AND caller.name IN ('main', 'init')
+	`, symbolID).Scan(&callerCount)
+	if err == nil && callerCount > 0 {
+		return true
+	}
+
+	// Check for cobra Execute patterns (often called from main)
+	if name == "Execute" && kind == "method" {
+		return true
+	}
+
+	return false
+}
+
+// isHandler checks if a symbol implements http.Handler or matches http handler signature.
+// Common patterns:
+// - ServeHTTP(http.ResponseWriter, *http.Request)
+// - func(http.ResponseWriter, *http.Request)
+func isHandler(signature string) bool {
+	if signature == "" {
+		return false
+	}
+	sig := strings.ToLower(signature)
+
+	// Check for ServeHTTP method signature
+	if strings.Contains(sig, "servehttp") {
+		return true
+	}
+
+	// Check for http handler function signature pattern
+	if strings.Contains(sig, "responsewriter") && strings.Contains(sig, "request") {
+		return true
+	}
+
+	// Check for gin/echo style handlers
+	if strings.Contains(sig, "*gin.context") || strings.Contains(sig, "echo.context") {
+		return true
+	}
+
+	return false
+}
+
+// isIOPrimitive checks if a symbol implements io.Reader, io.Writer, or io.Closer.
+// These are identified by method signatures: Read([]byte), Write([]byte), Close()
+func isIOPrimitive(signature string) bool {
+	if signature == "" {
+		return false
+	}
+	sig := strings.ToLower(signature)
+
+	// Check for Reader pattern: Read(p []byte) (n int, err error)
+	if strings.Contains(sig, "read(") && strings.Contains(sig, "[]byte") && strings.Contains(sig, "int") {
+		return true
+	}
+
+	// Check for Writer pattern: Write(p []byte) (n int, err error)
+	if strings.Contains(sig, "write(") && strings.Contains(sig, "[]byte") && strings.Contains(sig, "int") {
+		return true
+	}
+
+	// Check for Closer pattern: Close() error
+	if strings.Contains(sig, "close()") && strings.Contains(sig, "error") {
+		return true
+	}
+
+	return false
+}
+
+// isFactory checks if a symbol is a factory function:
+// - name starts with "New"
+// - returns a pointer (signature contains "*")
+func isFactory(name, signature string) bool {
+	if !strings.HasPrefix(name, "New") {
+		return false
+	}
+
+	// Must return something (have a return type)
+	if signature == "" {
+		return false
+	}
+
+	// Check for pointer return type (contains "*" after the closing paren of params)
+	// Example: "func NewStore(path string) (*Store, error)"
+	parenIdx := strings.LastIndex(signature, ")")
+	if parenIdx == -1 || parenIdx >= len(signature)-1 {
+		return false
+	}
+
+	returnPart := signature[parenIdx+1:]
+	return strings.Contains(returnPart, "*")
+}
+
+// isPersistence checks if a symbol is related to persistence:
+// - package path contains "store"
+// - calls sql.DB methods (sql.Open, db.Query, db.Exec, etc.)
+func isPersistence(db *sql.DB, symbolID, pkgPath string) bool {
+	// Check if package path contains "store"
+	if strings.Contains(strings.ToLower(pkgPath), "store") {
+		return true
+	}
+
+	// Check if this symbol calls any sql-related symbols
+	var sqlCallCount int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM call_graph cg
+		JOIN symbols callee ON cg.callee_id = callee.id
+		WHERE cg.caller_id = ?
+		  AND (
+		      callee.pkg_path LIKE '%database/sql%'
+		      OR callee.name IN ('Query', 'QueryRow', 'Exec', 'Begin', 'Commit', 'Rollback', 'Prepare')
+		  )
+	`, symbolID).Scan(&sqlCallCount)
+	if err == nil && sqlCallCount > 0 {
+		return true
+	}
+
+	return false
+}
+
+// isAPIBoundary checks if a symbol is an API boundary:
+// - is exported (name starts with uppercase)
+// - has callers from other packages
+func isAPIBoundary(db *sql.DB, symbolID, name, pkgPath string) bool {
+	// Must be exported
+	if inferVisibility(name) != VisibilityExported {
+		return false
+	}
+
+	// Check for callers from other packages
+	var crossPkgCallerCount int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM call_graph cg
+		JOIN symbols caller ON cg.caller_id = caller.id
+		WHERE cg.callee_id = ?
+		  AND caller.pkg_path IS NOT NULL
+		  AND caller.pkg_path != ?
+	`, symbolID, pkgPath).Scan(&crossPkgCallerCount)
+	if err == nil && crossPkgCallerCount > 0 {
+		return true
+	}
+
+	return false
+}
+
+// isInternal checks if a symbol is internal:
+// - is unexported (name starts with lowercase)
+// - OR only has callers from the same package
+func isInternal(db *sql.DB, symbolID, name, pkgPath string) bool {
+	// Unexported symbols are always internal
+	if inferVisibility(name) == VisibilityPackagePrivate {
+		return true
+	}
+
+	// Check if all callers are from the same package
+	var totalCallers, samePkgCallers int
+
+	// Get total caller count
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM call_graph
+		WHERE callee_id = ?
+	`, symbolID).Scan(&totalCallers)
+	if err != nil {
+		return false
+	}
+
+	// If no callers, could be internal or unused
+	if totalCallers == 0 {
+		return true
+	}
+
+	// Get same-package caller count
+	err = db.QueryRow(`
+		SELECT COUNT(*)
+		FROM call_graph cg
+		JOIN symbols caller ON cg.caller_id = caller.id
+		WHERE cg.callee_id = ?
+		  AND caller.pkg_path = ?
+	`, symbolID, pkgPath).Scan(&samePkgCallers)
+	if err != nil {
+		return false
+	}
+
+	// Internal if all callers are from same package
+	return samePkgCallers == totalCallers
+}
+
+// InferRolesSummary returns a summary of role counts for the repository.
+func InferRolesSummary(db *sql.DB, repoRoot string) (map[Role]int, error) {
+	roles, err := InferRoles(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := make(map[Role]int)
+	for _, r := range roles {
+		summary[r.Role]++
+	}
+	return summary, nil
+}
+
+// GetSymbolsByRole returns all symbols with a specific role.
+func GetSymbolsByRole(db *sql.DB, repoRoot string, role Role) ([]SymbolRole, error) {
+	roles, err := InferRoles(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []SymbolRole
+	for _, r := range roles {
+		if r.Role == role {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered, nil
+}
+
+// GetEntryPoints is a convenience function to get all entry point symbols.
+func GetEntryPoints(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
+	return GetSymbolsByRole(db, repoRoot, RoleEntryPoint)
+}
+
+// GetAPIBoundaries is a convenience function to get all API boundary symbols.
+func GetAPIBoundaries(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
+	return GetSymbolsByRole(db, repoRoot, RoleAPIBoundary)
+}

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -20,6 +20,63 @@ type BootContext struct {
 	KeySymbols  []SymbolRef `json:"key_symbols" yaml:"key_symbols"`
 	ActiveWork  *ActiveWork `json:"active_work,omitempty" yaml:"active_work,omitempty"`
 	Commit      string      `json:"commit" yaml:"commit"`
+
+	// Enhanced fields (Phase 2)
+	BootViews *BootViews   `json:"boot_views,omitempty" yaml:"boot_views,omitempty"`
+	Packages  []PackageRef `json:"packages,omitempty" yaml:"packages,omitempty"`
+
+	// Phase 4: Architecture summary
+	ArchSummary *ArchSummary `json:"arch_summary,omitempty" yaml:"arch_summary,omitempty"`
+}
+
+// BootViews contains the three orientation views for LLM boot sequences.
+type BootViews struct {
+	EntryPointDetails []EntryPointRef     `json:"entry_point_details,omitempty" yaml:"entry_point_details,omitempty"`
+	PrimaryFlows      []string            `json:"primary_flows,omitempty" yaml:"primary_flows,omitempty"`
+	ChangeBoundaries  map[string][]string `json:"change_boundaries,omitempty" yaml:"change_boundaries,omitempty"`
+}
+
+// ArchSummary provides a high-level architecture overview grounded in call graph data.
+// This is used for Phase 4 context enrichment to help LLMs understand codebase structure.
+type ArchSummary struct {
+	// Spine contains primary call flows from entry points (from static analysis)
+	Spine []string `json:"spine" yaml:"spine"`
+	// Components lists packages with their purposes
+	Components []PackagePurpose `json:"components" yaml:"components"`
+	// Edges contains top cross-package call relationships with counts
+	Edges []CrossPackageEdge `json:"edges" yaml:"edges"`
+	// Description is LLM-generated prose describing the architecture (placeholder for now)
+	Description string `json:"description" yaml:"description"`
+}
+
+// PackagePurpose describes a package and its inferred purpose.
+type PackagePurpose struct {
+	Name    string `json:"name" yaml:"name"`
+	Purpose string `json:"purpose" yaml:"purpose"`
+}
+
+// CrossPackageEdge represents a cross-package call relationship.
+type CrossPackageEdge struct {
+	From  string `json:"from" yaml:"from"`
+	To    string `json:"to" yaml:"to"`
+	Count int    `json:"count" yaml:"count"`
+}
+
+// EntryPointRef describes an entry point with its purpose and immediate callees.
+type EntryPointRef struct {
+	Name    string   `json:"name" yaml:"name"`
+	File    string   `json:"file" yaml:"file"`
+	Line    int      `json:"line" yaml:"line"`
+	Purpose string   `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Callees []string `json:"callees,omitempty" yaml:"callees,omitempty"`
+}
+
+// PackageRef describes a package with its purpose and role counts.
+type PackageRef struct {
+	Name       string         `json:"name" yaml:"name"`
+	Purpose    string         `json:"purpose" yaml:"purpose"`
+	Roles      map[string]int `json:"roles,omitempty" yaml:"roles,omitempty"`
+	TopSymbols []SymbolRef    `json:"top_symbols,omitempty" yaml:"top_symbols,omitempty"`
 }
 
 // Project contains basic project information.
@@ -94,9 +151,12 @@ type ExtensionPoint struct {
 
 // SymbolRef is a lightweight reference to a symbol.
 type SymbolRef struct {
-	Name string `json:"name" yaml:"name"`
-	File string `json:"file" yaml:"file"`
-	Line int    `json:"line" yaml:"line"`
+	Name       string `json:"name" yaml:"name"`
+	File       string `json:"file" yaml:"file"`
+	Line       int    `json:"line" yaml:"line"`
+	Role       string `json:"role,omitempty" yaml:"role,omitempty"`
+	Visibility string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+	Purpose    string `json:"purpose,omitempty" yaml:"purpose,omitempty"`
 }
 
 // Meta contains generation metadata.

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const schemaVersion = 11
+const schemaVersion = 12
 
 // migration represents a database migration.
 type migration struct {
@@ -180,6 +180,21 @@ var migrations = []migration{
 		version: 11,
 		name:    "add_pkg_path",
 		up:      ``, // Handled specially - need to add column and index
+	},
+	{
+		version: 12,
+		name:    "symbol_purposes_table",
+		up: `
+		CREATE TABLE IF NOT EXISTS symbol_purposes (
+			symbol_id TEXT PRIMARY KEY,
+			purpose TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
+			model TEXT NOT NULL,
+			generated_at TEXT NOT NULL,
+			FOREIGN KEY (symbol_id) REFERENCES symbols(id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_symbol_purposes_hash ON symbol_purposes(content_hash);
+		`,
 	},
 }
 
@@ -425,4 +440,33 @@ func (s *Store) GetMigrationHistory() ([]struct {
 	}
 
 	return history, rows.Err()
+}
+
+// GetPurpose retrieves the stored purpose for a symbol.
+func (s *Store) GetPurpose(symbolID string) (string, error) {
+	var purpose string
+	err := s.db.QueryRow(`SELECT purpose FROM symbol_purposes WHERE symbol_id = ?`, symbolID).Scan(&purpose)
+	if err != nil {
+		return "", err
+	}
+	return purpose, nil
+}
+
+// SetPurpose stores a purpose for a symbol.
+func (s *Store) SetPurpose(symbolID, purpose, contentHash, model string) error {
+	_, err := s.db.Exec(
+		`INSERT OR REPLACE INTO symbol_purposes (symbol_id, purpose, content_hash, model, generated_at) VALUES (?, ?, ?, ?, ?)`,
+		symbolID, purpose, contentHash, model, time.Now().UTC().Format(time.RFC3339),
+	)
+	return err
+}
+
+// GetPurposeByHash retrieves a purpose by content hash.
+func (s *Store) GetPurposeByHash(contentHash string) (string, error) {
+	var purpose string
+	err := s.db.QueryRow(`SELECT purpose FROM symbol_purposes WHERE content_hash = ?`, contentHash).Scan(&purpose)
+	if err != nil {
+		return "", err
+	}
+	return purpose, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -119,8 +119,8 @@ func TestSchemaCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMeta(schema_version) failed: %v", err)
 	}
-	if version != "11" {
-		t.Errorf("schema_version = %q, want %q", version, "11")
+	if version != "12" {
+		t.Errorf("schema_version = %q, want %q", version, "12")
 	}
 }
 


### PR DESCRIPTION
Adds role-based symbol ranking, boot views, and LLM enrichment infrastructure as outlined in docs/PLAN-context-enrichment.md.

Phase 1 - Role Inference:
- roles.go: Classify symbols by architectural role (entry_point, api_boundary, persistence, handler, factory, internal)
- interfaces.go: Detect std lib interface implementations

Phase 2 - Ranked Output with Boot Views:
- ranking.go: Role-weighted ranking algorithm (priority = log(ref_count + 1) * role_weight)
- flows.go: Extract primary call flows from entry points
- Boot views: entry_point_details, primary_flows, change_boundaries
- Updated types.go with BootViews, EntryPointRef, PackageRef

Phase 3 - LLM Enrichment:
- enrich.go: Symbol purpose generation framework (placeholder for LLM)
- schema.go: Add symbol_purposes table (migration 12)
- index.go: Add --enrich and --enrich-model flags

Phase 4 - Architecture Summary:
- architecture.go: Generate spine, components, edges, description
- Add ArchSummary to BootContext (optional via IncludeArchSummary)

All changes use batch SQL queries for performance (no queries in loops). Boot context now includes role information for key symbols.