### PR TITLE
Harden SQLite PRAGMA verification and incremental-write safety

### DIFF
--- a/internal/query/lookup.go
+++ b/internal/query/lookup.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -42,7 +43,7 @@ func LookupByID(db *sql.DB, id string) (*SymbolRow, error) {
 	`, id).Scan(&s.ID, &s.Name, &s.Kind, &s.FilePath, &filePathRel, &pkgPath, &s.LineStart, &s.ColStart, &s.LineEnd, &s.ColEnd,
 		&s.Signature, &s.Doc, &s.Receiver, &fileHash)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/query/position.go
+++ b/internal/query/position.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -88,7 +89,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		return symbolID, nil
 	}
 
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("query symbols by name position: %w", err)
 	}
 
@@ -104,7 +105,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		return symbolID, nil
 	}
 
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("query refs: %w", err)
 	}
 
@@ -120,7 +121,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		return symbolID, nil
 	}
 
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("query symbols by name line: %w", err)
 	}
 
@@ -136,7 +137,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		return symbolID, nil
 	}
 
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("query refs by line: %w", err)
 	}
 
@@ -152,7 +153,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		return symbolID, nil
 	}
 
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("query symbols: %w", err)
 	}
 
@@ -165,7 +166,7 @@ func ResolvePosition(db *sql.DB, pos *PositionQuery) (symbolID string, err error
 		LIMIT 1
 	`, pos.File, pos.Line, pos.Line).Scan(&symbolID)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("no symbol found at %s:%d:%d", pos.File, pos.Line, pos.Col)
 	}
 

--- a/internal/store/embed.go
+++ b/internal/store/embed.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/dkoosis/snipe/internal/embed"
@@ -13,7 +14,10 @@ func (s *Store) SaveEmbedding(symbolID string, embedding []float32, model string
 		`INSERT OR REPLACE INTO embeddings (symbol_id, embedding, model, created_at) VALUES (?, ?, ?, ?)`,
 		symbolID, data, model, time.Now().UTC().Format(time.RFC3339),
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("save embedding for symbol %s: %w", symbolID, err)
+	}
+	return nil
 }
 
 // GetEmbedding retrieves an embedding for a symbol.
@@ -77,5 +81,8 @@ func (s *Store) CountEmbeddings() (int, error) {
 // DeleteEmbeddings removes all embeddings (for re-indexing).
 func (s *Store) DeleteEmbeddings() error {
 	_, err := s.db.Exec(`DELETE FROM embeddings`)
-	return err
+	if err != nil {
+		return fmt.Errorf("delete embeddings: %w", err)
+	}
+	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,11 +38,19 @@ func Open(path string) (*Store, error) {
 		_ = db.Close() // G104: cleanup on error path
 		return nil, fmt.Errorf("enable WAL mode: %w", err)
 	}
+	if err := verifyPragmaString(db, "journal_mode", "wal"); err != nil {
+		_ = db.Close() // G104: cleanup on error path
+		return nil, err
+	}
 
 	// Balance durability and latency for WAL workloads
 	if _, err := db.Exec("PRAGMA synchronous=NORMAL"); err != nil {
 		_ = db.Close() // G104: cleanup on error path
 		return nil, fmt.Errorf("set synchronous: %w", err)
+	}
+	if err := verifyPragmaInt(db, "synchronous", 1); err != nil {
+		_ = db.Close() // G104: cleanup on error path
+		return nil, err
 	}
 
 	// Keep temporary data in memory for speed
@@ -50,17 +58,29 @@ func Open(path string) (*Store, error) {
 		_ = db.Close() // G104: cleanup on error path
 		return nil, fmt.Errorf("set temp_store: %w", err)
 	}
+	if err := verifyPragmaInt(db, "temp_store", 2); err != nil {
+		_ = db.Close() // G104: cleanup on error path
+		return nil, err
+	}
 
 	// Set busy timeout to avoid "database is locked" errors during concurrent access
 	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
 		_ = db.Close() // G104: cleanup on error path
 		return nil, fmt.Errorf("set busy_timeout: %w", err)
 	}
+	if err := verifyPragmaInt(db, "busy_timeout", 5000); err != nil {
+		_ = db.Close() // G104: cleanup on error path
+		return nil, err
+	}
 
 	// Enable foreign keys
 	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
 		_ = db.Close() // G104: cleanup on error path
 		return nil, fmt.Errorf("enable foreign keys: %w", err)
+	}
+	if err := verifyPragmaInt(db, "foreign_keys", 1); err != nil {
+		_ = db.Close() // G104: cleanup on error path
+		return nil, err
 	}
 
 	// Limit connections to avoid lock contention
@@ -127,4 +147,26 @@ func AcquireLock(dbPath string) error {
 // ReleaseLock removes the lock file
 func ReleaseLock(dbPath string) error {
 	return os.Remove(LockPath(dbPath))
+}
+
+func verifyPragmaString(db *sql.DB, pragma, want string) error {
+	var got string
+	if err := db.QueryRow("PRAGMA " + pragma).Scan(&got); err != nil {
+		return fmt.Errorf("verify %s pragma: %w", pragma, err)
+	}
+	if got != want {
+		return fmt.Errorf("verify %s pragma: got %q, want %q", pragma, got, want)
+	}
+	return nil
+}
+
+func verifyPragmaInt(db *sql.DB, pragma string, want int) error {
+	var got int
+	if err := db.QueryRow("PRAGMA " + pragma).Scan(&got); err != nil {
+		return fmt.Errorf("verify %s pragma: %w", pragma, err)
+	}
+	if got != want {
+		return fmt.Errorf("verify %s pragma: got %d, want %d", pragma, got, want)
+	}
+	return nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -251,6 +251,49 @@ func TestAcquireLockTwiceFails(t *testing.T) {
 	}
 }
 
+func TestOpenSetsPragmas(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "pragmas.db")
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	var mode string
+	if err := s.DB().QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode query failed: %v", err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+
+	var synchronous int
+	if err := s.DB().QueryRow("PRAGMA synchronous").Scan(&synchronous); err != nil {
+		t.Fatalf("PRAGMA synchronous query failed: %v", err)
+	}
+	if synchronous != 1 {
+		t.Errorf("synchronous = %d, want 1", synchronous)
+	}
+
+	var tempStore int
+	if err := s.DB().QueryRow("PRAGMA temp_store").Scan(&tempStore); err != nil {
+		t.Fatalf("PRAGMA temp_store query failed: %v", err)
+	}
+	if tempStore != 2 {
+		t.Errorf("temp_store = %d, want 2", tempStore)
+	}
+
+	var foreignKeys int
+	if err := s.DB().QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+		t.Fatalf("PRAGMA foreign_keys query failed: %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Errorf("foreign_keys = %d, want 1", foreignKeys)
+	}
+}
+
 func TestBusyTimeoutPragma(t *testing.T) {
 	// Verify busy_timeout is set
 	dir := t.TempDir()

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dkoosis/snipe/internal/index"
+	"modernc.org/sqlite"
 )
 
 // toRelPath converts an absolute file path to a repo-relative path.
@@ -139,19 +141,16 @@ func truncateTables(tx *sql.Tx) error {
 	if _, err := tx.Exec("DELETE FROM call_graph"); err != nil {
 		return fmt.Errorf("truncate call_graph: %w", err)
 	}
-	if _, err := tx.Exec("DELETE FROM imports"); err != nil {
-		// Ignore if table doesn't exist (backwards compatibility)
-		_ = err
+	if err := deleteOptionalTable(tx, "imports"); err != nil {
+		return err
 	}
 	// Delete embeddings (they'll be restored from temp table after symbols are inserted)
-	if _, err := tx.Exec("DELETE FROM embeddings"); err != nil {
-		// Ignore if table doesn't exist (backwards compatibility)
-		_ = err
+	if err := deleteOptionalTable(tx, "embeddings"); err != nil {
+		return err
 	}
 	// Delete symbol_purposes (enrichment data) - will be regenerated
-	if _, err := tx.Exec("DELETE FROM symbol_purposes"); err != nil {
-		// Ignore if table doesn't exist (backwards compatibility)
-		_ = err
+	if err := deleteOptionalTable(tx, "symbol_purposes"); err != nil {
+		return err
 	}
 	if _, err := tx.Exec("DELETE FROM symbols"); err != nil {
 		return fmt.Errorf("truncate symbols: %w", err)
@@ -168,8 +167,10 @@ func preserveEmbeddings(tx *sql.Tx) (int64, error) {
 		SELECT symbol_id, embedding, model, created_at FROM embeddings WHERE 1=0
 	`)
 	if err != nil {
-		// embeddings table might not exist - that's OK
-		return 0, nil //nolint:nilerr // Graceful degradation when embeddings table doesn't exist
+		if isNoSuchTableErr(err, "embeddings") {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("create preserved_embeddings temp table: %w", err)
 	}
 
 	// Copy current embeddings to temp table
@@ -196,14 +197,18 @@ func restoreEmbeddings(tx *sql.Tx) (int64, error) { //nolint:unparam // error ke
 		WHERE p.symbol_id IN (SELECT id FROM symbols)
 	`)
 	if err != nil {
-		// Temp table might not exist (no embeddings to preserve)
-		return 0, nil //nolint:nilerr // Graceful degradation when no embeddings to restore
+		if isNoSuchTableErr(err, "preserved_embeddings") {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("restore embeddings: %w", err)
 	}
 
 	count, _ := result.RowsAffected()
 
 	// Clean up temp table
-	_, _ = tx.Exec("DROP TABLE IF EXISTS preserved_embeddings")
+	if _, err := tx.Exec("DROP TABLE IF EXISTS preserved_embeddings"); err != nil {
+		return 0, fmt.Errorf("drop preserved_embeddings temp table: %w", err)
+	}
 
 	return count, nil
 }
@@ -217,8 +222,10 @@ func preserveSymbolPurposes(tx *sql.Tx) (int64, error) {
 		SELECT symbol_id, purpose, content_hash, model, generated_at FROM symbol_purposes WHERE 1=0
 	`)
 	if err != nil {
-		// symbol_purposes table might not exist - that's OK
-		return 0, nil //nolint:nilerr // Graceful degradation when table doesn't exist
+		if isNoSuchTableErr(err, "symbol_purposes") {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("create preserved_purposes temp table: %w", err)
 	}
 
 	// Copy current purposes to temp table
@@ -245,14 +252,18 @@ func restoreSymbolPurposes(tx *sql.Tx) (int64, error) { //nolint:unparam // erro
 		WHERE p.symbol_id IN (SELECT id FROM symbols)
 	`)
 	if err != nil {
-		// Temp table might not exist (no purposes to preserve)
-		return 0, nil //nolint:nilerr // Graceful degradation when no purposes to restore
+		if isNoSuchTableErr(err, "preserved_purposes") {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("restore symbol purposes: %w", err)
 	}
 
 	count, _ := result.RowsAffected()
 
 	// Clean up temp table
-	_, _ = tx.Exec("DROP TABLE IF EXISTS preserved_purposes")
+	if _, err := tx.Exec("DROP TABLE IF EXISTS preserved_purposes"); err != nil {
+		return 0, fmt.Errorf("drop preserved_purposes temp table: %w", err)
+	}
 
 	return count, nil
 }
@@ -456,7 +467,7 @@ func (s *Store) GetAllFiles() (map[string]index.FileInfo, error) {
 	for rows.Next() {
 		var f index.FileInfo
 		if err := rows.Scan(&f.Path, &f.Mtime, &f.Hash); err != nil {
-			continue
+			return nil, fmt.Errorf("scan file row: %w", err)
 		}
 		files[f.Path] = f
 	}
@@ -467,7 +478,7 @@ func (s *Store) GetAllFiles() (map[string]index.FileInfo, error) {
 func (s *Store) GetFileHash(path string) (string, error) {
 	var hash string
 	err := s.db.QueryRow(`SELECT hash FROM files WHERE path = ?`, path).Scan(&hash)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
 	if err != nil {
@@ -504,15 +515,22 @@ func (s *Store) WriteIndexIncremental(
 	}
 	incCount++
 
+	conn, err := s.db.Conn(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("acquire connection: %w", err)
+	}
+	defer conn.Close()
+
 	// Disable FK constraints (must be outside transaction in SQLite)
-	if _, err := s.db.Exec("PRAGMA foreign_keys=OFF"); err != nil {
+	if _, err := conn.ExecContext(context.Background(), "PRAGMA foreign_keys=OFF"); err != nil {
 		return nil, fmt.Errorf("disable FK: %w", err)
 	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(), "PRAGMA foreign_keys=ON")
+	}()
 
-	tx, err := s.db.Begin()
+	tx, err := conn.BeginTx(context.Background(), nil)
 	if err != nil {
-		// Re-enable FK on error
-		_, _ = s.db.Exec("PRAGMA foreign_keys=ON")
 		return nil, fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() {
@@ -574,20 +592,22 @@ func (s *Store) WriteIndexIncremental(
 	}
 
 	if err := tx.Commit(); err != nil {
-		_, _ = s.db.Exec("PRAGMA foreign_keys=ON")
 		return nil, fmt.Errorf("commit transaction: %w", err)
 	}
 
-	// Re-enable FK constraints (outside transaction)
-	_, _ = s.db.Exec("PRAGMA foreign_keys=ON")
-
 	// Count orphaned refs (outside transaction)
 	var orphanCount int
-	_ = s.db.QueryRow(`SELECT COUNT(*) FROM refs WHERE symbol_id NOT IN (SELECT id FROM symbols)`).Scan(&orphanCount)
+	if err := conn.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM refs WHERE symbol_id NOT IN (SELECT id FROM symbols)`).Scan(&orphanCount); err != nil {
+		return nil, fmt.Errorf("count orphaned refs: %w", err)
+	}
 
 	// Store incremental metadata
-	_ = s.SetMeta("orphaned_refs", fmt.Sprintf("%d", orphanCount))
-	_ = s.SetMeta("incremental_count", fmt.Sprintf("%d", incCount))
+	if _, err := conn.ExecContext(context.Background(), `INSERT OR REPLACE INTO meta (key, value) VALUES ('orphaned_refs', ?)`, fmt.Sprintf("%d", orphanCount)); err != nil {
+		return nil, fmt.Errorf("set orphaned_refs: %w", err)
+	}
+	if _, err := conn.ExecContext(context.Background(), `INSERT OR REPLACE INTO meta (key, value) VALUES ('incremental_count', ?)`, fmt.Sprintf("%d", incCount)); err != nil {
+		return nil, fmt.Errorf("set incremental_count: %w", err)
+	}
 
 	return &IncrementalResult{
 		OrphanedRefs:     orphanCount,
@@ -634,7 +654,7 @@ func deleteByFilePaths(tx *sql.Tx, selectQuery, deleteQuery string, files []stri
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			continue
+			return fmt.Errorf("scan symbol id: %w", err)
 		}
 		ids = append(ids, id)
 	}
@@ -657,7 +677,7 @@ func deleteByFilePaths(tx *sql.Tx, selectQuery, deleteQuery string, files []stri
 		for rows2.Next() {
 			var id string
 			if err := rows2.Scan(&id); err != nil {
-				continue
+				return fmt.Errorf("scan relative symbol id: %w", err)
 			}
 			ids = append(ids, id)
 		}
@@ -680,6 +700,25 @@ func deleteByFilePaths(tx *sql.Tx, selectQuery, deleteQuery string, files []stri
 	delQuery := fmt.Sprintf("%s (%s)", deleteQuery, strings.Join(idPlaceholders, ",")) // #nosec G201 -- query parts are hardcoded
 	_, err = tx.Exec(delQuery, idArgs...)
 	return err
+}
+
+func deleteOptionalTable(tx *sql.Tx, table string) error {
+	_, err := tx.Exec("DELETE FROM " + table)
+	if err == nil {
+		return nil
+	}
+	if isNoSuchTableErr(err, table) {
+		return nil
+	}
+	return fmt.Errorf("truncate %s: %w", table, err)
+}
+
+func isNoSuchTableErr(err error, table string) bool {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(sqliteErr.Error()), "no such table: "+strings.ToLower(table))
 }
 
 // GetStats returns index statistics


### PR DESCRIPTION
### Motivation

- Ensure the SQLite database is configured correctly at open time and that PRAGMA settings are actually applied and verified before schema init.
- Make the incremental write path robust to connection reuse and PRAGMA scoping by pinning FK toggles and the transaction to a single connection.
- Reduce silent error swallowing in store write/restore flows and make temp-table lifecycle failures observable.

### Description

- Add `verifyPragmaString` and `verifyPragmaInt` and call them in `Open()` to verify `journal_mode=WAL`, `synchronous=NORMAL` (`1`), `temp_store=MEMORY` (`2`), `busy_timeout=5000`, and `foreign_keys=ON` before running `initSchema()` in `internal/store/store.go`.
- Pin the incremental write path to a single `*sql.Conn` in `WriteIndexIncremental()` and run `PRAGMA foreign_keys=OFF` / `BEGIN` / `COMMIT` / `PRAGMA foreign_keys=ON` on that connection via `Conn.BeginTx` and `Conn.ExecContext` to avoid PRAGMA scope drift (uses `context` and `Conn` APIs).
- Tighten error handling in `internal/store/write.go`: stop silently continuing on `rows.Scan` errors and return wrapped errors, propagate temp-table create/restore/drop failures unless explicitly a missing-table error, add `deleteOptionalTable` + `isNoSuchTableErr` (uses `modernc.org/sqlite` error type) to make missing-table handling explicit.
- Standardize `sql.ErrNoRows` checks to `errors.Is` in selected query paths (`internal/query/lookup.go`, `internal/query/position.go`) for correctness with modern drivers.
- Wrap embedding write/delete errors with contextual messages in `internal/store/embed.go` and make `DeleteEmbeddings` return wrapped errors.
- Add `TestOpenSetsPragmas` in `internal/store/store_test.go` to assert PRAGMA values, and run `gofmt` across modified files.

### Testing

- Ran `gofmt` on modified files (`internal/store/store.go`, `internal/store/write.go`, `internal/store/embed.go`, `internal/query/lookup.go`, `internal/query/position.go`, `internal/store/store_test.go`).
- Ran unit tests for the modified packages with `source .codex/activate.sh && go test ./internal/store ./internal/query` and all tests in those packages passed.
- Ran `source .codex/activate.sh && go test ./...` during development; package-level tests for `internal/store` and `internal/query` passed in final validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986644e408c8325a311088f08c25724)