### PR TITLE
Simplify embed package tests to focus on behavior

### DIFF
--- a/internal/embed/batch_test.go
+++ b/internal/embed/batch_test.go
@@ -3,12 +3,15 @@ package embed
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func newTestBatchClient(stateDir string) *BatchClient {
+func testBatchClient(stateDir string) *BatchClient {
 	return &BatchClient{
 		apiKey:   "test-key",
 		model:    "test-model",
@@ -17,9 +20,9 @@ func newTestBatchClient(stateDir string) *BatchClient {
 	}
 }
 
-func TestWriteJSONL(t *testing.T) {
+func TestBatchWriteJSONLAndParseResultsRoundTrip(t *testing.T) {
 	dir := t.TempDir()
-	c := newTestBatchClient(dir)
+	c := testBatchClient(dir)
 
 	symbols := []SymbolText{
 		{ID: "sym1", Text: "func Open() error"},
@@ -27,199 +30,119 @@ func TestWriteJSONL(t *testing.T) {
 	}
 
 	path, err := c.WriteJSONL(symbols, dir)
-	if err != nil {
-		t.Fatalf("WriteJSONL failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Read back and verify
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile failed: %v", err)
+	require.NoError(t, err)
+
+	var reqs []BatchRequest
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+		var req BatchRequest
+		require.NoError(t, json.Unmarshal(line, &req))
+		reqs = append(reqs, req)
 	}
 
-	lines := splitLines(string(data))
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d", len(lines))
-	}
-
-	var req BatchRequest
-	if err := json.Unmarshal([]byte(lines[0]), &req); err != nil {
-		t.Fatalf("unmarshal first line: %v", err)
-	}
-	if req.CustomID != "sym1" {
-		t.Errorf("custom_id = %q, want %q", req.CustomID, "sym1")
-	}
-	if req.Body.Input != "func Open() error" {
-		t.Errorf("body.input = %q, want %q", req.Body.Input, "func Open() error")
-	}
+	require.Len(t, reqs, 2)
+	require.Equal(t, "sym1", reqs[0].CustomID)
+	require.Equal(t, "func Open() error", reqs[0].Body.Input)
+	require.Equal(t, "sym2", reqs[1].CustomID)
+	require.Equal(t, "func Close() error", reqs[1].Body.Input)
 }
 
-func TestParseBatchResults(t *testing.T) {
-	c := newTestBatchClient("")
+func TestBatchParseResultsBehavior(t *testing.T) {
+	c := testBatchClient("")
 
-	// Build a valid JSONL batch response
-	embBody, _ := json.Marshal(EmbeddingResponse{
+	embedBody, err := json.Marshal(EmbeddingResponse{
 		Data: []struct {
 			Object    string    `json:"object"`
 			Embedding []float32 `json:"embedding"`
 			Index     int       `json:"index"`
-		}{
-			{Embedding: []float32{0.1, 0.2, 0.3}, Index: 0},
-		},
+		}{{Embedding: []float32{0.1, 0.2, 0.3}, Index: 0}},
+	})
+	require.NoError(t, err)
+
+	line := func(resp BatchResponse) []byte {
+		b, err := json.Marshal(resp)
+		require.NoError(t, err)
+		return append(b, '\n')
+	}
+
+	t.Run("emits only successful embeddings", func(t *testing.T) {
+		stream := bytes.Join([][]byte{
+			line(BatchResponse{BatchID: "1", CustomID: "ok", Response: &BatchRespBody{StatusCode: 200, Body: embedBody}}),
+			line(BatchResponse{BatchID: "1", CustomID: "skip_error", Error: &BatchError{Code: "rate_limit", Message: "too fast"}}),
+			line(BatchResponse{BatchID: "1", CustomID: "skip_status", Response: &BatchRespBody{StatusCode: 500, Body: embedBody}}),
+			[]byte("\n"),
+		}, nil)
+
+		results := map[string][]float32{}
+		err := c.ParseBatchResults(bytes.NewReader(stream), func(id string, emb []float32) error {
+			results[id] = emb
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, map[string][]float32{"ok": {0.1, 0.2, 0.3}}, results)
 	})
 
-	resp := BatchResponse{
-		BatchID:  "batch-1",
-		CustomID: "sym1",
-		Response: &BatchRespBody{
-			StatusCode: 200,
-			Body:       embBody,
-		},
-	}
-
-	line, _ := json.Marshal(resp)
-	line = append(line, '\n')
-
-	results := make(map[string][]float32)
-	err := c.ParseBatchResults(bytes.NewReader(line), func(id string, emb []float32) error {
-		results[id] = emb
-		return nil
+	t.Run("returns callback error", func(t *testing.T) {
+		stream := line(BatchResponse{BatchID: "1", CustomID: "ok", Response: &BatchRespBody{StatusCode: 200, Body: embedBody}})
+		err := c.ParseBatchResults(bytes.NewReader(stream), func(string, []float32) error {
+			return errors.New("boom")
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "process embedding for ok")
 	})
-	if err != nil {
-		t.Fatalf("ParseBatchResults failed: %v", err)
-	}
 
-	emb, ok := results["sym1"]
-	if !ok {
-		t.Fatal("missing result for sym1")
-	}
-	if len(emb) != 3 {
-		t.Errorf("embedding length = %d, want 3", len(emb))
-	}
-	if emb[0] != 0.1 {
-		t.Errorf("emb[0] = %f, want 0.1", emb[0])
-	}
-}
-
-func TestParseBatchResults_SkipsErrors(t *testing.T) {
-	c := newTestBatchClient("")
-
-	resp := BatchResponse{
-		BatchID:  "batch-1",
-		CustomID: "sym1",
-		Error:    &BatchError{Code: "rate_limit", Message: "too fast"},
-	}
-
-	line, _ := json.Marshal(resp)
-	line = append(line, '\n')
-
-	count := 0
-	err := c.ParseBatchResults(bytes.NewReader(line), func(id string, emb []float32) error {
-		count++
-		return nil
+	t.Run("returns parse errors for invalid lines", func(t *testing.T) {
+		err := c.ParseBatchResults(bytes.NewReader([]byte("{not json}\n")), func(string, []float32) error { return nil })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse line")
 	})
-	if err != nil {
-		t.Fatalf("ParseBatchResults failed: %v", err)
-	}
-	if count != 0 {
-		t.Errorf("expected 0 results for error response, got %d", count)
-	}
+
+	t.Run("returns parse errors for invalid embedding body", func(t *testing.T) {
+		line := `{"batch_id":"1","custom_id":"bad","response":{"status_code":200,"body":"not-json"}}` + "\n"
+		err := c.ParseBatchResults(bytes.NewReader([]byte(line)), func(string, []float32) error { return nil })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse embedding result for bad")
+	})
 }
 
-func TestStatePersistence(t *testing.T) {
+func TestBatchStatePersistence(t *testing.T) {
 	dir := t.TempDir()
-	c := newTestBatchClient(dir)
+	c := testBatchClient(dir)
 
-	state := &BatchState{
-		BatchID: "batch-123",
-		Status:  "in_progress",
-		Total:   100,
-	}
-
-	if err := c.SaveState(state); err != nil {
-		t.Fatalf("SaveState failed: %v", err)
-	}
+	state := &BatchState{BatchID: "batch-123", Status: "in_progress", Total: 100}
+	require.NoError(t, c.SaveState(state))
 
 	loaded, err := c.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState failed: %v", err)
-	}
-	if loaded == nil {
-		t.Fatal("LoadState returned nil")
-	}
-	if loaded.BatchID != "batch-123" {
-		t.Errorf("BatchID = %q, want %q", loaded.BatchID, "batch-123")
-	}
-	if loaded.Status != "in_progress" {
-		t.Errorf("Status = %q, want %q", loaded.Status, "in_progress")
-	}
-	if loaded.Total != 100 {
-		t.Errorf("Total = %d, want 100", loaded.Total)
-	}
+	require.NoError(t, err)
+	require.Equal(t, state.BatchID, loaded.BatchID)
+	require.Equal(t, state.Status, loaded.Status)
+	require.Equal(t, state.Total, loaded.Total)
+
+	require.NoError(t, c.ClearState())
+	loaded, err = c.LoadState()
+	require.NoError(t, err)
+	require.Nil(t, loaded)
+
+	_, err = os.Stat(filepath.Join(dir, "batch_state.json"))
+	require.True(t, os.IsNotExist(err))
 }
 
-func TestClearState(t *testing.T) {
-	dir := t.TempDir()
-	c := newTestBatchClient(dir)
-
-	state := &BatchState{BatchID: "batch-123", Status: "completed"}
-	if err := c.SaveState(state); err != nil {
-		t.Fatalf("SaveState failed: %v", err)
-	}
-
-	// Verify file exists
-	statePath := filepath.Join(dir, "batch_state.json")
-	if _, err := os.Stat(statePath); os.IsNotExist(err) {
-		t.Fatal("state file should exist after SaveState")
-	}
-
-	if err := c.ClearState(); err != nil {
-		t.Fatalf("ClearState failed: %v", err)
-	}
-
-	// Verify file removed
-	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
-		t.Error("state file should not exist after ClearState")
-	}
-
-	// LoadState should return nil after clear
-	loaded, err := c.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState after clear failed: %v", err)
-	}
-	if loaded != nil {
-		t.Error("LoadState should return nil after ClearState")
-	}
+func TestBatchLoadStateWithoutFile(t *testing.T) {
+	c := testBatchClient(t.TempDir())
+	state, err := c.LoadState()
+	require.NoError(t, err)
+	require.Nil(t, state)
 }
 
-func TestLoadState_NoFile(t *testing.T) {
-	dir := t.TempDir()
-	c := newTestBatchClient(dir)
+func FuzzParseBatchResults(f *testing.F) {
+	f.Add("\n")
+	f.Add(`{"batch_id":"1","custom_id":"ok","response":{"status_code":200,"body":{"data":[{"embedding":[0.1],"index":0}]}}}` + "\n")
+	f.Add(`{"batch_id":"1","custom_id":"bad","response":{"status_code":200,"body":{"data":` + "\n")
 
-	loaded, err := c.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState failed: %v", err)
-	}
-	if loaded != nil {
-		t.Error("LoadState should return nil when no state file exists")
-	}
-}
-
-// splitLines splits on newlines, filtering empty trailing lines.
-func splitLines(s string) []string {
-	var lines []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' {
-			line := s[start:i]
-			if line != "" {
-				lines = append(lines, line)
-			}
-			start = i + 1
-		}
-	}
-	if start < len(s) {
-		lines = append(lines, s[start:])
-	}
-	return lines
+	c := testBatchClient("")
+	f.Fuzz(func(t *testing.T, input string) {
+		_ = c.ParseBatchResults(bytes.NewReader([]byte(input)), func(string, []float32) error { return nil })
+	})
 }

--- a/internal/embed/client_test.go
+++ b/internal/embed/client_test.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func newTestClient(endpoint string) *Client {
+func testClient(endpoint string) *Client {
 	return &Client{
 		apiKey:   "test-key",
 		model:    "test-model",
@@ -16,76 +18,95 @@ func newTestClient(endpoint string) *Client {
 	}
 }
 
-func TestEmbed(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer test-key" {
-			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
-		}
+func TestClientEmbedBehavior(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		inputType string
+		handler   http.HandlerFunc
+		want      [][]float32
+		wantErr   string
+	}{
+		{
+			name:      "returns embeddings in input order by index",
+			input:     []string{"hello", "world"},
+			inputType: "document",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
 
-		resp := EmbeddingResponse{
-			Object: "list",
-			Data: []struct {
-				Object    string    `json:"object"`
-				Embedding []float32 `json:"embedding"`
-				Index     int       `json:"index"`
-			}{
-				{Object: "embedding", Embedding: []float32{0.1, 0.2, 0.3}, Index: 0},
-				{Object: "embedding", Embedding: []float32{0.4, 0.5, 0.6}, Index: 1},
+				resp := EmbeddingResponse{
+					Object: "list",
+					Data: []struct {
+						Object    string    `json:"object"`
+						Embedding []float32 `json:"embedding"`
+						Index     int       `json:"index"`
+					}{
+						{Object: "embedding", Embedding: []float32{0.4, 0.5, 0.6}, Index: 1},
+						{Object: "embedding", Embedding: []float32{0.1, 0.2, 0.3}, Index: 0},
+					},
+					Model: "test-model",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(resp))
 			},
-			Model: "test-model",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	c := newTestClient(server.URL)
-	results, err := c.Embed([]string{"hello", "world"}, "document")
-	if err != nil {
-		t.Fatalf("Embed failed: %v", err)
+			want: [][]float32{{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}},
+		},
+		{
+			name:      "propagates non-200 api errors",
+			input:     []string{"hello"},
+			inputType: "document",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid_api_key"}`))
+			},
+			wantErr: "API error 401",
+		},
+		{
+			name:      "errors on invalid json response",
+			input:     []string{"hello"},
+			inputType: "query",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":`))
+			},
+			wantErr: "decode response",
+		},
 	}
 
-	if len(results) != 2 {
-		t.Fatalf("expected 2 results, got %d", len(results))
-	}
-	if results[0][0] != 0.1 {
-		t.Errorf("results[0][0] = %f, want 0.1", results[0][0])
-	}
-	if results[1][0] != 0.4 {
-		t.Errorf("results[1][0] = %f, want 0.4", results[1][0])
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			c := testClient(server.URL)
+			got, err := c.Embed(tc.input, tc.inputType)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
 	}
 }
 
-func TestEmbedAPIError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"error":"invalid_api_key"}`))
+func TestClientEmbedEmptyInputSkipsNetwork(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("server should not be called for empty input")
 	}))
 	defer server.Close()
 
-	c := newTestClient(server.URL)
-	_, err := c.Embed([]string{"hello"}, "document")
-	if err == nil {
-		t.Fatal("expected error for 401 response, got nil")
-	}
-	if !contains(err.Error(), "401") {
-		t.Errorf("error should mention 401, got: %s", err.Error())
-	}
-}
-
-func TestEmbedEmptyInput(t *testing.T) {
-	c := newTestClient("http://unused")
+	c := testClient(server.URL)
 	results, err := c.Embed(nil, "document")
-	if err != nil {
-		t.Fatalf("Embed with empty input should not error: %v", err)
-	}
-	if results != nil {
-		t.Errorf("expected nil results for empty input, got %v", results)
-	}
+	require.NoError(t, err)
+	require.Nil(t, results)
 }
 
-func TestEmbedOne(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestClientEmbedOne(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := EmbeddingResponse{
 			Data: []struct {
 				Object    string    `json:"object"`
@@ -95,43 +116,25 @@ func TestEmbedOne(t *testing.T) {
 				{Embedding: []float32{0.1, 0.2, 0.3}, Index: 0},
 			},
 		}
-		json.NewEncoder(w).Encode(resp)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
 	}))
 	defer server.Close()
 
-	c := newTestClient(server.URL)
-	result, err := c.EmbedOne("hello", "query")
-	if err != nil {
-		t.Fatalf("EmbedOne failed: %v", err)
-	}
-	if len(result) != 3 {
-		t.Errorf("expected 3 dimensions, got %d", len(result))
-	}
+	c := testClient(server.URL)
+	got, err := c.EmbedOne("hello", "query")
+	require.NoError(t, err)
+	require.Equal(t, []float32{0.1, 0.2, 0.3}, got)
 }
 
-func TestClientModel(t *testing.T) {
-	c := newTestClient("http://unused")
-	if c.Model() != "test-model" {
-		t.Errorf("Model() = %q, want %q", c.Model(), "test-model")
-	}
-}
+func TestClientEmbedOnePropagatesEmbedErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_api_key"}`))
+	}))
+	defer server.Close()
 
-func TestClientDimensions(t *testing.T) {
-	c := newTestClient("http://unused")
-	if c.Dimensions() != 1024 {
-		t.Errorf("Dimensions() = %d, want 1024", c.Dimensions())
-	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
-}
-
-func containsHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	c := testClient(server.URL)
+	_, err := c.EmbedOne("hello", "query")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "API error 401")
 }


### PR DESCRIPTION
### Motivation
- Tests in `internal/embed` contained fragile scaffolding and implementation-focused checks that added maintenance burden. 
- Aim to keep tests behavior-focused, using real dependencies where practical and removing ad-hoc helpers.

### Description
- Rewrote `internal/embed/client_test.go` as table-driven, behavior-focused tests that exercise `Client.Embed` and `Client.EmbedOne` using `httptest.Server` to observe real HTTP interactions. 
- Rewrote `internal/embed/batch_test.go` to validate observable outcomes: `WriteJSONL` output shape, `ParseBatchResults` success/skip/error behavior, and batch state `Save/Load/Clear` lifecycle. 
- Removed brittle custom helpers (`contains`, `splitLines`) and trivial getter tests, and replaced bespoke assertions with `require` from `stretchr/testify` for concise checks. 
- Added a fuzz test `FuzzParseBatchResults` to harden the batch parser against malformed external input.

### Testing
- Ran `snipe index`, `snipe doctor`, and `snipe status` successfully to refresh and validate the code index. 
- Ran `go test ./internal/embed` and it passed successfully. 
- Ran `gofumpt` and `goimports` on the modified test files and `go test ./...` which completed with package tests passing. 
- Attempted `mage` QA but `mage`'s staticcheck step failed due to a toolchain mismatch in the environment (linter binary built with Go 1.24 while repository requires Go 1.25), blocking the full `mage` gate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9d175d5c8325a7bb74cd57c017ef)