### PR TITLE
test: add table-driven regression tests for KG hint lookup

### DIFF
--- a/internal/kg/hints_test.go
+++ b/internal/kg/hints_test.go
@@ -1,0 +1,106 @@
+package kg_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dkoosis/snipe/internal/kg"
+)
+
+func TestGetHints_ReturnsExpectedResults_When_OrcaAvailabilityAndOutputVary(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        kg.Config
+		orcaScript string
+		want       []kg.Hint
+	}{
+		{
+			name: "error: returns nil when orca is unavailable",
+			cfg:  kg.Config{File: "internal/kg/hints.go"},
+			want: nil,
+		},
+		{
+			name:       "error: returns nil when orca command fails",
+			cfg:        kg.Config{File: "internal/kg/hints.go"},
+			orcaScript: "#!/bin/sh\nexit 1\n",
+			want:       nil,
+		},
+		{
+			name: "success: parses hints and extracts package suffix when file symbol and package are provided",
+			cfg: kg.Config{
+				File:    "internal/kg/hints.go",
+				Symbol:  "GetHints",
+				Package: "github.com/dkoosis/snipe/internal/kg",
+			},
+			orcaScript: `#!/bin/sh
+query=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--query" ]; then
+    shift
+    query="$1"
+    break
+  fi
+  shift
+done
+
+case "$query" in
+  file:internal/kg/hints.go)
+    echo "nug-file | trap:h | avoid stale index"
+    ;;
+  sym:GetHints)
+    echo "not enough fields"
+    echo "nug-symbol | pattern | query symbols first"
+    ;;
+  pkg:kg)
+    echo "nug-pkg | map:l | package-level knowledge"
+    ;;
+esac
+`,
+			want: []kg.Hint{
+				{ID: "nug-file", Kind: "trap", Severity: "h", Summary: "avoid stale index"},
+				{ID: "nug-symbol", Kind: "pattern", Summary: "query symbols first"},
+				{ID: "nug-pkg", Kind: "map", Severity: "l", Summary: "package-level knowledge"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.orcaScript != "" {
+				binDir := t.TempDir()
+				binaryName := "orca"
+				if runtime.GOOS == "windows" {
+					binaryName = "orca.bat"
+					tc.orcaScript = strings.ReplaceAll(tc.orcaScript, "#!/bin/sh\n", "")
+					tc.orcaScript = "@echo off\r\n" + strings.ReplaceAll(tc.orcaScript, "\n", "\r\n")
+				}
+
+				orcaPath := filepath.Join(binDir, binaryName)
+				require.NoError(t, os.WriteFile(orcaPath, []byte(tc.orcaScript), 0o755))
+				t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			} else {
+				t.Setenv("PATH", t.TempDir())
+			}
+
+			got := kg.GetHints(tc.cfg)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("hints mismatch (-want +got):\n%s", diff)
+			}
+
+			for _, hint := range got {
+				assert.NotEmpty(t, hint.ID, "invariant: each hint must have an ID")
+				assert.NotEmpty(t, hint.Kind, "invariant: each hint must have a kind")
+				assert.NotEmpty(t, hint.Summary, "invariant: each hint must have a summary")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Add black-box tests to protect `kg.GetHints` behavior when the external `orca` CLI is missing, fails, or returns malformed lines, and to document the expected parsing semantics.

### Description

- Add `internal/kg/hints_test.go` which implements a table-driven, ADR-008-named test `TestGetHints_ReturnsExpectedResults_When_OrcaAvailabilityAndOutputVary` that exercises error paths and success parsing cases.
- Tests simulate `orca` availability by writing a temporary helper script into a temp `PATH` and cover: (1) `orca` missing returns `nil`, (2) `orca` command failing returns `nil`, and (3) successful multi-source (file/symbol/package) responses with malformed-line filtering and severity extraction.
- Tests are black-box (`package kg_test`), use subtests with `t.Run`, and assert invariants that each parsed `kg.Hint` has a non-empty `ID`, `Kind`, and `Summary` using `cmp.Diff`, `require`, and `assert`.

### Testing

- Ran `go test ./internal/kg` and it passed.
- Ran `go test -race ./internal/kg` and it passed.
- Ran `mage test` as part of validation and the test suite completed (package-level tests reported in the QA output).
- Ran `mage qa` which fails on this environment during `gofmt` because the QA task scans module cache fixtures under `.codex/cache/mod/` containing intentionally invalid files, and therefore `mage qa` did not fully succeed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986637209b8832588216195a927806f)