### PR TITLE
feat: go.work workspace support (#132)

### DIFF
--- a/.claude/rules/boot.md
+++ b/.claude/rules/boot.md
@@ -1,18 +1,20 @@
-sha: 79c1851 | qa: pass | updated: 2026-03-18
+sha: c344076 | qa: pass | updated: 2026-03-19
 
 ## Do next
 
-Pick one: un-skip impl test | #121 search index fallback | #123 root detection
+Pick one: #127 un-skip impl test | #117 semsearch unit tests | #128 v0.1.1 tag
 
 ## Done
 
-- Renamed VOYAGE_API_KEY → SNIPE_VOYAGE_API_KEY throughout (env var, credentials file, docs, tests)
-- Full /sweep simplify: 15/17 packages simplified, -600+ lines dead code/duplication
-- Full /sweep craft: 14/17 packages improved, found+fixed 6 bugs
+- #123 root detection: FindProjectRoot in internal/util, OpenStore resolves git root, doctor mismatch check
+- #121 search index fallback: LookupByName fallback between rg and semantic, renamed no_index → rg_only
+- Simplify review: search.go resolves git root for store, cached Exists in OpenStore, renamed flag
+- Renamed VOYAGE_API_KEY → SNIPE_VOYAGE_API_KEY throughout
+- Full /sweep simplify + craft across all 17 packages
 
 ## Backlog
 
-un-skip impl test | #121 search index fallback | #123 root detection | #112 vague-intent search | #117 semsearch unit tests | v0.1.1 tag | Homebrew tap
+#127 un-skip impl test | #112 vague-intent search | #117 semsearch unit tests | #128 v0.1.1 tag | #129 Homebrew tap | #122 human/table format | #126 trixi audit
 
 ## Traps
 
@@ -21,3 +23,4 @@ un-skip impl test | #121 search index fallback | #123 root detection | #112 vagu
 - `knownSubcommands` map in cmd/root.go must be updated when adding new commands
 - No interfaces in snipe's own source — impl can only be tested via blackbox fixture
 - Do NOT optimize eval until telemetry provides ground truth
+- search.go bypasses OpenStore (by design — works without index). Root resolution added separately in simplify review.

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -132,10 +132,15 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stderr, "Loading packages from %s...\n", absDir)
 	loadStart := time.Now()
 
+	patterns, err := index.WorkspacePatterns(absDir)
+	if err != nil {
+		return fmt.Errorf("resolve workspace patterns: %w", err)
+	}
+
 	result, err := index.Load(index.LoadConfig{
 		Context:  GetContext(),
 		Dir:      absDir,
-		Patterns: []string{"./..."},
+		Patterns: patterns,
 		Tests:    true,
 	})
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -331,9 +331,10 @@ func OpenStore(w *output.Writer, cmdName string) (*store.Store, string, error) {
 	}
 
 	dbPath := store.DefaultIndexPath(root)
+	dbExists := store.Exists(dbPath)
 
 	// Mismatch detection: old index built at wrong location by previous bug
-	if !store.Exists(dbPath) && root != cwd {
+	if !dbExists && root != cwd {
 		cwdPath := store.DefaultIndexPath(cwd)
 		if store.Exists(cwdPath) {
 			if w != nil {
@@ -355,7 +356,7 @@ func OpenStore(w *output.Writer, cmdName string) (*store.Store, string, error) {
 	}
 
 	// Check for missing index
-	if !store.Exists(dbPath) {
+	if !dbExists {
 		if w != nil {
 			_ = w.WriteError(cmdName, output.NewMissingIndexError())
 		}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dkoosis/snipe/internal/query"
 	"github.com/dkoosis/snipe/internal/search"
 	"github.com/dkoosis/snipe/internal/store"
+	"github.com/dkoosis/snipe/internal/util"
 )
 
 var identifierRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)
@@ -67,8 +68,14 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		})
 	}
 
+	// Resolve to project root for index lookup (D3)
+	root := util.FindProjectRoot(dir)
+	if root == "" {
+		root = dir
+	}
+
 	// Open store once — used for both enrichment and potential semantic fallback
-	dbPath := store.DefaultIndexPath(dir)
+	dbPath := store.DefaultIndexPath(root)
 	var s *store.Store
 	if store.Exists(dbPath) && !store.IsIndexing(dbPath) {
 		if opened, err := store.Open(dbPath); err == nil {
@@ -98,7 +105,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// Index name fallback — when rg returns 0 results for an identifier-like pattern,
 	// check the symbols table directly. Faster than semantic search, no API call needed.
-	usedIndexFallback := false
+	indexFallbackFound := false
 	var decisionPath []string
 	if len(results) == 0 && searchFile == "" && s != nil && identifierRe.MatchString(pattern) {
 		symRows, lookupErr := query.LookupByName(s.DB(), pattern)
@@ -110,7 +117,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 				results = append(results, symRows[i].ToResult())
 			}
 			decisionPath = []string{"rg:0_results", fmt.Sprintf("index_fallback:%d_results", len(results))}
-			usedIndexFallback = true
+			indexFallbackFound = true
 		}
 	}
 
@@ -120,7 +127,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	// Note: identifier-like patterns add a *.go glob to rg but the semantic search
 	// operates over the full embedding space regardless of file type.
 	usedFallback := false
-	if len(results) == 0 && searchFile == "" && !usedIndexFallback && s != nil && embed.HasCredentials() {
+	if len(results) == 0 && searchFile == "" && !indexFallbackFound && s != nil && embed.HasCredentials() {
 		client, clientErr := embed.NewClient()
 		if clientErr != nil {
 			decisionPath = append(decisionPath, "rg:0_results", "sim:client_error")
@@ -142,7 +149,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	// Enrich rg results with index metadata if available (skip for semantic results)
 	var indexState output.IndexState
 	enriched := false
-	if s != nil && !usedFallback && !usedIndexFallback {
+	if s != nil && !usedFallback && !indexFallbackFound {
 		for i := range results {
 			if sym := query.FindSymbolAtPosition(s.DB(), results[i].File, results[i].Range.Start.Line); sym != nil {
 				results[i].Name = sym.Name
@@ -160,7 +167,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		// search gets staleness support generally.
 		indexState = query.CheckIndexState(s.DB(), dir, Version)
 		enriched = true
-	} else if usedIndexFallback && s != nil {
+	} else if indexFallbackFound && s != nil {
 		indexState = query.CheckIndexState(s.DB(), dir, Version)
 		enriched = true
 	}

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -186,6 +186,16 @@ Default output changed from JSON envelope to Claude-optimized structured text.
 
 ---
 
+## Issue fixes (2026-03-19)
+
+| Issue | Fix | PR | Notes |
+|-------|-----|-----|-------|
+| #123 | index: repo root detection causes misleading MISSING_INDEX errors | #130 | FindProjectRoot in internal/util, OpenStore resolves git root, doctor mismatch check, blackbox test |
+| #121 | search: 0 results with no_index degradation after indexing | #131 | LookupByName fallback between rg and semantic, renamed no_index → rg_only |
+| — | simplify review | c344076 | search.go resolves git root for store, cached Exists in OpenStore, renamed usedIndexFallback → indexFallbackFound |
+
+---
+
 ## Decisions log
 
 Canonical decision table now in CLAUDE.md (D1-D6). Below is history.

--- a/docs/superpowers/plans/2026-03-20-gowork-workspace-support.md
+++ b/docs/superpowers/plans/2026-03-20-gowork-workspace-support.md
@@ -1,0 +1,470 @@
+# go.work Workspace Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `snipe index` discover and index all modules in a `go.work` workspace, not just the root module.
+
+**Architecture:** Parse `go.work` with `golang.org/x/mod/modfile.ParseWork`, generate one `<dir>/...` load pattern per `use` directive, and feed those patterns to the existing `go/packages.Load` pipeline. No changes to storage, queries, or downstream commands.
+
+**Tech Stack:** `golang.org/x/mod/modfile` (already an indirect dependency), Go standard `os` for file detection.
+
+**Spec:** `docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md`
+
+**Verify:** `mage` (build + lint + test). Blackbox tests: `mage qa` or `go test -tags blackbox ./test/blackbox/...`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `internal/index/workspace.go` | New — `WorkspacePatterns(dir) ([]string, error)`: detect go.work, parse, return patterns |
+| `internal/index/workspace_test.go` | New — unit tests for WorkspacePatterns |
+| `internal/index/loader.go` | Modify — default pattern fallback uses WorkspacePatterns |
+| `cmd/index.go` | Modify — primary call site uses WorkspacePatterns |
+| `test/blackbox/fixture_test.go` | Modify — add `writeWorkspaceFixture` helper |
+| `test/blackbox/cli_workflows_test.go` | Modify — add workspace indexing + def test |
+
+---
+
+### Task 1: WorkspacePatterns — failing tests
+
+**Files:**
+- Create: `internal/index/workspace_test.go`
+- Create: `internal/index/workspace.go` (stub)
+
+- [ ] **Step 1: Write the test file**
+
+```go
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspacePatterns_WithGoWork_ReturnsPerModulePatterns(t *testing.T) {
+	dir := t.TempDir()
+	goWork := `go 1.21
+
+use (
+	.
+	./graph
+	./store
+	./mcp
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte(goWork), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]bool{
+		"./...":       true,
+		"./graph/...": true,
+		"./store/...": true,
+		"./mcp/...":   true,
+	}
+	if len(patterns) != len(want) {
+		t.Fatalf("got %d patterns, want %d: %v", len(patterns), len(want), patterns)
+	}
+	for _, p := range patterns {
+		if !want[p] {
+			t.Errorf("unexpected pattern: %s", p)
+		}
+	}
+}
+
+func TestWorkspacePatterns_NoGoWork_ReturnsDotSlashDotDotDot(t *testing.T) {
+	dir := t.TempDir()
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(patterns) != 1 || patterns[0] != "./..." {
+		t.Fatalf("got %v, want [./...]", patterns)
+	}
+}
+
+func TestWorkspacePatterns_MalformedGoWork_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte("not a valid go.work file {{{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := WorkspacePatterns(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed go.work")
+	}
+}
+
+func TestWorkspacePatterns_EmptyUseDirectives_ReturnsDotSlashDotDotDot(t *testing.T) {
+	dir := t.TempDir()
+	goWork := "go 1.21\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte(goWork), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(patterns) != 1 || patterns[0] != "./..." {
+		t.Fatalf("got %v, want [./...]", patterns)
+	}
+}
+
+func TestWorkspacePatterns_NonexistentUseDir_StillReturnsPattern(t *testing.T) {
+	dir := t.TempDir()
+	goWork := "go 1.21\n\nuse ./doesnotexist\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte(goWork), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(patterns) != 1 || patterns[0] != "./doesnotexist/..." {
+		t.Fatalf("got %v, want [./doesnotexist/...]", patterns)
+	}
+}
+```
+
+- [ ] **Step 2: Write the stub**
+
+Create `internal/index/workspace.go`:
+
+```go
+package index
+
+// WorkspacePatterns returns load patterns for go/packages.
+// If go.work exists at dir, returns a pattern per workspace module.
+// Otherwise returns ["./..."].
+func WorkspacePatterns(dir string) ([]string, error) {
+	return []string{"./..."}, nil
+}
+```
+
+- [ ] **Step 3: Run tests — verify failures**
+
+Run: `go test ./internal/index/ -run TestWorkspacePatterns -v`
+Expected: `TestWorkspacePatterns_WithGoWork_ReturnsPerModulePatterns` and `TestWorkspacePatterns_NonexistentUseDir_StillReturnsPattern` FAIL. Other tests PASS (stub returns `["./..."]`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/index/workspace.go internal/index/workspace_test.go
+git commit -m "test: add WorkspacePatterns tests (red)"
+```
+
+---
+
+### Task 2: WorkspacePatterns — implementation
+
+**Files:**
+- Modify: `internal/index/workspace.go`
+
+- [ ] **Step 1: Implement WorkspacePatterns**
+
+Replace the stub in `internal/index/workspace.go`:
+
+```go
+package index
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/mod/modfile"
+)
+
+// WorkspacePatterns returns load patterns for go/packages.
+// If go.work exists at dir, returns a pattern per workspace module.
+// Otherwise returns ["./..."].
+func WorkspacePatterns(dir string) ([]string, error) {
+	goWorkPath := filepath.Join(dir, "go.work")
+
+	data, err := os.ReadFile(goWorkPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{"./..."}, nil
+		}
+		return nil, fmt.Errorf("read go.work: %w", err)
+	}
+
+	wf, err := modfile.ParseWork(goWorkPath, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse go.work: %w", err)
+	}
+
+	if len(wf.Use) == 0 {
+		return []string{"./..."}, nil
+	}
+
+	patterns := make([]string, 0, len(wf.Use))
+	for _, u := range wf.Use {
+		patterns = append(patterns, u.Path+"/...")
+	}
+	return patterns, nil
+}
+```
+
+- [ ] **Step 2: Run tests — verify all pass**
+
+Run: `go test ./internal/index/ -run TestWorkspacePatterns -v`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `mage`
+Expected: PASS (no regressions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/index/workspace.go
+git commit -m "feat: implement WorkspacePatterns for go.work support (#132)"
+```
+
+---
+
+### Task 3: Wire into cmd/index.go (primary call site)
+
+**Files:**
+- Modify: `cmd/index.go:135-140`
+
+- [ ] **Step 1: Replace hardcoded pattern**
+
+In `cmd/index.go`, replace lines 135-140:
+
+```go
+// OLD:
+result, err := index.Load(index.LoadConfig{
+    Context:  GetContext(),
+    Dir:      absDir,
+    Patterns: []string{"./..."},
+    Tests:    true,
+})
+
+// NEW:
+patterns, err := index.WorkspacePatterns(absDir)
+if err != nil {
+    return fmt.Errorf("resolve workspace patterns: %w", err)
+}
+
+result, err := index.Load(index.LoadConfig{
+    Context:  GetContext(),
+    Dir:      absDir,
+    Patterns: patterns,
+    Tests:    true,
+})
+```
+
+- [ ] **Step 2: Run mage**
+
+Run: `mage`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/index.go
+git commit -m "feat: use WorkspacePatterns in index command (#132)"
+```
+
+---
+
+### Task 4: Wire into loader.go (defensive fallback)
+
+**Files:**
+- Modify: `internal/index/loader.go:59-61`
+
+- [ ] **Step 1: Update default pattern resolution**
+
+In `internal/index/loader.go`, replace lines 59-61:
+
+```go
+// OLD:
+if len(cfg.Patterns) == 0 {
+    cfg.Patterns = []string{"./..."}
+}
+
+// NEW:
+if len(cfg.Patterns) == 0 {
+    cfg.Patterns, _ = WorkspacePatterns(cfg.Dir)
+    if len(cfg.Patterns) == 0 {
+        cfg.Patterns = []string{"./..."}
+    }
+}
+```
+
+- [ ] **Step 2: Run mage**
+
+Run: `mage`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/index/loader.go
+git commit -m "feat: loader default pattern resolves workspace modules (#132)"
+```
+
+---
+
+### Task 5: Blackbox test — workspace indexing
+
+**Files:**
+- Modify: `test/blackbox/fixture_test.go` — add `writeWorkspaceFixture`
+- Modify: `test/blackbox/cli_workflows_test.go` — add workspace test
+
+- [ ] **Step 1: Add workspace fixture helper**
+
+Add to `test/blackbox/fixture_test.go`:
+
+```go
+// writeWorkspaceFixture creates a multi-module go.work project.
+// Returns the repo dir and a map of useful paths.
+func writeWorkspaceFixture(t *testing.T) (repoDir string, paths map[string]string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	paths = make(map[string]string)
+
+	// Workspace root
+	writeFile(t, filepath.Join(repoDir, "go.work"), `go 1.21
+
+use (
+	.
+	./lib
+)
+`)
+
+	// Root module
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/workspace\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repoDir, "main.go"), `package workspace
+
+import "example.com/workspace/lib"
+
+func UseLib() string {
+	return lib.Hello()
+}
+`)
+	paths["main"] = filepath.Join(repoDir, "main.go")
+
+	// Lib module (sibling workspace module)
+	writeFile(t, filepath.Join(repoDir, "lib", "go.mod"), "module example.com/workspace/lib\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repoDir, "lib", "lib.go"), `package lib
+
+// Hello returns a greeting from the lib module.
+func Hello() string {
+	return "hello from lib"
+}
+`)
+	paths["lib"] = filepath.Join(repoDir, "lib", "lib.go")
+
+	return repoDir, paths
+}
+```
+
+- [ ] **Step 2: Add workspace index + def test**
+
+Add to `test/blackbox/cli_workflows_test.go`:
+
+```go
+func TestIndex_WorkspaceFixture_IndexesAllModules(t *testing.T) {
+	repoDir, _ := writeWorkspaceFixture(t)
+
+	// Index the workspace
+	stdout, stderr, exitCode := run(t, repoDir, "index", repoDir)
+	if exitCode != 0 {
+		t.Fatalf("index exit %d stderr=%s", exitCode, string(stderr))
+	}
+
+	resp := parseJSON(t, stdout)
+	assertResponseContract(t, resp, responseExpectations{
+		command:           "index",
+		requireRepoRoot:   true,
+		requireIndexState: true,
+	})
+
+	// Verify lib.Hello is findable (proves lib module was indexed)
+	stdout, stderr, exitCode = run(t, repoDir, "def", "Hello")
+	if exitCode != 0 {
+		t.Fatalf("def exit %d stderr=%s", exitCode, string(stderr))
+	}
+
+	defResp := parseJSON(t, stdout)
+	results := requireSlice(t, defResp["results"], "results")
+	if len(results) == 0 {
+		t.Fatal("expected to find Hello in lib module, got 0 results")
+	}
+
+	// Verify the result is from the lib module
+	first := requireMap(t, results[0], "results[0]")
+	file, _ := first["file"].(string)
+	if !strings.Contains(file, "lib") {
+		t.Errorf("expected Hello from lib module, got file: %s", file)
+	}
+}
+```
+
+- [ ] **Step 3: Run blackbox tests**
+
+Run: `go test -tags blackbox ./test/blackbox/ -run TestIndex_WorkspaceFixture -v -timeout 60s`
+Expected: PASS — lib module's `Hello` symbol is found.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `mage`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/blackbox/fixture_test.go test/blackbox/cli_workflows_test.go
+git commit -m "test: blackbox test for go.work workspace indexing (#132)"
+```
+
+---
+
+### Task 6: Run mage qa + manual verification
+
+- [ ] **Step 1: Run mage qa**
+
+Run: `mage qa`
+Expected: PASS — all checks including race detector and blackbox tests.
+
+- [ ] **Step 2: Manual verification on trixi**
+
+Run: `cd /Users/vcto/Projects/trixi && /Users/vcto/Projects/snipe/snipe index . 2>&1`
+Expected: stderr shows loading 23+ packages (not 2), "Found N symbols" where N is significantly higher than root-module-only count.
+
+- [ ] **Step 3: Verify cross-module lookup on trixi**
+
+Run: `cd /Users/vcto/Projects/trixi && /Users/vcto/Projects/snipe/snipe def Hello` (or any symbol from a non-root module)
+Expected: Symbol found in the correct module.
+
+- [ ] **Step 4: Run go mod tidy**
+
+Run: `go mod tidy` (from snipe repo root)
+Expected: `golang.org/x/mod` promoted from indirect to direct in go.mod. Commit if changed.
+
+- [ ] **Step 5: Final commit if go.mod changed**
+
+```bash
+git add go.mod go.sum
+git commit -m "chore: promote golang.org/x/mod to direct dependency"
+```

--- a/docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md
+++ b/docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md
@@ -1,0 +1,75 @@
+# go.work Workspace Support
+
+**Issue:** #132 — commands only see root module in go.work workspaces
+**Date:** 2026-03-20
+
+## Problem
+
+`go list ./...` from a go.work workspace root only enumerates packages in the root module. Packages in sibling workspace modules (e.g., `./graph`, `./store`) are invisible. snipe hardcodes `["./..."]` as the load pattern, so indexing misses all non-root modules.
+
+Verified against trixi (7 modules): `go list ./...` returns 2 packages; explicit per-module patterns return 23.
+
+## Solution
+
+Parse `go.work` at the project root, extract `use` directives, and generate per-module load patterns for `go/packages`.
+
+### New function: `internal/index/workspace.go`
+
+```go
+// WorkspacePatterns returns load patterns for go/packages.
+// If go.work exists at dir, returns a pattern per workspace module.
+// Otherwise returns ["./..."].
+func WorkspacePatterns(dir string) ([]string, error)
+```
+
+**Logic:**
+1. Check if `go.work` exists at `dir`
+2. If yes: parse with `golang.org/x/mod/modfile.ParseWork`
+3. For each `Use` directive, generate `<dir>/...` pattern
+4. Deduplicate: skip `./...` for `use .` since root pattern already covers it
+5. Return combined patterns (e.g., `["./...", "./graph/...", "./store/..."]`)
+6. If no `go.work`: return `["./..."]` (current behavior unchanged)
+
+### Call site: `cmd/index.go`
+
+Replace hardcoded `[]string{"./..."}` (line ~138) with `index.WorkspacePatterns(absDir)`.
+
+### Why nothing else changes
+
+- `go/packages` resolves cross-module types when all patterns are loaded in one call
+- Symbol extraction, refs, call graph, imports all operate on `[]packages.Package` — module-agnostic
+- Store schema already has `pkg_path` per symbol — multi-module data coexists
+- Query layer uses `pkg_path` for lookups — works across modules
+- Fingerprinting already hashes `go.work` — cache invalidation works
+- `FindProjectRoot` finds `.git` at workspace root — correct for go.work repos
+
+### Edge cases
+
+| Case | Behavior |
+|------|----------|
+| No `go.work` | Returns `["./..."]`, zero impact |
+| `use .` present | Deduplicated — root `./...` covers it |
+| Malformed `go.work` | Return error (don't silently fall back) |
+| `use ./sub` with nested pkgs | `./sub/...` picks up all nested packages |
+
+## Files
+
+| File | Change |
+|------|--------|
+| `internal/index/workspace.go` | New — `WorkspacePatterns()` |
+| `internal/index/workspace_test.go` | New — unit tests |
+| `cmd/index.go` | One-line: call `WorkspacePatterns` instead of hardcoded pattern |
+| `go.mod` | Promote `golang.org/x/mod` from indirect to direct |
+
+## Testing
+
+- Unit: `WorkspacePatterns` with synthetic `go.work` in temp dir
+- Unit: no-go.work returns `["./..."]`
+- Unit: malformed go.work returns error
+- Manual: run `snipe index` on trixi, verify all 23 packages indexed
+
+## Non-goals
+
+- `FindProjectRoot` changes (already works — `.git` and `go.work` co-located)
+- Per-command changes (all query the index DB — fixed by fixing indexing)
+- Cross-repo test fixtures (trixi is external)

--- a/docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md
+++ b/docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md
@@ -28,11 +28,27 @@ func WorkspacePatterns(dir string) ([]string, error)
 3. For each `Use` directive, generate `<use-path>/...` pattern (e.g., `use ./graph` → `./graph/...`)
 4. If no `go.work`: return `["./..."]` (current behavior unchanged)
 
-One pattern per `use` directive. No base pattern, no dedup — the `use` directives are the complete list of modules.
+One pattern per `use` directive. No base pattern, no dedup — the `use` directives are the complete list of modules. `replace` directives in `go.work` are irrelevant (they affect module resolution, not package discovery) and are ignored.
 
 ### Call sites
 
-**Primary: `internal/index/loader.go`** — the loader's default fallback (lines 59-61) should resolve workspace patterns when `Patterns` is empty. This makes it defensive: any caller that omits patterns gets workspace-aware behavior automatically.
+**Primary: `cmd/index.go`** — line 138 hardcodes `Patterns: []string{"./..."}`, which is the direct cause of #132. Replace with `WorkspacePatterns(absDir)`. Error from `WorkspacePatterns` should be surfaced (fail loud — a malformed `go.work` is a real problem the user needs to know about).
+
+```go
+patterns, err := WorkspacePatterns(absDir)
+if err != nil {
+    return fmt.Errorf("resolve workspace patterns: %w", err)
+}
+
+result, err := index.Load(index.LoadConfig{
+    Context:  GetContext(),
+    Dir:      absDir,
+    Patterns: patterns,
+    Tests:    true,
+})
+```
+
+**Defensive: `internal/index/loader.go`** — the loader's default fallback (lines 59-61) should resolve workspace patterns when `Patterns` is empty. This ensures any future caller that omits patterns gets workspace-aware behavior automatically. Error is swallowed here (graceful degradation — the fallback to `["./..."]` is better than failing on an optional code path).
 
 ```go
 if len(cfg.Patterns) == 0 {
@@ -42,8 +58,6 @@ if len(cfg.Patterns) == 0 {
     }
 }
 ```
-
-**Secondary: `cmd/index.go`** — also passes explicit patterns. Update to use `WorkspacePatterns(absDir)` instead of hardcoded `[]string{"./..."}`.
 
 ### Why nothing else changes
 
@@ -64,10 +78,10 @@ if len(cfg.Patterns) == 0 {
 |------|----------|
 | No `go.work` | Returns `["./..."]`, zero impact |
 | `use .` present | Generates `./...` — one pattern like any other |
-| Malformed `go.work` | Return error (don't silently fall back) |
+| Malformed `go.work` | `cmd/index.go`: return error (fail loud). `loader.go` fallback: swallow error, degrade to `["./..."]` |
 | `use ./sub` with nested pkgs | `./sub/...` picks up all nested packages |
 | `use` dir doesn't exist | Let `go/packages` surface the error |
-| `GOWORK=off` in env | `go.work` file still parsed; `go/packages` will ignore workspace semantics — acceptable since explicit per-module patterns still load correctly |
+| `GOWORK=off` in env | `go.work` file still parsed, but `go/packages` will not resolve cross-module dependencies. Per-module patterns will fail for packages outside the root module. Acceptable: user explicitly opted out of workspaces. Not our problem to fix. |
 
 ## Files
 
@@ -75,8 +89,9 @@ if len(cfg.Patterns) == 0 {
 |------|--------|
 | `internal/index/workspace.go` | New — `WorkspacePatterns()` |
 | `internal/index/workspace_test.go` | New — unit tests |
-| `internal/index/loader.go` | Default pattern fallback uses `WorkspacePatterns` |
-| `cmd/index.go` | Call `WorkspacePatterns` instead of hardcoded pattern |
+| `cmd/index.go` | Call `WorkspacePatterns` instead of hardcoded pattern (primary fix) |
+| `internal/index/loader.go` | Default pattern fallback uses `WorkspacePatterns` (defensive) |
+| `go.mod` | `golang.org/x/mod` promoted from indirect to direct (already in dependency tree) |
 
 ## Testing
 
@@ -84,6 +99,7 @@ if len(cfg.Patterns) == 0 {
 - Unit: no-go.work returns `["./..."]`
 - Unit: malformed go.work returns error
 - Unit: `use` dir that doesn't exist (still returns pattern, go/packages errors)
+- Blackbox: multi-module fixture with `go.work`, verify `snipe index` + `snipe def` finds symbols from all modules
 - Manual: run `snipe index` on trixi, verify all 23 packages indexed
 
 ## Non-goals
@@ -92,3 +108,4 @@ if len(cfg.Patterns) == 0 {
 - Per-command changes (all query the index DB — fixed by fixing indexing)
 - Cross-repo test fixtures (trixi is external)
 - `use ../sibling` support (outside git root)
+- Handling `GOWORK=off` gracefully (user's explicit choice)

--- a/docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md
+++ b/docs/superpowers/specs/2026-03-20-gowork-workspace-support-design.md
@@ -25,14 +25,25 @@ func WorkspacePatterns(dir string) ([]string, error)
 **Logic:**
 1. Check if `go.work` exists at `dir`
 2. If yes: parse with `golang.org/x/mod/modfile.ParseWork`
-3. For each `Use` directive, generate `<dir>/...` pattern
-4. Deduplicate: skip `./...` for `use .` since root pattern already covers it
-5. Return combined patterns (e.g., `["./...", "./graph/...", "./store/..."]`)
-6. If no `go.work`: return `["./..."]` (current behavior unchanged)
+3. For each `Use` directive, generate `<use-path>/...` pattern (e.g., `use ./graph` → `./graph/...`)
+4. If no `go.work`: return `["./..."]` (current behavior unchanged)
 
-### Call site: `cmd/index.go`
+One pattern per `use` directive. No base pattern, no dedup — the `use` directives are the complete list of modules.
 
-Replace hardcoded `[]string{"./..."}` (line ~138) with `index.WorkspacePatterns(absDir)`.
+### Call sites
+
+**Primary: `internal/index/loader.go`** — the loader's default fallback (lines 59-61) should resolve workspace patterns when `Patterns` is empty. This makes it defensive: any caller that omits patterns gets workspace-aware behavior automatically.
+
+```go
+if len(cfg.Patterns) == 0 {
+    cfg.Patterns, _ = WorkspacePatterns(cfg.Dir)
+    if len(cfg.Patterns) == 0 {
+        cfg.Patterns = []string{"./..."}
+    }
+}
+```
+
+**Secondary: `cmd/index.go`** — also passes explicit patterns. Update to use `WorkspacePatterns(absDir)` instead of hardcoded `[]string{"./..."}`.
 
 ### Why nothing else changes
 
@@ -43,14 +54,20 @@ Replace hardcoded `[]string{"./..."}` (line ~138) with `index.WorkspacePatterns(
 - Fingerprinting already hashes `go.work` — cache invalidation works
 - `FindProjectRoot` finds `.git` at workspace root — correct for go.work repos
 
+### Assumptions
+
+- All `use` directives are children of the git root (standard monorepo layout). `use ../sibling` (directories outside the repo) is out of scope — would require multi-root file walking, which is a different problem.
+
 ### Edge cases
 
 | Case | Behavior |
 |------|----------|
 | No `go.work` | Returns `["./..."]`, zero impact |
-| `use .` present | Deduplicated — root `./...` covers it |
+| `use .` present | Generates `./...` — one pattern like any other |
 | Malformed `go.work` | Return error (don't silently fall back) |
 | `use ./sub` with nested pkgs | `./sub/...` picks up all nested packages |
+| `use` dir doesn't exist | Let `go/packages` surface the error |
+| `GOWORK=off` in env | `go.work` file still parsed; `go/packages` will ignore workspace semantics — acceptable since explicit per-module patterns still load correctly |
 
 ## Files
 
@@ -58,14 +75,15 @@ Replace hardcoded `[]string{"./..."}` (line ~138) with `index.WorkspacePatterns(
 |------|--------|
 | `internal/index/workspace.go` | New — `WorkspacePatterns()` |
 | `internal/index/workspace_test.go` | New — unit tests |
-| `cmd/index.go` | One-line: call `WorkspacePatterns` instead of hardcoded pattern |
-| `go.mod` | Promote `golang.org/x/mod` from indirect to direct |
+| `internal/index/loader.go` | Default pattern fallback uses `WorkspacePatterns` |
+| `cmd/index.go` | Call `WorkspacePatterns` instead of hardcoded pattern |
 
 ## Testing
 
 - Unit: `WorkspacePatterns` with synthetic `go.work` in temp dir
 - Unit: no-go.work returns `["./..."]`
 - Unit: malformed go.work returns error
+- Unit: `use` dir that doesn't exist (still returns pattern, go/packages errors)
 - Manual: run `snipe index` on trixi, verify all 23 packages indexed
 
 ## Non-goals
@@ -73,3 +91,4 @@ Replace hardcoded `[]string{"./..."}` (line ~138) with `index.WorkspacePatterns(
 - `FindProjectRoot` changes (already works — `.git` and `go.work` co-located)
 - Per-command changes (all query the index DB — fixed by fixing indexing)
 - Cross-repo test fixtures (trixi is external)
+- `use ../sibling` support (outside git root)

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/mod v0.32.0 // indirect
+	golang.org/x/mod v0.32.0
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	modernc.org/libc v1.67.4 // indirect

--- a/internal/index/loader.go
+++ b/internal/index/loader.go
@@ -57,7 +57,10 @@ func Load(cfg LoadConfig) (*LoadResult, error) {
 		cfg.Dir = "."
 	}
 	if len(cfg.Patterns) == 0 {
-		cfg.Patterns = []string{"./..."}
+		cfg.Patterns, _ = WorkspacePatterns(cfg.Dir)
+		if len(cfg.Patterns) == 0 {
+			cfg.Patterns = []string{"./..."}
+		}
 	}
 	if cfg.Exclude == nil {
 		cfg.Exclude = DefaultExclude()

--- a/internal/index/workspace.go
+++ b/internal/index/workspace.go
@@ -1,0 +1,40 @@
+package index
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/mod/modfile"
+)
+
+// WorkspacePatterns returns load patterns for go/packages.
+// If go.work exists at dir, returns a pattern per workspace module.
+// Otherwise returns ["./..."].
+func WorkspacePatterns(dir string) ([]string, error) {
+	goWorkPath := filepath.Join(dir, "go.work")
+
+	data, err := os.ReadFile(goWorkPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{"./..."}, nil
+		}
+		return nil, fmt.Errorf("read go.work: %w", err)
+	}
+
+	wf, err := modfile.ParseWork(goWorkPath, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse go.work: %w", err)
+	}
+
+	if len(wf.Use) == 0 {
+		return []string{"./..."}, nil
+	}
+
+	patterns := make([]string, 0, len(wf.Use))
+	for _, u := range wf.Use {
+		patterns = append(patterns, u.Path+"/...")
+	}
+	return patterns, nil
+}

--- a/internal/index/workspace_test.go
+++ b/internal/index/workspace_test.go
@@ -1,0 +1,102 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspacePatterns_WithGoWork_ReturnsPerModulePatterns(t *testing.T) {
+	dir := t.TempDir()
+	goWork := `go 1.21
+
+use (
+	.
+	./graph
+	./store
+	./mcp
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte(goWork), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]bool{
+		"./...":       true,
+		"./graph/...": true,
+		"./store/...": true,
+		"./mcp/...":   true,
+	}
+	if len(patterns) != len(want) {
+		t.Fatalf("got %d patterns, want %d: %v", len(patterns), len(want), patterns)
+	}
+	for _, p := range patterns {
+		if !want[p] {
+			t.Errorf("unexpected pattern: %s", p)
+		}
+	}
+}
+
+func TestWorkspacePatterns_NoGoWork_ReturnsDotSlashDotDotDot(t *testing.T) {
+	dir := t.TempDir()
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(patterns) != 1 || patterns[0] != "./..." {
+		t.Fatalf("got %v, want [./...]", patterns)
+	}
+}
+
+func TestWorkspacePatterns_MalformedGoWork_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte("not a valid go.work file {{{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := WorkspacePatterns(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed go.work")
+	}
+}
+
+func TestWorkspacePatterns_EmptyUseDirectives_ReturnsDotSlashDotDotDot(t *testing.T) {
+	dir := t.TempDir()
+	goWork := "go 1.21\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte(goWork), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(patterns) != 1 || patterns[0] != "./..." {
+		t.Fatalf("got %v, want [./...]", patterns)
+	}
+}
+
+func TestWorkspacePatterns_NonexistentUseDir_StillReturnsPattern(t *testing.T) {
+	dir := t.TempDir()
+	goWork := "go 1.21\n\nuse ./doesnotexist\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.work"), []byte(goWork), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := WorkspacePatterns(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(patterns) != 1 || patterns[0] != "./doesnotexist/..." {
+		t.Fatalf("got %v, want [./doesnotexist/...]", patterns)
+	}
+}

--- a/test/blackbox/cli_workflows_test.go
+++ b/test/blackbox/cli_workflows_test.go
@@ -1351,3 +1351,39 @@ func TestRootDetection_FindsIndexFromSubdirectory_When_IndexedAtGitRoot(t *testi
 		t.Fatalf("unexpected error from subdir: %v", errObj)
 	}
 }
+
+func TestIndex_WorkspaceFixture_IndexesAllModules(t *testing.T) {
+	repoDir, _ := writeWorkspaceFixture(t)
+
+	// Index the workspace
+	stdout, stderr, exitCode := run(t, repoDir, "index", repoDir)
+	if exitCode != 0 {
+		t.Fatalf("index exit %d stderr=%s", exitCode, string(stderr))
+	}
+
+	resp := parseJSON(t, stdout)
+	assertResponseContract(t, resp, responseExpectations{
+		command:           "index",
+		requireRepoRoot:   true,
+		requireIndexState: true,
+	})
+
+	// Verify lib.Hello is findable (proves lib module was indexed)
+	stdout, stderr, exitCode = run(t, repoDir, "def", "Hello")
+	if exitCode != 0 {
+		t.Fatalf("def exit %d stderr=%s", exitCode, string(stderr))
+	}
+
+	defResp := parseJSON(t, stdout)
+	results := requireSlice(t, defResp["results"], "results")
+	if len(results) == 0 {
+		t.Fatal("expected to find Hello in lib module, got 0 results")
+	}
+
+	// Verify the result is from the lib module
+	first := requireMap(t, results[0], "results[0]")
+	file, _ := first["file"].(string)
+	if !strings.Contains(file, "lib") {
+		t.Errorf("expected Hello from lib module, got file: %s", file)
+	}
+}

--- a/test/blackbox/fixture_test.go
+++ b/test/blackbox/fixture_test.go
@@ -187,6 +187,49 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
+// writeWorkspaceFixture creates a multi-module go.work project.
+// Returns the repo dir and a map of useful paths.
+func writeWorkspaceFixture(t *testing.T) (repoDir string, paths map[string]string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	paths = make(map[string]string)
+
+	// Workspace root
+	writeFile(t, filepath.Join(repoDir, "go.work"), `go 1.21
+
+use (
+	.
+	./lib
+)
+`)
+
+	// Root module
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/workspace\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repoDir, "main.go"), `package workspace
+
+import "example.com/workspace/lib"
+
+func UseLib() string {
+	return lib.Hello()
+}
+`)
+	paths["main"] = filepath.Join(repoDir, "main.go")
+
+	// Lib module (sibling workspace module)
+	writeFile(t, filepath.Join(repoDir, "lib", "go.mod"), "module example.com/workspace/lib\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repoDir, "lib", "lib.go"), `package lib
+
+// Hello returns a greeting from the lib module.
+func Hello() string {
+	return "hello from lib"
+}
+`)
+	paths["lib"] = filepath.Join(repoDir, "lib", "lib.go")
+
+	return repoDir, paths
+}
+
 func positionAfterMarker(t *testing.T, content, marker, symbol string) (line, col int) {
 	t.Helper()
 

--- a/vendor/golang.org/x/mod/internal/lazyregexp/lazyre.go
+++ b/vendor/golang.org/x/mod/internal/lazyregexp/lazyre.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package lazyregexp is a thin wrapper over regexp, allowing the use of global
+// regexp variables without forcing them to be compiled at init.
+package lazyregexp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Regexp is a wrapper around [regexp.Regexp], where the underlying regexp will be
+// compiled the first time it is needed.
+type Regexp struct {
+	str  string
+	once sync.Once
+	rx   *regexp.Regexp
+}
+
+func (r *Regexp) re() *regexp.Regexp {
+	r.once.Do(r.build)
+	return r.rx
+}
+
+func (r *Regexp) build() {
+	r.rx = regexp.MustCompile(r.str)
+	r.str = ""
+}
+
+func (r *Regexp) FindSubmatch(s []byte) [][]byte {
+	return r.re().FindSubmatch(s)
+}
+
+func (r *Regexp) FindStringSubmatch(s string) []string {
+	return r.re().FindStringSubmatch(s)
+}
+
+func (r *Regexp) FindStringSubmatchIndex(s string) []int {
+	return r.re().FindStringSubmatchIndex(s)
+}
+
+func (r *Regexp) ReplaceAllString(src, repl string) string {
+	return r.re().ReplaceAllString(src, repl)
+}
+
+func (r *Regexp) FindString(s string) string {
+	return r.re().FindString(s)
+}
+
+func (r *Regexp) FindAllString(s string, n int) []string {
+	return r.re().FindAllString(s, n)
+}
+
+func (r *Regexp) MatchString(s string) bool {
+	return r.re().MatchString(s)
+}
+
+func (r *Regexp) SubexpNames() []string {
+	return r.re().SubexpNames()
+}
+
+var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
+
+// New creates a new lazy regexp, delaying the compiling work until it is first
+// needed. If the code is being run as part of tests, the regexp compiling will
+// happen immediately.
+func New(str string) *Regexp {
+	lr := &Regexp{str: str}
+	if inTest {
+		// In tests, always compile the regexps early.
+		lr.re()
+	}
+	return lr
+}

--- a/vendor/golang.org/x/mod/modfile/print.go
+++ b/vendor/golang.org/x/mod/modfile/print.go
@@ -1,0 +1,184 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Module file printer.
+
+package modfile
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Format returns a go.mod file as a byte slice, formatted in standard style.
+func Format(f *FileSyntax) []byte {
+	pr := &printer{}
+	pr.file(f)
+
+	// remove trailing blank lines
+	b := pr.Bytes()
+	for len(b) > 0 && b[len(b)-1] == '\n' && (len(b) == 1 || b[len(b)-2] == '\n') {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+// A printer collects the state during printing of a file or expression.
+type printer struct {
+	bytes.Buffer           // output buffer
+	comment      []Comment // pending end-of-line comments
+	margin       int       // left margin (indent), a number of tabs
+}
+
+// printf prints to the buffer.
+func (p *printer) printf(format string, args ...any) {
+	fmt.Fprintf(p, format, args...)
+}
+
+// indent returns the position on the current line, in bytes, 0-indexed.
+func (p *printer) indent() int {
+	b := p.Bytes()
+	n := 0
+	for n < len(b) && b[len(b)-1-n] != '\n' {
+		n++
+	}
+	return n
+}
+
+// newline ends the current line, flushing end-of-line comments.
+func (p *printer) newline() {
+	if len(p.comment) > 0 {
+		p.printf(" ")
+		for i, com := range p.comment {
+			if i > 0 {
+				p.trim()
+				p.printf("\n")
+				for i := 0; i < p.margin; i++ {
+					p.printf("\t")
+				}
+			}
+			p.printf("%s", strings.TrimSpace(com.Token))
+		}
+		p.comment = p.comment[:0]
+	}
+
+	p.trim()
+	if b := p.Bytes(); len(b) == 0 || (len(b) >= 2 && b[len(b)-1] == '\n' && b[len(b)-2] == '\n') {
+		// skip the blank line at top of file or after a blank line
+	} else {
+		p.printf("\n")
+	}
+	for i := 0; i < p.margin; i++ {
+		p.printf("\t")
+	}
+}
+
+// trim removes trailing spaces and tabs from the current line.
+func (p *printer) trim() {
+	// Remove trailing spaces and tabs from line we're about to end.
+	b := p.Bytes()
+	n := len(b)
+	for n > 0 && (b[n-1] == '\t' || b[n-1] == ' ') {
+		n--
+	}
+	p.Truncate(n)
+}
+
+// file formats the given file into the print buffer.
+func (p *printer) file(f *FileSyntax) {
+	for _, com := range f.Before {
+		p.printf("%s", strings.TrimSpace(com.Token))
+		p.newline()
+	}
+
+	for i, stmt := range f.Stmt {
+		switch x := stmt.(type) {
+		case *CommentBlock:
+			// comments already handled
+			p.expr(x)
+
+		default:
+			p.expr(x)
+			p.newline()
+		}
+
+		for _, com := range stmt.Comment().After {
+			p.printf("%s", strings.TrimSpace(com.Token))
+			p.newline()
+		}
+
+		if i+1 < len(f.Stmt) {
+			p.newline()
+		}
+	}
+}
+
+func (p *printer) expr(x Expr) {
+	// Emit line-comments preceding this expression.
+	if before := x.Comment().Before; len(before) > 0 {
+		// Want to print a line comment.
+		// Line comments must be at the current margin.
+		p.trim()
+		if p.indent() > 0 {
+			// There's other text on the line. Start a new line.
+			p.printf("\n")
+		}
+		// Re-indent to margin.
+		for i := 0; i < p.margin; i++ {
+			p.printf("\t")
+		}
+		for _, com := range before {
+			p.printf("%s", strings.TrimSpace(com.Token))
+			p.newline()
+		}
+	}
+
+	switch x := x.(type) {
+	default:
+		panic(fmt.Errorf("printer: unexpected type %T", x))
+
+	case *CommentBlock:
+		// done
+
+	case *LParen:
+		p.printf("(")
+	case *RParen:
+		p.printf(")")
+
+	case *Line:
+		p.tokens(x.Token)
+
+	case *LineBlock:
+		p.tokens(x.Token)
+		p.printf(" ")
+		p.expr(&x.LParen)
+		p.margin++
+		for _, l := range x.Line {
+			p.newline()
+			p.expr(l)
+		}
+		p.margin--
+		p.newline()
+		p.expr(&x.RParen)
+	}
+
+	// Queue end-of-line comments for printing when we
+	// reach the end of the line.
+	p.comment = append(p.comment, x.Comment().Suffix...)
+}
+
+func (p *printer) tokens(tokens []string) {
+	sep := ""
+	for _, t := range tokens {
+		if t == "," || t == ")" || t == "]" || t == "}" {
+			sep = ""
+		}
+		p.printf("%s%s", sep, t)
+		sep = " "
+		if t == "(" || t == "[" || t == "{" {
+			sep = ""
+		}
+	}
+}

--- a/vendor/golang.org/x/mod/modfile/read.go
+++ b/vendor/golang.org/x/mod/modfile/read.go
@@ -1,0 +1,964 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package modfile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// A Position describes an arbitrary source position in a file, including the
+// file, line, column, and byte offset.
+type Position struct {
+	Line     int // line in input (starting at 1)
+	LineRune int // rune in line (starting at 1)
+	Byte     int // byte in input (starting at 0)
+}
+
+// add returns the position at the end of s, assuming it starts at p.
+func (p Position) add(s string) Position {
+	p.Byte += len(s)
+	if n := strings.Count(s, "\n"); n > 0 {
+		p.Line += n
+		s = s[strings.LastIndex(s, "\n")+1:]
+		p.LineRune = 1
+	}
+	p.LineRune += utf8.RuneCountInString(s)
+	return p
+}
+
+// An Expr represents an input element.
+type Expr interface {
+	// Span returns the start and end position of the expression,
+	// excluding leading or trailing comments.
+	Span() (start, end Position)
+
+	// Comment returns the comments attached to the expression.
+	// This method would normally be named 'Comments' but that
+	// would interfere with embedding a type of the same name.
+	Comment() *Comments
+}
+
+// A Comment represents a single // comment.
+type Comment struct {
+	Start  Position
+	Token  string // without trailing newline
+	Suffix bool   // an end of line (not whole line) comment
+}
+
+// Comments collects the comments associated with an expression.
+type Comments struct {
+	Before []Comment // whole-line comments before this expression
+	Suffix []Comment // end-of-line comments after this expression
+
+	// For top-level expressions only, After lists whole-line
+	// comments following the expression.
+	After []Comment
+}
+
+// Comment returns the receiver. This isn't useful by itself, but
+// a [Comments] struct is embedded into all the expression
+// implementation types, and this gives each of those a Comment
+// method to satisfy the Expr interface.
+func (c *Comments) Comment() *Comments {
+	return c
+}
+
+// A FileSyntax represents an entire go.mod file.
+type FileSyntax struct {
+	Name string // file path
+	Comments
+	Stmt []Expr
+}
+
+func (x *FileSyntax) Span() (start, end Position) {
+	if len(x.Stmt) == 0 {
+		return
+	}
+	start, _ = x.Stmt[0].Span()
+	_, end = x.Stmt[len(x.Stmt)-1].Span()
+	return start, end
+}
+
+// addLine adds a line containing the given tokens to the file.
+//
+// If the first token of the hint matches the first token of the
+// line, the new line is added at the end of the block containing hint,
+// extracting hint into a new block if it is not yet in one.
+//
+// If the hint is non-nil but its first token does not match,
+// the new line is added after the block containing hint
+// (or hint itself, if not in a block).
+//
+// If no hint is provided, addLine appends the line to the end of
+// the last block with a matching first token,
+// or to the end of the file if no such block exists.
+func (x *FileSyntax) addLine(hint Expr, tokens ...string) *Line {
+	if hint == nil {
+		// If no hint given, add to the last statement of the given type.
+	Loop:
+		for i := len(x.Stmt) - 1; i >= 0; i-- {
+			stmt := x.Stmt[i]
+			switch stmt := stmt.(type) {
+			case *Line:
+				if stmt.Token != nil && stmt.Token[0] == tokens[0] {
+					hint = stmt
+					break Loop
+				}
+			case *LineBlock:
+				if stmt.Token[0] == tokens[0] {
+					hint = stmt
+					break Loop
+				}
+			}
+		}
+	}
+
+	newLineAfter := func(i int) *Line {
+		new := &Line{Token: tokens}
+		if i == len(x.Stmt) {
+			x.Stmt = append(x.Stmt, new)
+		} else {
+			x.Stmt = append(x.Stmt, nil)
+			copy(x.Stmt[i+2:], x.Stmt[i+1:])
+			x.Stmt[i+1] = new
+		}
+		return new
+	}
+
+	if hint != nil {
+		for i, stmt := range x.Stmt {
+			switch stmt := stmt.(type) {
+			case *Line:
+				if stmt == hint {
+					if stmt.Token == nil || stmt.Token[0] != tokens[0] {
+						return newLineAfter(i)
+					}
+
+					// Convert line to line block.
+					stmt.InBlock = true
+					block := &LineBlock{Token: stmt.Token[:1], Line: []*Line{stmt}}
+					stmt.Token = stmt.Token[1:]
+					x.Stmt[i] = block
+					new := &Line{Token: tokens[1:], InBlock: true}
+					block.Line = append(block.Line, new)
+					return new
+				}
+
+			case *LineBlock:
+				if stmt == hint {
+					if stmt.Token[0] != tokens[0] {
+						return newLineAfter(i)
+					}
+
+					new := &Line{Token: tokens[1:], InBlock: true}
+					stmt.Line = append(stmt.Line, new)
+					return new
+				}
+
+				for j, line := range stmt.Line {
+					if line == hint {
+						if stmt.Token[0] != tokens[0] {
+							return newLineAfter(i)
+						}
+
+						// Add new line after hint within the block.
+						stmt.Line = append(stmt.Line, nil)
+						copy(stmt.Line[j+2:], stmt.Line[j+1:])
+						new := &Line{Token: tokens[1:], InBlock: true}
+						stmt.Line[j+1] = new
+						return new
+					}
+				}
+			}
+		}
+	}
+
+	new := &Line{Token: tokens}
+	x.Stmt = append(x.Stmt, new)
+	return new
+}
+
+func (x *FileSyntax) updateLine(line *Line, tokens ...string) {
+	if line.InBlock {
+		tokens = tokens[1:]
+	}
+	line.Token = tokens
+}
+
+// markRemoved modifies line so that it (and its end-of-line comment, if any)
+// will be dropped by (*FileSyntax).Cleanup.
+func (line *Line) markRemoved() {
+	line.Token = nil
+	line.Comments.Suffix = nil
+}
+
+// Cleanup cleans up the file syntax x after any edit operations.
+// To avoid quadratic behavior, (*Line).markRemoved marks the line as dead
+// by setting line.Token = nil but does not remove it from the slice
+// in which it appears. After edits have all been indicated,
+// calling Cleanup cleans out the dead lines.
+func (x *FileSyntax) Cleanup() {
+	w := 0
+	for _, stmt := range x.Stmt {
+		switch stmt := stmt.(type) {
+		case *Line:
+			if stmt.Token == nil {
+				continue
+			}
+		case *LineBlock:
+			ww := 0
+			for _, line := range stmt.Line {
+				if line.Token != nil {
+					stmt.Line[ww] = line
+					ww++
+				}
+			}
+			if ww == 0 {
+				continue
+			}
+			if ww == 1 && len(stmt.RParen.Comments.Before) == 0 {
+				// Collapse block into single line but keep the Line reference used by the
+				// parsed File structure.
+				*stmt.Line[0] = Line{
+					Comments: Comments{
+						Before: commentsAdd(stmt.Before, stmt.Line[0].Before),
+						Suffix: commentsAdd(stmt.Line[0].Suffix, stmt.Suffix),
+						After:  commentsAdd(stmt.Line[0].After, stmt.After),
+					},
+					Token: stringsAdd(stmt.Token, stmt.Line[0].Token),
+				}
+				x.Stmt[w] = stmt.Line[0]
+				w++
+				continue
+			}
+			stmt.Line = stmt.Line[:ww]
+		}
+		x.Stmt[w] = stmt
+		w++
+	}
+	x.Stmt = x.Stmt[:w]
+}
+
+func commentsAdd(x, y []Comment) []Comment {
+	return append(x[:len(x):len(x)], y...)
+}
+
+func stringsAdd(x, y []string) []string {
+	return append(x[:len(x):len(x)], y...)
+}
+
+// A CommentBlock represents a top-level block of comments separate
+// from any rule.
+type CommentBlock struct {
+	Comments
+	Start Position
+}
+
+func (x *CommentBlock) Span() (start, end Position) {
+	return x.Start, x.Start
+}
+
+// A Line is a single line of tokens.
+type Line struct {
+	Comments
+	Start   Position
+	Token   []string
+	InBlock bool
+	End     Position
+}
+
+func (x *Line) Span() (start, end Position) {
+	return x.Start, x.End
+}
+
+// A LineBlock is a factored block of lines, like
+//
+//	require (
+//		"x"
+//		"y"
+//	)
+type LineBlock struct {
+	Comments
+	Start  Position
+	LParen LParen
+	Token  []string
+	Line   []*Line
+	RParen RParen
+}
+
+func (x *LineBlock) Span() (start, end Position) {
+	return x.Start, x.RParen.Pos.add(")")
+}
+
+// An LParen represents the beginning of a parenthesized line block.
+// It is a place to store suffix comments.
+type LParen struct {
+	Comments
+	Pos Position
+}
+
+func (x *LParen) Span() (start, end Position) {
+	return x.Pos, x.Pos.add(")")
+}
+
+// An RParen represents the end of a parenthesized line block.
+// It is a place to store whole-line (before) comments.
+type RParen struct {
+	Comments
+	Pos Position
+}
+
+func (x *RParen) Span() (start, end Position) {
+	return x.Pos, x.Pos.add(")")
+}
+
+// An input represents a single input file being parsed.
+type input struct {
+	// Lexing state.
+	filename   string    // name of input file, for errors
+	complete   []byte    // entire input
+	remaining  []byte    // remaining input
+	tokenStart []byte    // token being scanned to end of input
+	token      token     // next token to be returned by lex, peek
+	pos        Position  // current input position
+	comments   []Comment // accumulated comments
+
+	// Parser state.
+	file        *FileSyntax // returned top-level syntax tree
+	parseErrors ErrorList   // errors encountered during parsing
+
+	// Comment assignment state.
+	pre  []Expr // all expressions, in preorder traversal
+	post []Expr // all expressions, in postorder traversal
+}
+
+func newInput(filename string, data []byte) *input {
+	return &input{
+		filename:  filename,
+		complete:  data,
+		remaining: data,
+		pos:       Position{Line: 1, LineRune: 1, Byte: 0},
+	}
+}
+
+// parse parses the input file.
+func parse(file string, data []byte) (f *FileSyntax, err error) {
+	// The parser panics for both routine errors like syntax errors
+	// and for programmer bugs like array index errors.
+	// Turn both into error returns. Catching bug panics is
+	// especially important when processing many files.
+	in := newInput(file, data)
+	defer func() {
+		if e := recover(); e != nil && e != &in.parseErrors {
+			in.parseErrors = append(in.parseErrors, Error{
+				Filename: in.filename,
+				Pos:      in.pos,
+				Err:      fmt.Errorf("internal error: %v", e),
+			})
+		}
+		if err == nil && len(in.parseErrors) > 0 {
+			err = in.parseErrors
+		}
+	}()
+
+	// Prime the lexer by reading in the first token. It will be available
+	// in the next peek() or lex() call.
+	in.readToken()
+
+	// Invoke the parser.
+	in.parseFile()
+	if len(in.parseErrors) > 0 {
+		return nil, in.parseErrors
+	}
+	in.file.Name = in.filename
+
+	// Assign comments to nearby syntax.
+	in.assignComments()
+
+	return in.file, nil
+}
+
+// Error is called to report an error.
+// Error does not return: it panics.
+func (in *input) Error(s string) {
+	in.parseErrors = append(in.parseErrors, Error{
+		Filename: in.filename,
+		Pos:      in.pos,
+		Err:      errors.New(s),
+	})
+	panic(&in.parseErrors)
+}
+
+// eof reports whether the input has reached end of file.
+func (in *input) eof() bool {
+	return len(in.remaining) == 0
+}
+
+// peekRune returns the next rune in the input without consuming it.
+func (in *input) peekRune() int {
+	if len(in.remaining) == 0 {
+		return 0
+	}
+	r, _ := utf8.DecodeRune(in.remaining)
+	return int(r)
+}
+
+// peekPrefix reports whether the remaining input begins with the given prefix.
+func (in *input) peekPrefix(prefix string) bool {
+	// This is like bytes.HasPrefix(in.remaining, []byte(prefix))
+	// but without the allocation of the []byte copy of prefix.
+	for i := 0; i < len(prefix); i++ {
+		if i >= len(in.remaining) || in.remaining[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// readRune consumes and returns the next rune in the input.
+func (in *input) readRune() int {
+	if len(in.remaining) == 0 {
+		in.Error("internal lexer error: readRune at EOF")
+	}
+	r, size := utf8.DecodeRune(in.remaining)
+	in.remaining = in.remaining[size:]
+	if r == '\n' {
+		in.pos.Line++
+		in.pos.LineRune = 1
+	} else {
+		in.pos.LineRune++
+	}
+	in.pos.Byte += size
+	return int(r)
+}
+
+type token struct {
+	kind   tokenKind
+	pos    Position
+	endPos Position
+	text   string
+}
+
+type tokenKind int
+
+const (
+	_EOF tokenKind = -(iota + 1)
+	_EOLCOMMENT
+	_IDENT
+	_STRING
+	_COMMENT
+
+	// newlines and punctuation tokens are allowed as ASCII codes.
+)
+
+func (k tokenKind) isComment() bool {
+	return k == _COMMENT || k == _EOLCOMMENT
+}
+
+// isEOL returns whether a token terminates a line.
+func (k tokenKind) isEOL() bool {
+	return k == _EOF || k == _EOLCOMMENT || k == '\n'
+}
+
+// startToken marks the beginning of the next input token.
+// It must be followed by a call to endToken, once the token's text has
+// been consumed using readRune.
+func (in *input) startToken() {
+	in.tokenStart = in.remaining
+	in.token.text = ""
+	in.token.pos = in.pos
+}
+
+// endToken marks the end of an input token.
+// It records the actual token string in tok.text.
+// A single trailing newline (LF or CRLF) will be removed from comment tokens.
+func (in *input) endToken(kind tokenKind) {
+	in.token.kind = kind
+	text := string(in.tokenStart[:len(in.tokenStart)-len(in.remaining)])
+	if kind.isComment() {
+		if strings.HasSuffix(text, "\r\n") {
+			text = text[:len(text)-2]
+		} else {
+			text = strings.TrimSuffix(text, "\n")
+		}
+	}
+	in.token.text = text
+	in.token.endPos = in.pos
+}
+
+// peek returns the kind of the next token returned by lex.
+func (in *input) peek() tokenKind {
+	return in.token.kind
+}
+
+// lex is called from the parser to obtain the next input token.
+func (in *input) lex() token {
+	tok := in.token
+	in.readToken()
+	return tok
+}
+
+// readToken lexes the next token from the text and stores it in in.token.
+func (in *input) readToken() {
+	// Skip past spaces, stopping at non-space or EOF.
+	for !in.eof() {
+		c := in.peekRune()
+		if c == ' ' || c == '\t' || c == '\r' {
+			in.readRune()
+			continue
+		}
+
+		// Comment runs to end of line.
+		if in.peekPrefix("//") {
+			in.startToken()
+
+			// Is this comment the only thing on its line?
+			// Find the last \n before this // and see if it's all
+			// spaces from there to here.
+			i := bytes.LastIndex(in.complete[:in.pos.Byte], []byte("\n"))
+			suffix := len(bytes.TrimSpace(in.complete[i+1:in.pos.Byte])) > 0
+			in.readRune()
+			in.readRune()
+
+			// Consume comment.
+			for len(in.remaining) > 0 && in.readRune() != '\n' {
+			}
+
+			// If we are at top level (not in a statement), hand the comment to
+			// the parser as a _COMMENT token. The grammar is written
+			// to handle top-level comments itself.
+			if !suffix {
+				in.endToken(_COMMENT)
+				return
+			}
+
+			// Otherwise, save comment for later attachment to syntax tree.
+			in.endToken(_EOLCOMMENT)
+			in.comments = append(in.comments, Comment{in.token.pos, in.token.text, suffix})
+			return
+		}
+
+		if in.peekPrefix("/*") {
+			in.Error("mod files must use // comments (not /* */ comments)")
+		}
+
+		// Found non-space non-comment.
+		break
+	}
+
+	// Found the beginning of the next token.
+	in.startToken()
+
+	// End of file.
+	if in.eof() {
+		in.endToken(_EOF)
+		return
+	}
+
+	// Punctuation tokens.
+	switch c := in.peekRune(); c {
+	case '\n', '(', ')', '[', ']', '{', '}', ',':
+		in.readRune()
+		in.endToken(tokenKind(c))
+		return
+
+	case '"', '`': // quoted string
+		quote := c
+		in.readRune()
+		for {
+			if in.eof() {
+				in.pos = in.token.pos
+				in.Error("unexpected EOF in string")
+			}
+			if in.peekRune() == '\n' {
+				in.Error("unexpected newline in string")
+			}
+			c := in.readRune()
+			if c == quote {
+				break
+			}
+			if c == '\\' && quote != '`' {
+				if in.eof() {
+					in.pos = in.token.pos
+					in.Error("unexpected EOF in string")
+				}
+				in.readRune()
+			}
+		}
+		in.endToken(_STRING)
+		return
+	}
+
+	// Checked all punctuation. Must be identifier token.
+	if c := in.peekRune(); !isIdent(c) {
+		in.Error(fmt.Sprintf("unexpected input character %#q", rune(c)))
+	}
+
+	// Scan over identifier.
+	for isIdent(in.peekRune()) {
+		if in.peekPrefix("//") {
+			break
+		}
+		if in.peekPrefix("/*") {
+			in.Error("mod files must use // comments (not /* */ comments)")
+		}
+		in.readRune()
+	}
+	in.endToken(_IDENT)
+}
+
+// isIdent reports whether c is an identifier rune.
+// We treat most printable runes as identifier runes, except for a handful of
+// ASCII punctuation characters.
+func isIdent(c int) bool {
+	switch r := rune(c); r {
+	case ' ', '(', ')', '[', ']', '{', '}', ',':
+		return false
+	default:
+		return !unicode.IsSpace(r) && unicode.IsPrint(r)
+	}
+}
+
+// Comment assignment.
+// We build two lists of all subexpressions, preorder and postorder.
+// The preorder list is ordered by start location, with outer expressions first.
+// The postorder list is ordered by end location, with outer expressions last.
+// We use the preorder list to assign each whole-line comment to the syntax
+// immediately following it, and we use the postorder list to assign each
+// end-of-line comment to the syntax immediately preceding it.
+
+// order walks the expression adding it and its subexpressions to the
+// preorder and postorder lists.
+func (in *input) order(x Expr) {
+	if x != nil {
+		in.pre = append(in.pre, x)
+	}
+	switch x := x.(type) {
+	default:
+		panic(fmt.Errorf("order: unexpected type %T", x))
+	case nil:
+		// nothing
+	case *LParen, *RParen:
+		// nothing
+	case *CommentBlock:
+		// nothing
+	case *Line:
+		// nothing
+	case *FileSyntax:
+		for _, stmt := range x.Stmt {
+			in.order(stmt)
+		}
+	case *LineBlock:
+		in.order(&x.LParen)
+		for _, l := range x.Line {
+			in.order(l)
+		}
+		in.order(&x.RParen)
+	}
+	if x != nil {
+		in.post = append(in.post, x)
+	}
+}
+
+// assignComments attaches comments to nearby syntax.
+func (in *input) assignComments() {
+	const debug = false
+
+	// Generate preorder and postorder lists.
+	in.order(in.file)
+
+	// Split into whole-line comments and suffix comments.
+	var line, suffix []Comment
+	for _, com := range in.comments {
+		if com.Suffix {
+			suffix = append(suffix, com)
+		} else {
+			line = append(line, com)
+		}
+	}
+
+	if debug {
+		for _, c := range line {
+			fmt.Fprintf(os.Stderr, "LINE %q :%d:%d #%d\n", c.Token, c.Start.Line, c.Start.LineRune, c.Start.Byte)
+		}
+	}
+
+	// Assign line comments to syntax immediately following.
+	for _, x := range in.pre {
+		start, _ := x.Span()
+		if debug {
+			fmt.Fprintf(os.Stderr, "pre %T :%d:%d #%d\n", x, start.Line, start.LineRune, start.Byte)
+		}
+		xcom := x.Comment()
+		for len(line) > 0 && start.Byte >= line[0].Start.Byte {
+			if debug {
+				fmt.Fprintf(os.Stderr, "ASSIGN LINE %q #%d\n", line[0].Token, line[0].Start.Byte)
+			}
+			xcom.Before = append(xcom.Before, line[0])
+			line = line[1:]
+		}
+	}
+
+	// Remaining line comments go at end of file.
+	in.file.After = append(in.file.After, line...)
+
+	if debug {
+		for _, c := range suffix {
+			fmt.Fprintf(os.Stderr, "SUFFIX %q :%d:%d #%d\n", c.Token, c.Start.Line, c.Start.LineRune, c.Start.Byte)
+		}
+	}
+
+	// Assign suffix comments to syntax immediately before.
+	for i := len(in.post) - 1; i >= 0; i-- {
+		x := in.post[i]
+
+		start, end := x.Span()
+		if debug {
+			fmt.Fprintf(os.Stderr, "post %T :%d:%d #%d :%d:%d #%d\n", x, start.Line, start.LineRune, start.Byte, end.Line, end.LineRune, end.Byte)
+		}
+
+		// Do not assign suffix comments to end of line block or whole file.
+		// Instead assign them to the last element inside.
+		switch x.(type) {
+		case *FileSyntax:
+			continue
+		}
+
+		// Do not assign suffix comments to something that starts
+		// on an earlier line, so that in
+		//
+		//	x ( y
+		//		z ) // comment
+		//
+		// we assign the comment to z and not to x ( ... ).
+		if start.Line != end.Line {
+			continue
+		}
+		xcom := x.Comment()
+		for len(suffix) > 0 && end.Byte <= suffix[len(suffix)-1].Start.Byte {
+			if debug {
+				fmt.Fprintf(os.Stderr, "ASSIGN SUFFIX %q #%d\n", suffix[len(suffix)-1].Token, suffix[len(suffix)-1].Start.Byte)
+			}
+			xcom.Suffix = append(xcom.Suffix, suffix[len(suffix)-1])
+			suffix = suffix[:len(suffix)-1]
+		}
+	}
+
+	// We assigned suffix comments in reverse.
+	// If multiple suffix comments were appended to the same
+	// expression node, they are now in reverse. Fix that.
+	for _, x := range in.post {
+		reverseComments(x.Comment().Suffix)
+	}
+
+	// Remaining suffix comments go at beginning of file.
+	in.file.Before = append(in.file.Before, suffix...)
+}
+
+// reverseComments reverses the []Comment list.
+func reverseComments(list []Comment) {
+	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+		list[i], list[j] = list[j], list[i]
+	}
+}
+
+func (in *input) parseFile() {
+	in.file = new(FileSyntax)
+	var cb *CommentBlock
+	for {
+		switch in.peek() {
+		case '\n':
+			in.lex()
+			if cb != nil {
+				in.file.Stmt = append(in.file.Stmt, cb)
+				cb = nil
+			}
+		case _COMMENT:
+			tok := in.lex()
+			if cb == nil {
+				cb = &CommentBlock{Start: tok.pos}
+			}
+			com := cb.Comment()
+			com.Before = append(com.Before, Comment{Start: tok.pos, Token: tok.text})
+		case _EOF:
+			if cb != nil {
+				in.file.Stmt = append(in.file.Stmt, cb)
+			}
+			return
+		default:
+			in.parseStmt()
+			if cb != nil {
+				in.file.Stmt[len(in.file.Stmt)-1].Comment().Before = cb.Before
+				cb = nil
+			}
+		}
+	}
+}
+
+func (in *input) parseStmt() {
+	tok := in.lex()
+	start := tok.pos
+	end := tok.endPos
+	tokens := []string{tok.text}
+	for {
+		tok := in.lex()
+		switch {
+		case tok.kind.isEOL():
+			in.file.Stmt = append(in.file.Stmt, &Line{
+				Start: start,
+				Token: tokens,
+				End:   end,
+			})
+			return
+
+		case tok.kind == '(':
+			if next := in.peek(); next.isEOL() {
+				// Start of block: no more tokens on this line.
+				in.file.Stmt = append(in.file.Stmt, in.parseLineBlock(start, tokens, tok))
+				return
+			} else if next == ')' {
+				rparen := in.lex()
+				if in.peek().isEOL() {
+					// Empty block.
+					in.lex()
+					in.file.Stmt = append(in.file.Stmt, &LineBlock{
+						Start:  start,
+						Token:  tokens,
+						LParen: LParen{Pos: tok.pos},
+						RParen: RParen{Pos: rparen.pos},
+					})
+					return
+				}
+				// '( )' in the middle of the line, not a block.
+				tokens = append(tokens, tok.text, rparen.text)
+			} else {
+				// '(' in the middle of the line, not a block.
+				tokens = append(tokens, tok.text)
+			}
+
+		default:
+			tokens = append(tokens, tok.text)
+			end = tok.endPos
+		}
+	}
+}
+
+func (in *input) parseLineBlock(start Position, token []string, lparen token) *LineBlock {
+	x := &LineBlock{
+		Start:  start,
+		Token:  token,
+		LParen: LParen{Pos: lparen.pos},
+	}
+	var comments []Comment
+	for {
+		switch in.peek() {
+		case _EOLCOMMENT:
+			// Suffix comment, will be attached later by assignComments.
+			in.lex()
+		case '\n':
+			// Blank line. Add an empty comment to preserve it.
+			in.lex()
+			if len(comments) == 0 && len(x.Line) > 0 || len(comments) > 0 && comments[len(comments)-1].Token != "" {
+				comments = append(comments, Comment{})
+			}
+		case _COMMENT:
+			tok := in.lex()
+			comments = append(comments, Comment{Start: tok.pos, Token: tok.text})
+		case _EOF:
+			in.Error(fmt.Sprintf("syntax error (unterminated block started at %s:%d:%d)", in.filename, x.Start.Line, x.Start.LineRune))
+		case ')':
+			rparen := in.lex()
+			// Don't preserve blank lines (denoted by a single empty comment, added above)
+			// at the end of the block.
+			if len(comments) == 1 && comments[0] == (Comment{}) {
+				comments = nil
+			}
+			x.RParen.Before = comments
+			x.RParen.Pos = rparen.pos
+			if !in.peek().isEOL() {
+				in.Error("syntax error (expected newline after closing paren)")
+			}
+			in.lex()
+			return x
+		default:
+			l := in.parseLine()
+			x.Line = append(x.Line, l)
+			l.Comment().Before = comments
+			comments = nil
+		}
+	}
+}
+
+func (in *input) parseLine() *Line {
+	tok := in.lex()
+	if tok.kind.isEOL() {
+		in.Error("internal parse error: parseLine at end of line")
+	}
+	start := tok.pos
+	end := tok.endPos
+	tokens := []string{tok.text}
+	for {
+		tok := in.lex()
+		if tok.kind.isEOL() {
+			return &Line{
+				Start:   start,
+				Token:   tokens,
+				End:     end,
+				InBlock: true,
+			}
+		}
+		tokens = append(tokens, tok.text)
+		end = tok.endPos
+	}
+}
+
+var (
+	slashSlash = []byte("//")
+	moduleStr  = []byte("module")
+)
+
+// ModulePath returns the module path from the gomod file text.
+// If it cannot find a module path, it returns an empty string.
+// It is tolerant of unrelated problems in the go.mod file.
+func ModulePath(mod []byte) string {
+	for len(mod) > 0 {
+		line := mod
+		mod = nil
+		if i := bytes.IndexByte(line, '\n'); i >= 0 {
+			line, mod = line[:i], line[i+1:]
+		}
+		if i := bytes.Index(line, slashSlash); i >= 0 {
+			line = line[:i]
+		}
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, moduleStr) {
+			continue
+		}
+		line = line[len(moduleStr):]
+		n := len(line)
+		line = bytes.TrimSpace(line)
+		if len(line) == n || len(line) == 0 {
+			continue
+		}
+
+		if line[0] == '"' || line[0] == '`' {
+			p, err := strconv.Unquote(string(line))
+			if err != nil {
+				return "" // malformed quoted string or multiline module path
+			}
+			return p
+		}
+
+		return string(line)
+	}
+	return "" // missing module path
+}

--- a/vendor/golang.org/x/mod/modfile/rule.go
+++ b/vendor/golang.org/x/mod/modfile/rule.go
@@ -1,0 +1,1904 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package modfile implements a parser and formatter for go.mod files.
+//
+// The go.mod syntax is described in
+// https://pkg.go.dev/cmd/go/#hdr-The_go_mod_file.
+//
+// The [Parse] and [ParseLax] functions both parse a go.mod file and return an
+// abstract syntax tree. ParseLax ignores unknown statements and may be used to
+// parse go.mod files that may have been developed with newer versions of Go.
+//
+// The [File] struct returned by Parse and ParseLax represent an abstract
+// go.mod file. File has several methods like [File.AddNewRequire] and
+// [File.DropReplace] that can be used to programmatically edit a file.
+//
+// The [Format] function formats a File back to a byte slice which can be
+// written to a file.
+package modfile
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"golang.org/x/mod/internal/lazyregexp"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+)
+
+// A File is the parsed, interpreted form of a go.mod file.
+type File struct {
+	Module    *Module
+	Go        *Go
+	Toolchain *Toolchain
+	Godebug   []*Godebug
+	Require   []*Require
+	Exclude   []*Exclude
+	Replace   []*Replace
+	Retract   []*Retract
+	Tool      []*Tool
+	Ignore    []*Ignore
+
+	Syntax *FileSyntax
+}
+
+// A Module is the module statement.
+type Module struct {
+	Mod        module.Version
+	Deprecated string
+	Syntax     *Line
+}
+
+// A Go is the go statement.
+type Go struct {
+	Version string // "1.23"
+	Syntax  *Line
+}
+
+// A Toolchain is the toolchain statement.
+type Toolchain struct {
+	Name   string // "go1.21rc1"
+	Syntax *Line
+}
+
+// A Godebug is a single godebug key=value statement.
+type Godebug struct {
+	Key    string
+	Value  string
+	Syntax *Line
+}
+
+// An Exclude is a single exclude statement.
+type Exclude struct {
+	Mod    module.Version
+	Syntax *Line
+}
+
+// A Replace is a single replace statement.
+type Replace struct {
+	Old    module.Version
+	New    module.Version
+	Syntax *Line
+}
+
+// A Retract is a single retract statement.
+type Retract struct {
+	VersionInterval
+	Rationale string
+	Syntax    *Line
+}
+
+// A Tool is a single tool statement.
+type Tool struct {
+	Path   string
+	Syntax *Line
+}
+
+// An Ignore is a single ignore statement.
+type Ignore struct {
+	Path   string
+	Syntax *Line
+}
+
+// A VersionInterval represents a range of versions with upper and lower bounds.
+// Intervals are closed: both bounds are included. When Low is equal to High,
+// the interval may refer to a single version ('v1.2.3') or an interval
+// ('[v1.2.3, v1.2.3]'); both have the same representation.
+type VersionInterval struct {
+	Low, High string
+}
+
+// A Require is a single require statement.
+type Require struct {
+	Mod      module.Version
+	Indirect bool // has "// indirect" comment
+	Syntax   *Line
+}
+
+func (r *Require) markRemoved() {
+	r.Syntax.markRemoved()
+	*r = Require{}
+}
+
+func (r *Require) setVersion(v string) {
+	r.Mod.Version = v
+
+	if line := r.Syntax; len(line.Token) > 0 {
+		if line.InBlock {
+			// If the line is preceded by an empty line, remove it; see
+			// https://golang.org/issue/33779.
+			if len(line.Comments.Before) == 1 && len(line.Comments.Before[0].Token) == 0 {
+				line.Comments.Before = line.Comments.Before[:0]
+			}
+			if len(line.Token) >= 2 { // example.com v1.2.3
+				line.Token[1] = v
+			}
+		} else {
+			if len(line.Token) >= 3 { // require example.com v1.2.3
+				line.Token[2] = v
+			}
+		}
+	}
+}
+
+// setIndirect sets line to have (or not have) a "// indirect" comment.
+func (r *Require) setIndirect(indirect bool) {
+	r.Indirect = indirect
+	line := r.Syntax
+	if isIndirect(line) == indirect {
+		return
+	}
+	if indirect {
+		// Adding comment.
+		if len(line.Suffix) == 0 {
+			// New comment.
+			line.Suffix = []Comment{{Token: "// indirect", Suffix: true}}
+			return
+		}
+
+		com := &line.Suffix[0]
+		text := strings.TrimSpace(strings.TrimPrefix(com.Token, string(slashSlash)))
+		if text == "" {
+			// Empty comment.
+			com.Token = "// indirect"
+			return
+		}
+
+		// Insert at beginning of existing comment.
+		com.Token = "// indirect; " + text
+		return
+	}
+
+	// Removing comment.
+	f := strings.TrimSpace(strings.TrimPrefix(line.Suffix[0].Token, string(slashSlash)))
+	if f == "indirect" {
+		// Remove whole comment.
+		line.Suffix = nil
+		return
+	}
+
+	// Remove comment prefix.
+	com := &line.Suffix[0]
+	i := strings.Index(com.Token, "indirect;")
+	com.Token = "//" + com.Token[i+len("indirect;"):]
+}
+
+// isIndirect reports whether line has a "// indirect" comment,
+// meaning it is in go.mod only for its effect on indirect dependencies,
+// so that it can be dropped entirely once the effective version of the
+// indirect dependency reaches the given minimum version.
+func isIndirect(line *Line) bool {
+	if len(line.Suffix) == 0 {
+		return false
+	}
+	f := strings.Fields(strings.TrimPrefix(line.Suffix[0].Token, string(slashSlash)))
+	return (len(f) == 1 && f[0] == "indirect" || len(f) > 1 && f[0] == "indirect;")
+}
+
+func (f *File) AddModuleStmt(path string) error {
+	if f.Syntax == nil {
+		f.Syntax = new(FileSyntax)
+	}
+	if f.Module == nil {
+		f.Module = &Module{
+			Mod:    module.Version{Path: path},
+			Syntax: f.Syntax.addLine(nil, "module", AutoQuote(path)),
+		}
+	} else {
+		f.Module.Mod.Path = path
+		f.Syntax.updateLine(f.Module.Syntax, "module", AutoQuote(path))
+	}
+	return nil
+}
+
+func (f *File) AddComment(text string) {
+	if f.Syntax == nil {
+		f.Syntax = new(FileSyntax)
+	}
+	f.Syntax.Stmt = append(f.Syntax.Stmt, &CommentBlock{
+		Comments: Comments{
+			Before: []Comment{
+				{
+					Token: text,
+				},
+			},
+		},
+	})
+}
+
+type VersionFixer func(path, version string) (string, error)
+
+// errDontFix is returned by a VersionFixer to indicate the version should be
+// left alone, even if it's not canonical.
+var dontFixRetract VersionFixer = func(_, vers string) (string, error) {
+	return vers, nil
+}
+
+// Parse parses and returns a go.mod file.
+//
+// file is the name of the file, used in positions and errors.
+//
+// data is the content of the file.
+//
+// fix is an optional function that canonicalizes module versions.
+// If fix is nil, all module versions must be canonical ([module.CanonicalVersion]
+// must return the same string).
+func Parse(file string, data []byte, fix VersionFixer) (*File, error) {
+	return parseToFile(file, data, fix, true)
+}
+
+// ParseLax is like Parse but ignores unknown statements.
+// It is used when parsing go.mod files other than the main module,
+// under the theory that most statement types we add in the future will
+// only apply in the main module, like exclude and replace,
+// and so we get better gradual deployments if old go commands
+// simply ignore those statements when found in go.mod files
+// in dependencies.
+func ParseLax(file string, data []byte, fix VersionFixer) (*File, error) {
+	return parseToFile(file, data, fix, false)
+}
+
+func parseToFile(file string, data []byte, fix VersionFixer, strict bool) (parsed *File, err error) {
+	fs, err := parse(file, data)
+	if err != nil {
+		return nil, err
+	}
+	f := &File{
+		Syntax: fs,
+	}
+	var errs ErrorList
+
+	// fix versions in retract directives after the file is parsed.
+	// We need the module path to fix versions, and it might be at the end.
+	defer func() {
+		oldLen := len(errs)
+		f.fixRetract(fix, &errs)
+		if len(errs) > oldLen {
+			parsed, err = nil, errs
+		}
+	}()
+
+	for _, x := range fs.Stmt {
+		switch x := x.(type) {
+		case *Line:
+			f.add(&errs, nil, x, x.Token[0], x.Token[1:], fix, strict)
+
+		case *LineBlock:
+			if len(x.Token) > 1 {
+				if strict {
+					errs = append(errs, Error{
+						Filename: file,
+						Pos:      x.Start,
+						Err:      fmt.Errorf("unknown block type: %s", strings.Join(x.Token, " ")),
+					})
+				}
+				continue
+			}
+			switch x.Token[0] {
+			default:
+				if strict {
+					errs = append(errs, Error{
+						Filename: file,
+						Pos:      x.Start,
+						Err:      fmt.Errorf("unknown block type: %s", strings.Join(x.Token, " ")),
+					})
+				}
+				continue
+			case "module", "godebug", "require", "exclude", "replace", "retract", "tool", "ignore":
+				for _, l := range x.Line {
+					f.add(&errs, x, l, x.Token[0], l.Token, fix, strict)
+				}
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	return f, nil
+}
+
+var GoVersionRE = lazyregexp.New(`^([1-9][0-9]*)\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?([a-z]+[0-9]+)?$`)
+var laxGoVersionRE = lazyregexp.New(`^v?(([1-9][0-9]*)\.(0|[1-9][0-9]*))([^0-9].*)$`)
+
+// Toolchains must be named beginning with `go1`,
+// like "go1.20.3" or "go1.20.3-gccgo". As a special case, "default" is also permitted.
+// Note that this regexp is a much looser condition than go/version.IsValid,
+// for forward compatibility.
+// (This code has to be work to identify new toolchains even if we tweak the syntax in the future.)
+var ToolchainRE = lazyregexp.New(`^default$|^go1($|\.)`)
+
+func (f *File) add(errs *ErrorList, block *LineBlock, line *Line, verb string, args []string, fix VersionFixer, strict bool) {
+	// If strict is false, this module is a dependency.
+	// We ignore all unknown directives as well as main-module-only
+	// directives like replace and exclude. It will work better for
+	// forward compatibility if we can depend on modules that have unknown
+	// statements (presumed relevant only when acting as the main module)
+	// and simply ignore those statements.
+	if !strict {
+		switch verb {
+		case "go", "module", "retract", "require", "ignore":
+			// want these even for dependency go.mods
+		default:
+			return
+		}
+	}
+
+	wrapModPathError := func(modPath string, err error) {
+		*errs = append(*errs, Error{
+			Filename: f.Syntax.Name,
+			Pos:      line.Start,
+			ModPath:  modPath,
+			Verb:     verb,
+			Err:      err,
+		})
+	}
+	wrapError := func(err error) {
+		*errs = append(*errs, Error{
+			Filename: f.Syntax.Name,
+			Pos:      line.Start,
+			Err:      err,
+		})
+	}
+	errorf := func(format string, args ...any) {
+		wrapError(fmt.Errorf(format, args...))
+	}
+
+	switch verb {
+	default:
+		errorf("unknown directive: %s", verb)
+
+	case "go":
+		if f.Go != nil {
+			errorf("repeated go statement")
+			return
+		}
+		if len(args) != 1 {
+			errorf("go directive expects exactly one argument")
+			return
+		} else if !GoVersionRE.MatchString(args[0]) {
+			fixed := false
+			if !strict {
+				if m := laxGoVersionRE.FindStringSubmatch(args[0]); m != nil {
+					args[0] = m[1]
+					fixed = true
+				}
+			}
+			if !fixed {
+				errorf("invalid go version '%s': must match format 1.23.0", args[0])
+				return
+			}
+		}
+
+		f.Go = &Go{Syntax: line}
+		f.Go.Version = args[0]
+
+	case "toolchain":
+		if f.Toolchain != nil {
+			errorf("repeated toolchain statement")
+			return
+		}
+		if len(args) != 1 {
+			errorf("toolchain directive expects exactly one argument")
+			return
+		} else if !ToolchainRE.MatchString(args[0]) {
+			errorf("invalid toolchain version '%s': must match format go1.23.0 or default", args[0])
+			return
+		}
+		f.Toolchain = &Toolchain{Syntax: line}
+		f.Toolchain.Name = args[0]
+
+	case "module":
+		if f.Module != nil {
+			errorf("repeated module statement")
+			return
+		}
+		deprecated := parseDeprecation(block, line)
+		f.Module = &Module{
+			Syntax:     line,
+			Deprecated: deprecated,
+		}
+		if len(args) != 1 {
+			errorf("usage: module module/path")
+			return
+		}
+		s, err := parseString(&args[0])
+		if err != nil {
+			errorf("invalid quoted string: %v", err)
+			return
+		}
+		f.Module.Mod = module.Version{Path: s}
+
+	case "godebug":
+		if len(args) != 1 || strings.ContainsAny(args[0], "\"`',") {
+			errorf("usage: godebug key=value")
+			return
+		}
+		key, value, ok := strings.Cut(args[0], "=")
+		if !ok {
+			errorf("usage: godebug key=value")
+			return
+		}
+		f.Godebug = append(f.Godebug, &Godebug{
+			Key:    key,
+			Value:  value,
+			Syntax: line,
+		})
+
+	case "require", "exclude":
+		if len(args) != 2 {
+			errorf("usage: %s module/path v1.2.3", verb)
+			return
+		}
+		s, err := parseString(&args[0])
+		if err != nil {
+			errorf("invalid quoted string: %v", err)
+			return
+		}
+		v, err := parseVersion(verb, s, &args[1], fix)
+		if err != nil {
+			wrapError(err)
+			return
+		}
+		pathMajor, err := modulePathMajor(s)
+		if err != nil {
+			wrapError(err)
+			return
+		}
+		if err := module.CheckPathMajor(v, pathMajor); err != nil {
+			wrapModPathError(s, err)
+			return
+		}
+		if verb == "require" {
+			f.Require = append(f.Require, &Require{
+				Mod:      module.Version{Path: s, Version: v},
+				Syntax:   line,
+				Indirect: isIndirect(line),
+			})
+		} else {
+			f.Exclude = append(f.Exclude, &Exclude{
+				Mod:    module.Version{Path: s, Version: v},
+				Syntax: line,
+			})
+		}
+
+	case "replace":
+		replace, wrappederr := parseReplace(f.Syntax.Name, line, verb, args, fix)
+		if wrappederr != nil {
+			*errs = append(*errs, *wrappederr)
+			return
+		}
+		f.Replace = append(f.Replace, replace)
+
+	case "retract":
+		rationale := parseDirectiveComment(block, line)
+		vi, err := parseVersionInterval(verb, "", &args, dontFixRetract)
+		if err != nil {
+			if strict {
+				wrapError(err)
+				return
+			} else {
+				// Only report errors parsing intervals in the main module. We may
+				// support additional syntax in the future, such as open and half-open
+				// intervals. Those can't be supported now, because they break the
+				// go.mod parser, even in lax mode.
+				return
+			}
+		}
+		if len(args) > 0 && strict {
+			// In the future, there may be additional information after the version.
+			errorf("unexpected token after version: %q", args[0])
+			return
+		}
+		retract := &Retract{
+			VersionInterval: vi,
+			Rationale:       rationale,
+			Syntax:          line,
+		}
+		f.Retract = append(f.Retract, retract)
+
+	case "tool":
+		if len(args) != 1 {
+			errorf("tool directive expects exactly one argument")
+			return
+		}
+		s, err := parseString(&args[0])
+		if err != nil {
+			errorf("invalid quoted string: %v", err)
+			return
+		}
+		f.Tool = append(f.Tool, &Tool{
+			Path:   s,
+			Syntax: line,
+		})
+
+	case "ignore":
+		if len(args) != 1 {
+			errorf("ignore directive expects exactly one argument")
+			return
+		}
+		s, err := parseString(&args[0])
+		if err != nil {
+			errorf("invalid quoted string: %v", err)
+			return
+		}
+		f.Ignore = append(f.Ignore, &Ignore{
+			Path:   s,
+			Syntax: line,
+		})
+	}
+}
+
+func parseReplace(filename string, line *Line, verb string, args []string, fix VersionFixer) (*Replace, *Error) {
+	wrapModPathError := func(modPath string, err error) *Error {
+		return &Error{
+			Filename: filename,
+			Pos:      line.Start,
+			ModPath:  modPath,
+			Verb:     verb,
+			Err:      err,
+		}
+	}
+	wrapError := func(err error) *Error {
+		return &Error{
+			Filename: filename,
+			Pos:      line.Start,
+			Err:      err,
+		}
+	}
+	errorf := func(format string, args ...any) *Error {
+		return wrapError(fmt.Errorf(format, args...))
+	}
+
+	arrow := 2
+	if len(args) >= 2 && args[1] == "=>" {
+		arrow = 1
+	}
+	if len(args) < arrow+2 || len(args) > arrow+3 || args[arrow] != "=>" {
+		return nil, errorf("usage: %s module/path [v1.2.3] => other/module v1.4\n\t or %s module/path [v1.2.3] => ../local/directory", verb, verb)
+	}
+	s, err := parseString(&args[0])
+	if err != nil {
+		return nil, errorf("invalid quoted string: %v", err)
+	}
+	pathMajor, err := modulePathMajor(s)
+	if err != nil {
+		return nil, wrapModPathError(s, err)
+
+	}
+	var v string
+	if arrow == 2 {
+		v, err = parseVersion(verb, s, &args[1], fix)
+		if err != nil {
+			return nil, wrapError(err)
+		}
+		if err := module.CheckPathMajor(v, pathMajor); err != nil {
+			return nil, wrapModPathError(s, err)
+		}
+	}
+	ns, err := parseString(&args[arrow+1])
+	if err != nil {
+		return nil, errorf("invalid quoted string: %v", err)
+	}
+	nv := ""
+	if len(args) == arrow+2 {
+		if !IsDirectoryPath(ns) {
+			if strings.Contains(ns, "@") {
+				return nil, errorf("replacement module must match format 'path version', not 'path@version'")
+			}
+			return nil, errorf("replacement module without version must be directory path (rooted or starting with . or ..)")
+		}
+		if filepath.Separator == '/' && strings.Contains(ns, `\`) {
+			return nil, errorf("replacement directory appears to be Windows path (on a non-windows system)")
+		}
+	}
+	if len(args) == arrow+3 {
+		nv, err = parseVersion(verb, ns, &args[arrow+2], fix)
+		if err != nil {
+			return nil, wrapError(err)
+		}
+		if IsDirectoryPath(ns) {
+			return nil, errorf("replacement module directory path %q cannot have version", ns)
+		}
+	}
+	return &Replace{
+		Old:    module.Version{Path: s, Version: v},
+		New:    module.Version{Path: ns, Version: nv},
+		Syntax: line,
+	}, nil
+}
+
+// fixRetract applies fix to each retract directive in f, appending any errors
+// to errs.
+//
+// Most versions are fixed as we parse the file, but for retract directives,
+// the relevant module path is the one specified with the module directive,
+// and that might appear at the end of the file (or not at all).
+func (f *File) fixRetract(fix VersionFixer, errs *ErrorList) {
+	if fix == nil {
+		return
+	}
+	path := ""
+	if f.Module != nil {
+		path = f.Module.Mod.Path
+	}
+	var r *Retract
+	wrapError := func(err error) {
+		*errs = append(*errs, Error{
+			Filename: f.Syntax.Name,
+			Pos:      r.Syntax.Start,
+			Err:      err,
+		})
+	}
+
+	for _, r = range f.Retract {
+		if path == "" {
+			wrapError(errors.New("no module directive found, so retract cannot be used"))
+			return // only print the first one of these
+		}
+
+		args := r.Syntax.Token
+		if args[0] == "retract" {
+			args = args[1:]
+		}
+		vi, err := parseVersionInterval("retract", path, &args, fix)
+		if err != nil {
+			wrapError(err)
+		}
+		r.VersionInterval = vi
+	}
+}
+
+func (f *WorkFile) add(errs *ErrorList, line *Line, verb string, args []string, fix VersionFixer) {
+	wrapError := func(err error) {
+		*errs = append(*errs, Error{
+			Filename: f.Syntax.Name,
+			Pos:      line.Start,
+			Err:      err,
+		})
+	}
+	errorf := func(format string, args ...any) {
+		wrapError(fmt.Errorf(format, args...))
+	}
+
+	switch verb {
+	default:
+		errorf("unknown directive: %s", verb)
+
+	case "go":
+		if f.Go != nil {
+			errorf("repeated go statement")
+			return
+		}
+		if len(args) != 1 {
+			errorf("go directive expects exactly one argument")
+			return
+		} else if !GoVersionRE.MatchString(args[0]) {
+			errorf("invalid go version '%s': must match format 1.23.0", args[0])
+			return
+		}
+
+		f.Go = &Go{Syntax: line}
+		f.Go.Version = args[0]
+
+	case "toolchain":
+		if f.Toolchain != nil {
+			errorf("repeated toolchain statement")
+			return
+		}
+		if len(args) != 1 {
+			errorf("toolchain directive expects exactly one argument")
+			return
+		} else if !ToolchainRE.MatchString(args[0]) {
+			errorf("invalid toolchain version '%s': must match format go1.23.0 or default", args[0])
+			return
+		}
+
+		f.Toolchain = &Toolchain{Syntax: line}
+		f.Toolchain.Name = args[0]
+
+	case "godebug":
+		if len(args) != 1 || strings.ContainsAny(args[0], "\"`',") {
+			errorf("usage: godebug key=value")
+			return
+		}
+		key, value, ok := strings.Cut(args[0], "=")
+		if !ok {
+			errorf("usage: godebug key=value")
+			return
+		}
+		f.Godebug = append(f.Godebug, &Godebug{
+			Key:    key,
+			Value:  value,
+			Syntax: line,
+		})
+
+	case "use":
+		if len(args) != 1 {
+			errorf("usage: %s local/dir", verb)
+			return
+		}
+		s, err := parseString(&args[0])
+		if err != nil {
+			errorf("invalid quoted string: %v", err)
+			return
+		}
+		f.Use = append(f.Use, &Use{
+			Path:   s,
+			Syntax: line,
+		})
+
+	case "replace":
+		replace, wrappederr := parseReplace(f.Syntax.Name, line, verb, args, fix)
+		if wrappederr != nil {
+			*errs = append(*errs, *wrappederr)
+			return
+		}
+		f.Replace = append(f.Replace, replace)
+	}
+}
+
+// IsDirectoryPath reports whether the given path should be interpreted as a directory path.
+// Just like on the go command line, relative paths starting with a '.' or '..' path component
+// and rooted paths are directory paths; the rest are module paths.
+func IsDirectoryPath(ns string) bool {
+	// Because go.mod files can move from one system to another,
+	// we check all known path syntaxes, both Unix and Windows.
+	return ns == "." || strings.HasPrefix(ns, "./") || strings.HasPrefix(ns, `.\`) ||
+		ns == ".." || strings.HasPrefix(ns, "../") || strings.HasPrefix(ns, `..\`) ||
+		strings.HasPrefix(ns, "/") || strings.HasPrefix(ns, `\`) ||
+		len(ns) >= 2 && ('A' <= ns[0] && ns[0] <= 'Z' || 'a' <= ns[0] && ns[0] <= 'z') && ns[1] == ':'
+}
+
+// MustQuote reports whether s must be quoted in order to appear as
+// a single token in a go.mod line.
+func MustQuote(s string) bool {
+	for _, r := range s {
+		switch r {
+		case ' ', '"', '\'', '`':
+			return true
+
+		case '(', ')', '[', ']', '{', '}', ',':
+			if len(s) > 1 {
+				return true
+			}
+
+		default:
+			if !unicode.IsPrint(r) {
+				return true
+			}
+		}
+	}
+	return s == "" || strings.Contains(s, "//") || strings.Contains(s, "/*")
+}
+
+// AutoQuote returns s or, if quoting is required for s to appear in a go.mod,
+// the quotation of s.
+func AutoQuote(s string) string {
+	if MustQuote(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func parseVersionInterval(verb string, path string, args *[]string, fix VersionFixer) (VersionInterval, error) {
+	toks := *args
+	if len(toks) == 0 || toks[0] == "(" {
+		return VersionInterval{}, fmt.Errorf("expected '[' or version")
+	}
+	if toks[0] != "[" {
+		v, err := parseVersion(verb, path, &toks[0], fix)
+		if err != nil {
+			return VersionInterval{}, err
+		}
+		*args = toks[1:]
+		return VersionInterval{Low: v, High: v}, nil
+	}
+	toks = toks[1:]
+
+	if len(toks) == 0 {
+		return VersionInterval{}, fmt.Errorf("expected version after '['")
+	}
+	low, err := parseVersion(verb, path, &toks[0], fix)
+	if err != nil {
+		return VersionInterval{}, err
+	}
+	toks = toks[1:]
+
+	if len(toks) == 0 || toks[0] != "," {
+		return VersionInterval{}, fmt.Errorf("expected ',' after version")
+	}
+	toks = toks[1:]
+
+	if len(toks) == 0 {
+		return VersionInterval{}, fmt.Errorf("expected version after ','")
+	}
+	high, err := parseVersion(verb, path, &toks[0], fix)
+	if err != nil {
+		return VersionInterval{}, err
+	}
+	toks = toks[1:]
+
+	if len(toks) == 0 || toks[0] != "]" {
+		return VersionInterval{}, fmt.Errorf("expected ']' after version")
+	}
+	toks = toks[1:]
+
+	*args = toks
+	return VersionInterval{Low: low, High: high}, nil
+}
+
+func parseString(s *string) (string, error) {
+	t := *s
+	if strings.HasPrefix(t, `"`) {
+		var err error
+		if t, err = strconv.Unquote(t); err != nil {
+			return "", err
+		}
+	} else if strings.ContainsAny(t, "\"'`") {
+		// Other quotes are reserved both for possible future expansion
+		// and to avoid confusion. For example if someone types 'x'
+		// we want that to be a syntax error and not a literal x in literal quotation marks.
+		return "", fmt.Errorf("unquoted string cannot contain quote")
+	}
+	*s = AutoQuote(t)
+	return t, nil
+}
+
+var deprecatedRE = lazyregexp.New(`(?s)(?:^|\n\n)Deprecated: *(.*?)(?:$|\n\n)`)
+
+// parseDeprecation extracts the text of comments on a "module" directive and
+// extracts a deprecation message from that.
+//
+// A deprecation message is contained in a paragraph within a block of comments
+// that starts with "Deprecated:" (case sensitive). The message runs until the
+// end of the paragraph and does not include the "Deprecated:" prefix. If the
+// comment block has multiple paragraphs that start with "Deprecated:",
+// parseDeprecation returns the message from the first.
+func parseDeprecation(block *LineBlock, line *Line) string {
+	text := parseDirectiveComment(block, line)
+	m := deprecatedRE.FindStringSubmatch(text)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// parseDirectiveComment extracts the text of comments on a directive.
+// If the directive's line does not have comments and is part of a block that
+// does have comments, the block's comments are used.
+func parseDirectiveComment(block *LineBlock, line *Line) string {
+	comments := line.Comment()
+	if block != nil && len(comments.Before) == 0 && len(comments.Suffix) == 0 {
+		comments = block.Comment()
+	}
+	groups := [][]Comment{comments.Before, comments.Suffix}
+	var lines []string
+	for _, g := range groups {
+		for _, c := range g {
+			if !strings.HasPrefix(c.Token, "//") {
+				continue // blank line
+			}
+			lines = append(lines, strings.TrimSpace(strings.TrimPrefix(c.Token, "//")))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+type ErrorList []Error
+
+func (e ErrorList) Error() string {
+	errStrs := make([]string, len(e))
+	for i, err := range e {
+		errStrs[i] = err.Error()
+	}
+	return strings.Join(errStrs, "\n")
+}
+
+type Error struct {
+	Filename string
+	Pos      Position
+	Verb     string
+	ModPath  string
+	Err      error
+}
+
+func (e *Error) Error() string {
+	var pos string
+	if e.Pos.LineRune > 1 {
+		// Don't print LineRune if it's 1 (beginning of line).
+		// It's always 1 except in scanner errors, which are rare.
+		pos = fmt.Sprintf("%s:%d:%d: ", e.Filename, e.Pos.Line, e.Pos.LineRune)
+	} else if e.Pos.Line > 0 {
+		pos = fmt.Sprintf("%s:%d: ", e.Filename, e.Pos.Line)
+	} else if e.Filename != "" {
+		pos = fmt.Sprintf("%s: ", e.Filename)
+	}
+
+	var directive string
+	if e.ModPath != "" {
+		directive = fmt.Sprintf("%s %s: ", e.Verb, e.ModPath)
+	} else if e.Verb != "" {
+		directive = fmt.Sprintf("%s: ", e.Verb)
+	}
+
+	return pos + directive + e.Err.Error()
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+func parseVersion(verb string, path string, s *string, fix VersionFixer) (string, error) {
+	t, err := parseString(s)
+	if err != nil {
+		return "", &Error{
+			Verb:    verb,
+			ModPath: path,
+			Err: &module.InvalidVersionError{
+				Version: *s,
+				Err:     err,
+			},
+		}
+	}
+	if fix != nil {
+		fixed, err := fix(path, t)
+		if err != nil {
+			if err, ok := err.(*module.ModuleError); ok {
+				return "", &Error{
+					Verb:    verb,
+					ModPath: path,
+					Err:     err.Err,
+				}
+			}
+			return "", err
+		}
+		t = fixed
+	} else {
+		cv := module.CanonicalVersion(t)
+		if cv == "" {
+			return "", &Error{
+				Verb:    verb,
+				ModPath: path,
+				Err: &module.InvalidVersionError{
+					Version: t,
+					Err:     errors.New("must be of the form v1.2.3"),
+				},
+			}
+		}
+		t = cv
+	}
+	*s = t
+	return *s, nil
+}
+
+func modulePathMajor(path string) (string, error) {
+	_, major, ok := module.SplitPathVersion(path)
+	if !ok {
+		return "", fmt.Errorf("invalid module path")
+	}
+	return major, nil
+}
+
+func (f *File) Format() ([]byte, error) {
+	return Format(f.Syntax), nil
+}
+
+// Cleanup cleans up the file f after any edit operations.
+// To avoid quadratic behavior, modifications like [File.DropRequire]
+// clear the entry but do not remove it from the slice.
+// Cleanup cleans out all the cleared entries.
+func (f *File) Cleanup() {
+	w := 0
+	for _, g := range f.Godebug {
+		if g.Key != "" {
+			f.Godebug[w] = g
+			w++
+		}
+	}
+	f.Godebug = f.Godebug[:w]
+
+	w = 0
+	for _, r := range f.Require {
+		if r.Mod.Path != "" {
+			f.Require[w] = r
+			w++
+		}
+	}
+	f.Require = f.Require[:w]
+
+	w = 0
+	for _, x := range f.Exclude {
+		if x.Mod.Path != "" {
+			f.Exclude[w] = x
+			w++
+		}
+	}
+	f.Exclude = f.Exclude[:w]
+
+	w = 0
+	for _, r := range f.Replace {
+		if r.Old.Path != "" {
+			f.Replace[w] = r
+			w++
+		}
+	}
+	f.Replace = f.Replace[:w]
+
+	w = 0
+	for _, r := range f.Retract {
+		if r.Low != "" || r.High != "" {
+			f.Retract[w] = r
+			w++
+		}
+	}
+	f.Retract = f.Retract[:w]
+
+	f.Syntax.Cleanup()
+}
+
+func (f *File) AddGoStmt(version string) error {
+	if !GoVersionRE.MatchString(version) {
+		return fmt.Errorf("invalid language version %q", version)
+	}
+	if f.Go == nil {
+		var hint Expr
+		if f.Module != nil && f.Module.Syntax != nil {
+			hint = f.Module.Syntax
+		} else if f.Syntax == nil {
+			f.Syntax = new(FileSyntax)
+		}
+		f.Go = &Go{
+			Version: version,
+			Syntax:  f.Syntax.addLine(hint, "go", version),
+		}
+	} else {
+		f.Go.Version = version
+		f.Syntax.updateLine(f.Go.Syntax, "go", version)
+	}
+	return nil
+}
+
+// DropGoStmt deletes the go statement from the file.
+func (f *File) DropGoStmt() {
+	if f.Go != nil {
+		f.Go.Syntax.markRemoved()
+		f.Go = nil
+	}
+}
+
+// DropToolchainStmt deletes the toolchain statement from the file.
+func (f *File) DropToolchainStmt() {
+	if f.Toolchain != nil {
+		f.Toolchain.Syntax.markRemoved()
+		f.Toolchain = nil
+	}
+}
+
+func (f *File) AddToolchainStmt(name string) error {
+	if !ToolchainRE.MatchString(name) {
+		return fmt.Errorf("invalid toolchain name %q", name)
+	}
+	if f.Toolchain == nil {
+		var hint Expr
+		if f.Go != nil && f.Go.Syntax != nil {
+			hint = f.Go.Syntax
+		} else if f.Module != nil && f.Module.Syntax != nil {
+			hint = f.Module.Syntax
+		}
+		f.Toolchain = &Toolchain{
+			Name:   name,
+			Syntax: f.Syntax.addLine(hint, "toolchain", name),
+		}
+	} else {
+		f.Toolchain.Name = name
+		f.Syntax.updateLine(f.Toolchain.Syntax, "toolchain", name)
+	}
+	return nil
+}
+
+// AddGodebug sets the first godebug line for key to value,
+// preserving any existing comments for that line and removing all
+// other godebug lines for key.
+//
+// If no line currently exists for key, AddGodebug adds a new line
+// at the end of the last godebug block.
+func (f *File) AddGodebug(key, value string) error {
+	need := true
+	for _, g := range f.Godebug {
+		if g.Key == key {
+			if need {
+				g.Value = value
+				f.Syntax.updateLine(g.Syntax, "godebug", key+"="+value)
+				need = false
+			} else {
+				g.Syntax.markRemoved()
+				*g = Godebug{}
+			}
+		}
+	}
+
+	if need {
+		f.addNewGodebug(key, value)
+	}
+	return nil
+}
+
+// addNewGodebug adds a new godebug key=value line at the end
+// of the last godebug block, regardless of any existing godebug lines for key.
+func (f *File) addNewGodebug(key, value string) {
+	line := f.Syntax.addLine(nil, "godebug", key+"="+value)
+	g := &Godebug{
+		Key:    key,
+		Value:  value,
+		Syntax: line,
+	}
+	f.Godebug = append(f.Godebug, g)
+}
+
+// AddRequire sets the first require line for path to version vers,
+// preserving any existing comments for that line and removing all
+// other lines for path.
+//
+// If no line currently exists for path, AddRequire adds a new line
+// at the end of the last require block.
+func (f *File) AddRequire(path, vers string) error {
+	need := true
+	for _, r := range f.Require {
+		if r.Mod.Path == path {
+			if need {
+				r.Mod.Version = vers
+				f.Syntax.updateLine(r.Syntax, "require", AutoQuote(path), vers)
+				need = false
+			} else {
+				r.Syntax.markRemoved()
+				*r = Require{}
+			}
+		}
+	}
+
+	if need {
+		f.AddNewRequire(path, vers, false)
+	}
+	return nil
+}
+
+// AddNewRequire adds a new require line for path at version vers at the end of
+// the last require block, regardless of any existing require lines for path.
+func (f *File) AddNewRequire(path, vers string, indirect bool) {
+	line := f.Syntax.addLine(nil, "require", AutoQuote(path), vers)
+	r := &Require{
+		Mod:    module.Version{Path: path, Version: vers},
+		Syntax: line,
+	}
+	r.setIndirect(indirect)
+	f.Require = append(f.Require, r)
+}
+
+// SetRequire updates the requirements of f to contain exactly req, preserving
+// the existing block structure and line comment contents (except for 'indirect'
+// markings) for the first requirement on each named module path.
+//
+// The Syntax field is ignored for the requirements in req.
+//
+// Any requirements not already present in the file are added to the block
+// containing the last require line.
+//
+// The requirements in req must specify at most one distinct version for each
+// module path.
+//
+// If any existing requirements may be removed, the caller should call
+// [File.Cleanup] after all edits are complete.
+func (f *File) SetRequire(req []*Require) {
+	type elem struct {
+		version  string
+		indirect bool
+	}
+	need := make(map[string]elem)
+	for _, r := range req {
+		if prev, dup := need[r.Mod.Path]; dup && prev.version != r.Mod.Version {
+			panic(fmt.Errorf("SetRequire called with conflicting versions for path %s (%s and %s)", r.Mod.Path, prev.version, r.Mod.Version))
+		}
+		need[r.Mod.Path] = elem{r.Mod.Version, r.Indirect}
+	}
+
+	// Update or delete the existing Require entries to preserve
+	// only the first for each module path in req.
+	for _, r := range f.Require {
+		e, ok := need[r.Mod.Path]
+		if ok {
+			r.setVersion(e.version)
+			r.setIndirect(e.indirect)
+		} else {
+			r.markRemoved()
+		}
+		delete(need, r.Mod.Path)
+	}
+
+	// Add new entries in the last block of the file for any paths that weren't
+	// already present.
+	//
+	// This step is nondeterministic, but the final result will be deterministic
+	// because we will sort the block.
+	for path, e := range need {
+		f.AddNewRequire(path, e.version, e.indirect)
+	}
+
+	f.SortBlocks()
+}
+
+// SetRequireSeparateIndirect updates the requirements of f to contain the given
+// requirements. Comment contents (except for 'indirect' markings) are retained
+// from the first existing requirement for each module path. Like SetRequire,
+// SetRequireSeparateIndirect adds requirements for new paths in req,
+// updates the version and "// indirect" comment on existing requirements,
+// and deletes requirements on paths not in req. Existing duplicate requirements
+// are deleted.
+//
+// As its name suggests, SetRequireSeparateIndirect puts direct and indirect
+// requirements into two separate blocks, one containing only direct
+// requirements, and the other containing only indirect requirements.
+// SetRequireSeparateIndirect may move requirements between these two blocks
+// when their indirect markings change. However, SetRequireSeparateIndirect
+// won't move requirements from other blocks, especially blocks with comments.
+//
+// If the file initially has one uncommented block of requirements,
+// SetRequireSeparateIndirect will split it into a direct-only and indirect-only
+// block. This aids in the transition to separate blocks.
+func (f *File) SetRequireSeparateIndirect(req []*Require) {
+	// hasComments returns whether a line or block has comments
+	// other than "indirect".
+	hasComments := func(c Comments) bool {
+		return len(c.Before) > 0 || len(c.After) > 0 || len(c.Suffix) > 1 ||
+			(len(c.Suffix) == 1 &&
+				strings.TrimSpace(strings.TrimPrefix(c.Suffix[0].Token, string(slashSlash))) != "indirect")
+	}
+
+	// moveReq adds r to block. If r was in another block, moveReq deletes
+	// it from that block and transfers its comments.
+	moveReq := func(r *Require, block *LineBlock) {
+		var line *Line
+		if r.Syntax == nil {
+			line = &Line{Token: []string{AutoQuote(r.Mod.Path), r.Mod.Version}}
+			r.Syntax = line
+			if r.Indirect {
+				r.setIndirect(true)
+			}
+		} else {
+			line = new(Line)
+			*line = *r.Syntax
+			if !line.InBlock && len(line.Token) > 0 && line.Token[0] == "require" {
+				line.Token = line.Token[1:]
+			}
+			r.Syntax.Token = nil // Cleanup will delete the old line.
+			r.Syntax = line
+		}
+		line.InBlock = true
+		block.Line = append(block.Line, line)
+	}
+
+	// Examine existing require lines and blocks.
+	var (
+		// We may insert new requirements into the last uncommented
+		// direct-only and indirect-only blocks. We may also move requirements
+		// to the opposite block if their indirect markings change.
+		lastDirectIndex   = -1
+		lastIndirectIndex = -1
+
+		// If there are no direct-only or indirect-only blocks, a new block may
+		// be inserted after the last require line or block.
+		lastRequireIndex = -1
+
+		// If there's only one require line or block, and it's uncommented,
+		// we'll move its requirements to the direct-only or indirect-only blocks.
+		requireLineOrBlockCount = 0
+
+		// Track the block each requirement belongs to (if any) so we can
+		// move them later.
+		lineToBlock = make(map[*Line]*LineBlock)
+	)
+	for i, stmt := range f.Syntax.Stmt {
+		switch stmt := stmt.(type) {
+		case *Line:
+			if len(stmt.Token) == 0 || stmt.Token[0] != "require" {
+				continue
+			}
+			lastRequireIndex = i
+			requireLineOrBlockCount++
+			if !hasComments(stmt.Comments) {
+				if isIndirect(stmt) {
+					lastIndirectIndex = i
+				} else {
+					lastDirectIndex = i
+				}
+			}
+
+		case *LineBlock:
+			if len(stmt.Token) == 0 || stmt.Token[0] != "require" {
+				continue
+			}
+			lastRequireIndex = i
+			requireLineOrBlockCount++
+			allDirect := len(stmt.Line) > 0 && !hasComments(stmt.Comments)
+			allIndirect := len(stmt.Line) > 0 && !hasComments(stmt.Comments)
+			for _, line := range stmt.Line {
+				lineToBlock[line] = stmt
+				if hasComments(line.Comments) {
+					allDirect = false
+					allIndirect = false
+				} else if isIndirect(line) {
+					allDirect = false
+				} else {
+					allIndirect = false
+				}
+			}
+			if allDirect {
+				lastDirectIndex = i
+			}
+			if allIndirect {
+				lastIndirectIndex = i
+			}
+		}
+	}
+
+	oneFlatUncommentedBlock := requireLineOrBlockCount == 1 &&
+		!hasComments(*f.Syntax.Stmt[lastRequireIndex].Comment())
+
+	// Create direct and indirect blocks if needed. Convert lines into blocks
+	// if needed. If we end up with an empty block or a one-line block,
+	// Cleanup will delete it or convert it to a line later.
+	insertBlock := func(i int) *LineBlock {
+		block := &LineBlock{Token: []string{"require"}}
+		f.Syntax.Stmt = append(f.Syntax.Stmt, nil)
+		copy(f.Syntax.Stmt[i+1:], f.Syntax.Stmt[i:])
+		f.Syntax.Stmt[i] = block
+		return block
+	}
+
+	ensureBlock := func(i int) *LineBlock {
+		switch stmt := f.Syntax.Stmt[i].(type) {
+		case *LineBlock:
+			return stmt
+		case *Line:
+			block := &LineBlock{
+				Token: []string{"require"},
+				Line:  []*Line{stmt},
+			}
+			stmt.Token = stmt.Token[1:] // remove "require"
+			stmt.InBlock = true
+			f.Syntax.Stmt[i] = block
+			return block
+		default:
+			panic(fmt.Sprintf("unexpected statement: %v", stmt))
+		}
+	}
+
+	var lastDirectBlock *LineBlock
+	if lastDirectIndex < 0 {
+		if lastIndirectIndex >= 0 {
+			lastDirectIndex = lastIndirectIndex
+			lastIndirectIndex++
+		} else if lastRequireIndex >= 0 {
+			lastDirectIndex = lastRequireIndex + 1
+		} else {
+			lastDirectIndex = len(f.Syntax.Stmt)
+		}
+		lastDirectBlock = insertBlock(lastDirectIndex)
+	} else {
+		lastDirectBlock = ensureBlock(lastDirectIndex)
+	}
+
+	var lastIndirectBlock *LineBlock
+	if lastIndirectIndex < 0 {
+		lastIndirectIndex = lastDirectIndex + 1
+		lastIndirectBlock = insertBlock(lastIndirectIndex)
+	} else {
+		lastIndirectBlock = ensureBlock(lastIndirectIndex)
+	}
+
+	// Delete requirements we don't want anymore.
+	// Update versions and indirect comments on requirements we want to keep.
+	// If a requirement is in last{Direct,Indirect}Block with the wrong
+	// indirect marking after this, or if the requirement is in an single
+	// uncommented mixed block (oneFlatUncommentedBlock), move it to the
+	// correct block.
+	//
+	// Some blocks may be empty after this. Cleanup will remove them.
+	need := make(map[string]*Require)
+	for _, r := range req {
+		need[r.Mod.Path] = r
+	}
+	have := make(map[string]*Require)
+	for _, r := range f.Require {
+		path := r.Mod.Path
+		if need[path] == nil || have[path] != nil {
+			// Requirement not needed, or duplicate requirement. Delete.
+			r.markRemoved()
+			continue
+		}
+		have[r.Mod.Path] = r
+		r.setVersion(need[path].Mod.Version)
+		r.setIndirect(need[path].Indirect)
+		if need[path].Indirect &&
+			(oneFlatUncommentedBlock || lineToBlock[r.Syntax] == lastDirectBlock) {
+			moveReq(r, lastIndirectBlock)
+		} else if !need[path].Indirect &&
+			(oneFlatUncommentedBlock || lineToBlock[r.Syntax] == lastIndirectBlock) {
+			moveReq(r, lastDirectBlock)
+		}
+	}
+
+	// Add new requirements.
+	for path, r := range need {
+		if have[path] == nil {
+			if r.Indirect {
+				moveReq(r, lastIndirectBlock)
+			} else {
+				moveReq(r, lastDirectBlock)
+			}
+			f.Require = append(f.Require, r)
+		}
+	}
+
+	f.SortBlocks()
+}
+
+func (f *File) DropGodebug(key string) error {
+	for _, g := range f.Godebug {
+		if g.Key == key {
+			g.Syntax.markRemoved()
+			*g = Godebug{}
+		}
+	}
+	return nil
+}
+
+func (f *File) DropRequire(path string) error {
+	for _, r := range f.Require {
+		if r.Mod.Path == path {
+			r.Syntax.markRemoved()
+			*r = Require{}
+		}
+	}
+	return nil
+}
+
+// AddExclude adds a exclude statement to the mod file. Errors if the provided
+// version is not a canonical version string
+func (f *File) AddExclude(path, vers string) error {
+	if err := checkCanonicalVersion(path, vers); err != nil {
+		return err
+	}
+
+	var hint *Line
+	for _, x := range f.Exclude {
+		if x.Mod.Path == path && x.Mod.Version == vers {
+			return nil
+		}
+		if x.Mod.Path == path {
+			hint = x.Syntax
+		}
+	}
+
+	f.Exclude = append(f.Exclude, &Exclude{Mod: module.Version{Path: path, Version: vers}, Syntax: f.Syntax.addLine(hint, "exclude", AutoQuote(path), vers)})
+	return nil
+}
+
+func (f *File) DropExclude(path, vers string) error {
+	for _, x := range f.Exclude {
+		if x.Mod.Path == path && x.Mod.Version == vers {
+			x.Syntax.markRemoved()
+			*x = Exclude{}
+		}
+	}
+	return nil
+}
+
+func (f *File) AddReplace(oldPath, oldVers, newPath, newVers string) error {
+	return addReplace(f.Syntax, &f.Replace, oldPath, oldVers, newPath, newVers)
+}
+
+func addReplace(syntax *FileSyntax, replace *[]*Replace, oldPath, oldVers, newPath, newVers string) error {
+	need := true
+	old := module.Version{Path: oldPath, Version: oldVers}
+	new := module.Version{Path: newPath, Version: newVers}
+	tokens := []string{"replace", AutoQuote(oldPath)}
+	if oldVers != "" {
+		tokens = append(tokens, oldVers)
+	}
+	tokens = append(tokens, "=>", AutoQuote(newPath))
+	if newVers != "" {
+		tokens = append(tokens, newVers)
+	}
+
+	var hint *Line
+	for _, r := range *replace {
+		if r.Old.Path == oldPath && (oldVers == "" || r.Old.Version == oldVers) {
+			if need {
+				// Found replacement for old; update to use new.
+				r.New = new
+				syntax.updateLine(r.Syntax, tokens...)
+				need = false
+				continue
+			}
+			// Already added; delete other replacements for same.
+			r.Syntax.markRemoved()
+			*r = Replace{}
+		}
+		if r.Old.Path == oldPath {
+			hint = r.Syntax
+		}
+	}
+	if need {
+		*replace = append(*replace, &Replace{Old: old, New: new, Syntax: syntax.addLine(hint, tokens...)})
+	}
+	return nil
+}
+
+func (f *File) DropReplace(oldPath, oldVers string) error {
+	for _, r := range f.Replace {
+		if r.Old.Path == oldPath && r.Old.Version == oldVers {
+			r.Syntax.markRemoved()
+			*r = Replace{}
+		}
+	}
+	return nil
+}
+
+// AddRetract adds a retract statement to the mod file. Errors if the provided
+// version interval does not consist of canonical version strings
+func (f *File) AddRetract(vi VersionInterval, rationale string) error {
+	var path string
+	if f.Module != nil {
+		path = f.Module.Mod.Path
+	}
+	if err := checkCanonicalVersion(path, vi.High); err != nil {
+		return err
+	}
+	if err := checkCanonicalVersion(path, vi.Low); err != nil {
+		return err
+	}
+
+	r := &Retract{
+		VersionInterval: vi,
+	}
+	if vi.Low == vi.High {
+		r.Syntax = f.Syntax.addLine(nil, "retract", AutoQuote(vi.Low))
+	} else {
+		r.Syntax = f.Syntax.addLine(nil, "retract", "[", AutoQuote(vi.Low), ",", AutoQuote(vi.High), "]")
+	}
+	if rationale != "" {
+		for line := range strings.SplitSeq(rationale, "\n") {
+			com := Comment{Token: "// " + line}
+			r.Syntax.Comment().Before = append(r.Syntax.Comment().Before, com)
+		}
+	}
+	return nil
+}
+
+func (f *File) DropRetract(vi VersionInterval) error {
+	for _, r := range f.Retract {
+		if r.VersionInterval == vi {
+			r.Syntax.markRemoved()
+			*r = Retract{}
+		}
+	}
+	return nil
+}
+
+// AddTool adds a new tool directive with the given path.
+// It does nothing if the tool line already exists.
+func (f *File) AddTool(path string) error {
+	for _, t := range f.Tool {
+		if t.Path == path {
+			return nil
+		}
+	}
+
+	f.Tool = append(f.Tool, &Tool{
+		Path:   path,
+		Syntax: f.Syntax.addLine(nil, "tool", path),
+	})
+
+	f.SortBlocks()
+	return nil
+}
+
+// RemoveTool removes a tool directive with the given path.
+// It does nothing if no such tool directive exists.
+func (f *File) DropTool(path string) error {
+	for _, t := range f.Tool {
+		if t.Path == path {
+			t.Syntax.markRemoved()
+			*t = Tool{}
+		}
+	}
+	return nil
+}
+
+// AddIgnore adds a new ignore directive with the given path.
+// It does nothing if the ignore line already exists.
+func (f *File) AddIgnore(path string) error {
+	for _, t := range f.Ignore {
+		if t.Path == path {
+			return nil
+		}
+	}
+
+	f.Ignore = append(f.Ignore, &Ignore{
+		Path:   path,
+		Syntax: f.Syntax.addLine(nil, "ignore", path),
+	})
+
+	f.SortBlocks()
+	return nil
+}
+
+// DropIgnore removes a ignore directive with the given path.
+// It does nothing if no such ignore directive exists.
+func (f *File) DropIgnore(path string) error {
+	for _, t := range f.Ignore {
+		if t.Path == path {
+			t.Syntax.markRemoved()
+			*t = Ignore{}
+		}
+	}
+	return nil
+}
+
+func (f *File) SortBlocks() {
+	f.removeDups() // otherwise sorting is unsafe
+
+	// semanticSortForExcludeVersionV is the Go version (plus leading "v") at which
+	// lines in exclude blocks start to use semantic sort instead of lexicographic sort.
+	// See go.dev/issue/60028.
+	const semanticSortForExcludeVersionV = "v1.21"
+	useSemanticSortForExclude := f.Go != nil && semver.Compare("v"+f.Go.Version, semanticSortForExcludeVersionV) >= 0
+
+	for _, stmt := range f.Syntax.Stmt {
+		block, ok := stmt.(*LineBlock)
+		if !ok {
+			continue
+		}
+		less := compareLine
+		if block.Token[0] == "exclude" && useSemanticSortForExclude {
+			less = compareLineExclude
+		} else if block.Token[0] == "retract" {
+			less = compareLineRetract
+		}
+		slices.SortStableFunc(block.Line, less)
+	}
+}
+
+// removeDups removes duplicate exclude, replace and tool directives.
+//
+// Earlier exclude and tool directives take priority.
+//
+// Later replace directives take priority.
+//
+// require directives are not de-duplicated. That's left up to higher-level
+// logic (MVS).
+//
+// retract directives are not de-duplicated since comments are
+// meaningful, and versions may be retracted multiple times.
+func (f *File) removeDups() {
+	removeDups(f.Syntax, &f.Exclude, &f.Replace, &f.Tool, &f.Ignore)
+}
+
+func removeDups(syntax *FileSyntax, exclude *[]*Exclude, replace *[]*Replace, tool *[]*Tool, ignore *[]*Ignore) {
+	kill := make(map[*Line]bool)
+
+	// Remove duplicate excludes.
+	if exclude != nil {
+		haveExclude := make(map[module.Version]bool)
+		for _, x := range *exclude {
+			if haveExclude[x.Mod] {
+				kill[x.Syntax] = true
+				continue
+			}
+			haveExclude[x.Mod] = true
+		}
+		var excl []*Exclude
+		for _, x := range *exclude {
+			if !kill[x.Syntax] {
+				excl = append(excl, x)
+			}
+		}
+		*exclude = excl
+	}
+
+	// Remove duplicate replacements.
+	// Later replacements take priority over earlier ones.
+	haveReplace := make(map[module.Version]bool)
+	for i := len(*replace) - 1; i >= 0; i-- {
+		x := (*replace)[i]
+		if haveReplace[x.Old] {
+			kill[x.Syntax] = true
+			continue
+		}
+		haveReplace[x.Old] = true
+	}
+	var repl []*Replace
+	for _, x := range *replace {
+		if !kill[x.Syntax] {
+			repl = append(repl, x)
+		}
+	}
+	*replace = repl
+
+	if tool != nil {
+		haveTool := make(map[string]bool)
+		for _, t := range *tool {
+			if haveTool[t.Path] {
+				kill[t.Syntax] = true
+				continue
+			}
+			haveTool[t.Path] = true
+		}
+		var newTool []*Tool
+		for _, t := range *tool {
+			if !kill[t.Syntax] {
+				newTool = append(newTool, t)
+			}
+		}
+		*tool = newTool
+	}
+
+	if ignore != nil {
+		haveIgnore := make(map[string]bool)
+		for _, i := range *ignore {
+			if haveIgnore[i.Path] {
+				kill[i.Syntax] = true
+				continue
+			}
+			haveIgnore[i.Path] = true
+		}
+		var newIgnore []*Ignore
+		for _, i := range *ignore {
+			if !kill[i.Syntax] {
+				newIgnore = append(newIgnore, i)
+			}
+		}
+		*ignore = newIgnore
+	}
+
+	// Duplicate require and retract directives are not removed.
+
+	// Drop killed statements from the syntax tree.
+	var stmts []Expr
+	for _, stmt := range syntax.Stmt {
+		switch stmt := stmt.(type) {
+		case *Line:
+			if kill[stmt] {
+				continue
+			}
+		case *LineBlock:
+			var lines []*Line
+			for _, line := range stmt.Line {
+				if !kill[line] {
+					lines = append(lines, line)
+				}
+			}
+			stmt.Line = lines
+			if len(lines) == 0 {
+				continue
+			}
+		}
+		stmts = append(stmts, stmt)
+	}
+	syntax.Stmt = stmts
+}
+
+// compareLine compares li and lj. It sorts lexicographically without assigning
+// any special meaning to tokens.
+func compareLine(li, lj *Line) int {
+	for k := 0; k < len(li.Token) && k < len(lj.Token); k++ {
+		if li.Token[k] != lj.Token[k] {
+			return cmp.Compare(li.Token[k], lj.Token[k])
+		}
+	}
+	return cmp.Compare(len(li.Token), len(lj.Token))
+}
+
+// compareLineExclude compares li and lj for lines in an "exclude" block.
+func compareLineExclude(li, lj *Line) int {
+	if len(li.Token) != 2 || len(lj.Token) != 2 {
+		// Not a known exclude specification.
+		// Fall back to sorting lexicographically.
+		return compareLine(li, lj)
+	}
+	// An exclude specification has two tokens: ModulePath and Version.
+	// Compare module path by string order and version by semver rules.
+	if pi, pj := li.Token[0], lj.Token[0]; pi != pj {
+		return cmp.Compare(pi, pj)
+	}
+	return semver.Compare(li.Token[1], lj.Token[1])
+}
+
+// compareLineRetract compares li and lj for lines in a "retract" block.
+// It treats each line as a version interval. Single versions are compared as
+// if they were intervals with the same low and high version.
+// Intervals are sorted in descending order, first by low version, then by
+// high version, using [semver.Compare].
+func compareLineRetract(li, lj *Line) int {
+	interval := func(l *Line) VersionInterval {
+		if len(l.Token) == 1 {
+			return VersionInterval{Low: l.Token[0], High: l.Token[0]}
+		} else if len(l.Token) == 5 && l.Token[0] == "[" && l.Token[2] == "," && l.Token[4] == "]" {
+			return VersionInterval{Low: l.Token[1], High: l.Token[3]}
+		} else {
+			// Line in unknown format. Treat as an invalid version.
+			return VersionInterval{}
+		}
+	}
+	vii := interval(li)
+	vij := interval(lj)
+	if cmp := semver.Compare(vii.Low, vij.Low); cmp != 0 {
+		return -cmp
+	}
+	return -semver.Compare(vii.High, vij.High)
+}
+
+// checkCanonicalVersion returns a non-nil error if vers is not a canonical
+// version string or does not match the major version of path.
+//
+// If path is non-empty, the error text suggests a format with a major version
+// corresponding to the path.
+func checkCanonicalVersion(path, vers string) error {
+	_, pathMajor, pathMajorOk := module.SplitPathVersion(path)
+
+	if vers == "" || vers != module.CanonicalVersion(vers) {
+		if pathMajor == "" {
+			return &module.InvalidVersionError{
+				Version: vers,
+				Err:     fmt.Errorf("must be of the form v1.2.3"),
+			}
+		}
+		return &module.InvalidVersionError{
+			Version: vers,
+			Err:     fmt.Errorf("must be of the form %s.2.3", module.PathMajorPrefix(pathMajor)),
+		}
+	}
+
+	if pathMajorOk {
+		if err := module.CheckPathMajor(vers, pathMajor); err != nil {
+			if pathMajor == "" {
+				// In this context, the user probably wrote "v2.3.4" when they meant
+				// "v2.3.4+incompatible". Suggest that instead of "v0 or v1".
+				return &module.InvalidVersionError{
+					Version: vers,
+					Err:     fmt.Errorf("should be %s+incompatible (or module %s/%v)", vers, path, semver.Major(vers)),
+				}
+			}
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/golang.org/x/mod/modfile/work.go
+++ b/vendor/golang.org/x/mod/modfile/work.go
@@ -1,0 +1,333 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package modfile
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// A WorkFile is the parsed, interpreted form of a go.work file.
+type WorkFile struct {
+	Go        *Go
+	Toolchain *Toolchain
+	Godebug   []*Godebug
+	Use       []*Use
+	Replace   []*Replace
+
+	Syntax *FileSyntax
+}
+
+// A Use is a single directory statement.
+type Use struct {
+	Path       string // Use path of module.
+	ModulePath string // Module path in the comment.
+	Syntax     *Line
+}
+
+// ParseWork parses and returns a go.work file.
+//
+// file is the name of the file, used in positions and errors.
+//
+// data is the content of the file.
+//
+// fix is an optional function that canonicalizes module versions.
+// If fix is nil, all module versions must be canonical ([module.CanonicalVersion]
+// must return the same string).
+func ParseWork(file string, data []byte, fix VersionFixer) (*WorkFile, error) {
+	fs, err := parse(file, data)
+	if err != nil {
+		return nil, err
+	}
+	f := &WorkFile{
+		Syntax: fs,
+	}
+	var errs ErrorList
+
+	for _, x := range fs.Stmt {
+		switch x := x.(type) {
+		case *Line:
+			f.add(&errs, x, x.Token[0], x.Token[1:], fix)
+
+		case *LineBlock:
+			if len(x.Token) > 1 {
+				errs = append(errs, Error{
+					Filename: file,
+					Pos:      x.Start,
+					Err:      fmt.Errorf("unknown block type: %s", strings.Join(x.Token, " ")),
+				})
+				continue
+			}
+			switch x.Token[0] {
+			default:
+				errs = append(errs, Error{
+					Filename: file,
+					Pos:      x.Start,
+					Err:      fmt.Errorf("unknown block type: %s", strings.Join(x.Token, " ")),
+				})
+				continue
+			case "godebug", "use", "replace":
+				for _, l := range x.Line {
+					f.add(&errs, l, x.Token[0], l.Token, fix)
+				}
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+	return f, nil
+}
+
+// Cleanup cleans up the file f after any edit operations.
+// To avoid quadratic behavior, modifications like [WorkFile.DropRequire]
+// clear the entry but do not remove it from the slice.
+// Cleanup cleans out all the cleared entries.
+func (f *WorkFile) Cleanup() {
+	w := 0
+	for _, r := range f.Use {
+		if r.Path != "" {
+			f.Use[w] = r
+			w++
+		}
+	}
+	f.Use = f.Use[:w]
+
+	w = 0
+	for _, r := range f.Replace {
+		if r.Old.Path != "" {
+			f.Replace[w] = r
+			w++
+		}
+	}
+	f.Replace = f.Replace[:w]
+
+	f.Syntax.Cleanup()
+}
+
+func (f *WorkFile) AddGoStmt(version string) error {
+	if !GoVersionRE.MatchString(version) {
+		return fmt.Errorf("invalid language version %q", version)
+	}
+	if f.Go == nil {
+		stmt := &Line{Token: []string{"go", version}}
+		f.Go = &Go{
+			Version: version,
+			Syntax:  stmt,
+		}
+		// Find the first non-comment-only block and add
+		// the go statement before it. That will keep file comments at the top.
+		i := 0
+		for i = 0; i < len(f.Syntax.Stmt); i++ {
+			if _, ok := f.Syntax.Stmt[i].(*CommentBlock); !ok {
+				break
+			}
+		}
+		f.Syntax.Stmt = append(append(f.Syntax.Stmt[:i:i], stmt), f.Syntax.Stmt[i:]...)
+	} else {
+		f.Go.Version = version
+		f.Syntax.updateLine(f.Go.Syntax, "go", version)
+	}
+	return nil
+}
+
+func (f *WorkFile) AddToolchainStmt(name string) error {
+	if !ToolchainRE.MatchString(name) {
+		return fmt.Errorf("invalid toolchain name %q", name)
+	}
+	if f.Toolchain == nil {
+		stmt := &Line{Token: []string{"toolchain", name}}
+		f.Toolchain = &Toolchain{
+			Name:   name,
+			Syntax: stmt,
+		}
+		// Find the go line and add the toolchain line after it.
+		// Or else find the first non-comment-only block and add
+		// the toolchain line before it. That will keep file comments at the top.
+		i := 0
+		for i = 0; i < len(f.Syntax.Stmt); i++ {
+			if line, ok := f.Syntax.Stmt[i].(*Line); ok && len(line.Token) > 0 && line.Token[0] == "go" {
+				i++
+				goto Found
+			}
+		}
+		for i = 0; i < len(f.Syntax.Stmt); i++ {
+			if _, ok := f.Syntax.Stmt[i].(*CommentBlock); !ok {
+				break
+			}
+		}
+	Found:
+		f.Syntax.Stmt = append(append(f.Syntax.Stmt[:i:i], stmt), f.Syntax.Stmt[i:]...)
+	} else {
+		f.Toolchain.Name = name
+		f.Syntax.updateLine(f.Toolchain.Syntax, "toolchain", name)
+	}
+	return nil
+}
+
+// DropGoStmt deletes the go statement from the file.
+func (f *WorkFile) DropGoStmt() {
+	if f.Go != nil {
+		f.Go.Syntax.markRemoved()
+		f.Go = nil
+	}
+}
+
+// DropToolchainStmt deletes the toolchain statement from the file.
+func (f *WorkFile) DropToolchainStmt() {
+	if f.Toolchain != nil {
+		f.Toolchain.Syntax.markRemoved()
+		f.Toolchain = nil
+	}
+}
+
+// AddGodebug sets the first godebug line for key to value,
+// preserving any existing comments for that line and removing all
+// other godebug lines for key.
+//
+// If no line currently exists for key, AddGodebug adds a new line
+// at the end of the last godebug block.
+func (f *WorkFile) AddGodebug(key, value string) error {
+	need := true
+	for _, g := range f.Godebug {
+		if g.Key == key {
+			if need {
+				g.Value = value
+				f.Syntax.updateLine(g.Syntax, "godebug", key+"="+value)
+				need = false
+			} else {
+				g.Syntax.markRemoved()
+				*g = Godebug{}
+			}
+		}
+	}
+
+	if need {
+		f.addNewGodebug(key, value)
+	}
+	return nil
+}
+
+// addNewGodebug adds a new godebug key=value line at the end
+// of the last godebug block, regardless of any existing godebug lines for key.
+func (f *WorkFile) addNewGodebug(key, value string) {
+	line := f.Syntax.addLine(nil, "godebug", key+"="+value)
+	g := &Godebug{
+		Key:    key,
+		Value:  value,
+		Syntax: line,
+	}
+	f.Godebug = append(f.Godebug, g)
+}
+
+func (f *WorkFile) DropGodebug(key string) error {
+	for _, g := range f.Godebug {
+		if g.Key == key {
+			g.Syntax.markRemoved()
+			*g = Godebug{}
+		}
+	}
+	return nil
+}
+
+func (f *WorkFile) AddUse(diskPath, modulePath string) error {
+	need := true
+	for _, d := range f.Use {
+		if d.Path == diskPath {
+			if need {
+				d.ModulePath = modulePath
+				f.Syntax.updateLine(d.Syntax, "use", AutoQuote(diskPath))
+				need = false
+			} else {
+				d.Syntax.markRemoved()
+				*d = Use{}
+			}
+		}
+	}
+
+	if need {
+		f.AddNewUse(diskPath, modulePath)
+	}
+	return nil
+}
+
+func (f *WorkFile) AddNewUse(diskPath, modulePath string) {
+	line := f.Syntax.addLine(nil, "use", AutoQuote(diskPath))
+	f.Use = append(f.Use, &Use{Path: diskPath, ModulePath: modulePath, Syntax: line})
+}
+
+func (f *WorkFile) SetUse(dirs []*Use) {
+	need := make(map[string]string)
+	for _, d := range dirs {
+		need[d.Path] = d.ModulePath
+	}
+
+	for _, d := range f.Use {
+		if modulePath, ok := need[d.Path]; ok {
+			d.ModulePath = modulePath
+		} else {
+			d.Syntax.markRemoved()
+			*d = Use{}
+		}
+	}
+
+	// TODO(#45713): Add module path to comment.
+
+	for diskPath, modulePath := range need {
+		f.AddNewUse(diskPath, modulePath)
+	}
+	f.SortBlocks()
+}
+
+func (f *WorkFile) DropUse(path string) error {
+	for _, d := range f.Use {
+		if d.Path == path {
+			d.Syntax.markRemoved()
+			*d = Use{}
+		}
+	}
+	return nil
+}
+
+func (f *WorkFile) AddReplace(oldPath, oldVers, newPath, newVers string) error {
+	return addReplace(f.Syntax, &f.Replace, oldPath, oldVers, newPath, newVers)
+}
+
+func (f *WorkFile) DropReplace(oldPath, oldVers string) error {
+	for _, r := range f.Replace {
+		if r.Old.Path == oldPath && r.Old.Version == oldVers {
+			r.Syntax.markRemoved()
+			*r = Replace{}
+		}
+	}
+	return nil
+}
+
+func (f *WorkFile) SortBlocks() {
+	f.removeDups() // otherwise sorting is unsafe
+
+	for _, stmt := range f.Syntax.Stmt {
+		block, ok := stmt.(*LineBlock)
+		if !ok {
+			continue
+		}
+		slices.SortStableFunc(block.Line, compareLine)
+	}
+}
+
+// removeDups removes duplicate replace directives.
+//
+// Later replace directives take priority.
+//
+// require directives are not de-duplicated. That's left up to higher-level
+// logic (MVS).
+//
+// retract directives are not de-duplicated since comments are
+// meaningful, and versions may be retracted multiple times.
+func (f *WorkFile) removeDups() {
+	removeDups(f.Syntax, nil, &f.Replace, nil, nil)
+}

--- a/vendor/golang.org/x/mod/module/module.go
+++ b/vendor/golang.org/x/mod/module/module.go
@@ -1,0 +1,840 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package module defines the module.Version type along with support code.
+//
+// The [module.Version] type is a simple Path, Version pair:
+//
+//	type Version struct {
+//		Path string
+//		Version string
+//	}
+//
+// There are no restrictions imposed directly by use of this structure,
+// but additional checking functions, most notably [Check], verify that
+// a particular path, version pair is valid.
+//
+// # Escaped Paths
+//
+// Module paths appear as substrings of file system paths
+// (in the download cache) and of web server URLs in the proxy protocol.
+// In general we cannot rely on file systems to be case-sensitive,
+// nor can we rely on web servers, since they read from file systems.
+// That is, we cannot rely on the file system to keep rsc.io/QUOTE
+// and rsc.io/quote separate. Windows and macOS don't.
+// Instead, we must never require two different casings of a file path.
+// Because we want the download cache to match the proxy protocol,
+// and because we want the proxy protocol to be possible to serve
+// from a tree of static files (which might be stored on a case-insensitive
+// file system), the proxy protocol must never require two different casings
+// of a URL path either.
+//
+// One possibility would be to make the escaped form be the lowercase
+// hexadecimal encoding of the actual path bytes. This would avoid ever
+// needing different casings of a file path, but it would be fairly illegible
+// to most programmers when those paths appeared in the file system
+// (including in file paths in compiler errors and stack traces)
+// in web server logs, and so on. Instead, we want a safe escaped form that
+// leaves most paths unaltered.
+//
+// The safe escaped form is to replace every uppercase letter
+// with an exclamation mark followed by the letter's lowercase equivalent.
+//
+// For example,
+//
+//	github.com/Azure/azure-sdk-for-go ->  github.com/!azure/azure-sdk-for-go.
+//	github.com/GoogleCloudPlatform/cloudsql-proxy -> github.com/!google!cloud!platform/cloudsql-proxy
+//	github.com/Sirupsen/logrus -> github.com/!sirupsen/logrus.
+//
+// Import paths that avoid upper-case letters are left unchanged.
+// Note that because import paths are ASCII-only and avoid various
+// problematic punctuation (like : < and >), the escaped form is also ASCII-only
+// and avoids the same problematic punctuation.
+//
+// Import paths have never allowed exclamation marks, so there is no
+// need to define how to escape a literal !.
+//
+// # Unicode Restrictions
+//
+// Today, paths are disallowed from using Unicode.
+//
+// Although paths are currently disallowed from using Unicode,
+// we would like at some point to allow Unicode letters as well, to assume that
+// file systems and URLs are Unicode-safe (storing UTF-8), and apply
+// the !-for-uppercase convention for escaping them in the file system.
+// But there are at least two subtle considerations.
+//
+// First, note that not all case-fold equivalent distinct runes
+// form an upper/lower pair.
+// For example, U+004B ('K'), U+006B ('k'), and U+212A ('K' for Kelvin)
+// are three distinct runes that case-fold to each other.
+// When we do add Unicode letters, we must not assume that upper/lower
+// are the only case-equivalent pairs.
+// Perhaps the Kelvin symbol would be disallowed entirely, for example.
+// Or perhaps it would escape as "!!k", or perhaps as "(212A)".
+//
+// Second, it would be nice to allow Unicode marks as well as letters,
+// but marks include combining marks, and then we must deal not
+// only with case folding but also normalization: both U+00E9 ('é')
+// and U+0065 U+0301 ('e' followed by combining acute accent)
+// look the same on the page and are treated by some file systems
+// as the same path. If we do allow Unicode marks in paths, there
+// must be some kind of normalization to allow only one canonical
+// encoding of any character used in an import path.
+package module
+
+// IMPORTANT NOTE
+//
+// This file essentially defines the set of valid import paths for the go command.
+// There are many subtle considerations, including Unicode ambiguity,
+// security, network, and file system representations.
+//
+// This file also defines the set of valid module path and version combinations,
+// another topic with many subtle considerations.
+//
+// Changes to the semantics in this file require approval from rsc.
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/mod/semver"
+)
+
+// A Version (for clients, a module.Version) is defined by a module path and version pair.
+// These are stored in their plain (unescaped) form.
+type Version struct {
+	// Path is a module path, like "golang.org/x/text" or "rsc.io/quote/v2".
+	Path string
+
+	// Version is usually a semantic version in canonical form.
+	// There are three exceptions to this general rule.
+	// First, the top-level target of a build has no specific version
+	// and uses Version = "".
+	// Second, during MVS calculations the version "none" is used
+	// to represent the decision to take no version of a given module.
+	// Third, filesystem paths found in "replace" directives are
+	// represented by a path with an empty version.
+	Version string `json:",omitempty"`
+}
+
+// String returns a representation of the Version suitable for logging
+// (Path@Version, or just Path if Version is empty).
+func (m Version) String() string {
+	if m.Version == "" {
+		return m.Path
+	}
+	return m.Path + "@" + m.Version
+}
+
+// A ModuleError indicates an error specific to a module.
+type ModuleError struct {
+	Path    string
+	Version string
+	Err     error
+}
+
+// VersionError returns a [ModuleError] derived from a [Version] and error,
+// or err itself if it is already such an error.
+func VersionError(v Version, err error) error {
+	var mErr *ModuleError
+	if errors.As(err, &mErr) && mErr.Path == v.Path && mErr.Version == v.Version {
+		return err
+	}
+	return &ModuleError{
+		Path:    v.Path,
+		Version: v.Version,
+		Err:     err,
+	}
+}
+
+func (e *ModuleError) Error() string {
+	if v, ok := e.Err.(*InvalidVersionError); ok {
+		return fmt.Sprintf("%s@%s: invalid %s: %v", e.Path, v.Version, v.noun(), v.Err)
+	}
+	if e.Version != "" {
+		return fmt.Sprintf("%s@%s: %v", e.Path, e.Version, e.Err)
+	}
+	return fmt.Sprintf("module %s: %v", e.Path, e.Err)
+}
+
+func (e *ModuleError) Unwrap() error { return e.Err }
+
+// An InvalidVersionError indicates an error specific to a version, with the
+// module path unknown or specified externally.
+//
+// A [ModuleError] may wrap an InvalidVersionError, but an InvalidVersionError
+// must not wrap a ModuleError.
+type InvalidVersionError struct {
+	Version string
+	Pseudo  bool
+	Err     error
+}
+
+// noun returns either "version" or "pseudo-version", depending on whether
+// e.Version is a pseudo-version.
+func (e *InvalidVersionError) noun() string {
+	if e.Pseudo {
+		return "pseudo-version"
+	}
+	return "version"
+}
+
+func (e *InvalidVersionError) Error() string {
+	return fmt.Sprintf("%s %q invalid: %s", e.noun(), e.Version, e.Err)
+}
+
+func (e *InvalidVersionError) Unwrap() error { return e.Err }
+
+// An InvalidPathError indicates a module, import, or file path doesn't
+// satisfy all naming constraints. See [CheckPath], [CheckImportPath],
+// and [CheckFilePath] for specific restrictions.
+type InvalidPathError struct {
+	Kind string // "module", "import", or "file"
+	Path string
+	Err  error
+}
+
+func (e *InvalidPathError) Error() string {
+	return fmt.Sprintf("malformed %s path %q: %v", e.Kind, e.Path, e.Err)
+}
+
+func (e *InvalidPathError) Unwrap() error { return e.Err }
+
+// Check checks that a given module path, version pair is valid.
+// In addition to the path being a valid module path
+// and the version being a valid semantic version,
+// the two must correspond.
+// For example, the path "yaml/v2" only corresponds to
+// semantic versions beginning with "v2.".
+func Check(path, version string) error {
+	if err := CheckPath(path); err != nil {
+		return err
+	}
+	if !semver.IsValid(version) {
+		return &ModuleError{
+			Path: path,
+			Err:  &InvalidVersionError{Version: version, Err: errors.New("not a semantic version")},
+		}
+	}
+	_, pathMajor, _ := SplitPathVersion(path)
+	if err := CheckPathMajor(version, pathMajor); err != nil {
+		return &ModuleError{Path: path, Err: err}
+	}
+	return nil
+}
+
+// firstPathOK reports whether r can appear in the first element of a module path.
+// The first element of the path must be an LDH domain name, at least for now.
+// To avoid case ambiguity, the domain name must be entirely lower case.
+func firstPathOK(r rune) bool {
+	return r == '-' || r == '.' ||
+		'0' <= r && r <= '9' ||
+		'a' <= r && r <= 'z'
+}
+
+// modPathOK reports whether r can appear in a module path element.
+// Paths can be ASCII letters, ASCII digits, and limited ASCII punctuation: - . _ and ~.
+//
+// This matches what "go get" has historically recognized in import paths,
+// and avoids confusing sequences like '%20' or '+' that would change meaning
+// if used in a URL.
+//
+// TODO(rsc): We would like to allow Unicode letters, but that requires additional
+// care in the safe encoding (see "escaped paths" above).
+func modPathOK(r rune) bool {
+	if r < utf8.RuneSelf {
+		return r == '-' || r == '.' || r == '_' || r == '~' ||
+			'0' <= r && r <= '9' ||
+			'A' <= r && r <= 'Z' ||
+			'a' <= r && r <= 'z'
+	}
+	return false
+}
+
+// importPathOK reports whether r can appear in a package import path element.
+//
+// Import paths are intermediate between module paths and file paths: we
+// disallow characters that would be confusing or ambiguous as arguments to
+// 'go get' (such as '@' and ' ' ), but allow certain characters that are
+// otherwise-unambiguous on the command line and historically used for some
+// binary names (such as '++' as a suffix for compiler binaries and wrappers).
+func importPathOK(r rune) bool {
+	return modPathOK(r) || r == '+'
+}
+
+// fileNameOK reports whether r can appear in a file name.
+// For now we allow all Unicode letters but otherwise limit to pathOK plus a few more punctuation characters.
+// If we expand the set of allowed characters here, we have to
+// work harder at detecting potential case-folding and normalization collisions.
+// See note about "escaped paths" above.
+func fileNameOK(r rune) bool {
+	if r < utf8.RuneSelf {
+		// Entire set of ASCII punctuation, from which we remove characters:
+		//     ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~
+		// We disallow some shell special characters: " ' * < > ? ` |
+		// (Note that some of those are disallowed by the Windows file system as well.)
+		// We also disallow path separators / : and \ (fileNameOK is only called on path element characters).
+		// We allow spaces (U+0020) in file names.
+		const allowed = "!#$%&()+,-.=@[]^_{}~ "
+		if '0' <= r && r <= '9' || 'A' <= r && r <= 'Z' || 'a' <= r && r <= 'z' {
+			return true
+		}
+		return strings.ContainsRune(allowed, r)
+	}
+	// It may be OK to add more ASCII punctuation here, but only carefully.
+	// For example Windows disallows < > \, and macOS disallows :, so we must not allow those.
+	return unicode.IsLetter(r)
+}
+
+// CheckPath checks that a module path is valid.
+// A valid module path is a valid import path, as checked by [CheckImportPath],
+// with three additional constraints.
+// First, the leading path element (up to the first slash, if any),
+// by convention a domain name, must contain only lower-case ASCII letters,
+// ASCII digits, dots (U+002E), and dashes (U+002D);
+// it must contain at least one dot and cannot start with a dash.
+// Second, for a final path element of the form /vN, where N looks numeric
+// (ASCII digits and dots) must not begin with a leading zero, must not be /v1,
+// and must not contain any dots. For paths beginning with "gopkg.in/",
+// this second requirement is replaced by a requirement that the path
+// follow the gopkg.in server's conventions.
+// Third, no path element may begin with a dot.
+func CheckPath(path string) (err error) {
+	defer func() {
+		if err != nil {
+			err = &InvalidPathError{Kind: "module", Path: path, Err: err}
+		}
+	}()
+
+	if err := checkPath(path, modulePath); err != nil {
+		return err
+	}
+	i := strings.Index(path, "/")
+	if i < 0 {
+		i = len(path)
+	}
+	if i == 0 {
+		return fmt.Errorf("leading slash")
+	}
+	if !strings.Contains(path[:i], ".") {
+		return fmt.Errorf("missing dot in first path element")
+	}
+	if path[0] == '-' {
+		return fmt.Errorf("leading dash in first path element")
+	}
+	for _, r := range path[:i] {
+		if !firstPathOK(r) {
+			return fmt.Errorf("invalid char %q in first path element", r)
+		}
+	}
+	if _, _, ok := SplitPathVersion(path); !ok {
+		return fmt.Errorf("invalid version")
+	}
+	return nil
+}
+
+// CheckImportPath checks that an import path is valid.
+//
+// A valid import path consists of one or more valid path elements
+// separated by slashes (U+002F). (It must not begin with nor end in a slash.)
+//
+// A valid path element is a non-empty string made up of
+// ASCII letters, ASCII digits, and limited ASCII punctuation: - . _ and ~.
+// It must not end with a dot (U+002E), nor contain two dots in a row.
+//
+// The element prefix up to the first dot must not be a reserved file name
+// on Windows, regardless of case (CON, com1, NuL, and so on). The element
+// must not have a suffix of a tilde followed by one or more ASCII digits
+// (to exclude paths elements that look like Windows short-names).
+//
+// CheckImportPath may be less restrictive in the future, but see the
+// top-level package documentation for additional information about
+// subtleties of Unicode.
+func CheckImportPath(path string) error {
+	if err := checkPath(path, importPath); err != nil {
+		return &InvalidPathError{Kind: "import", Path: path, Err: err}
+	}
+	return nil
+}
+
+// pathKind indicates what kind of path we're checking. Module paths,
+// import paths, and file paths have different restrictions.
+type pathKind int
+
+const (
+	modulePath pathKind = iota
+	importPath
+	filePath
+)
+
+// checkPath checks that a general path is valid. kind indicates what
+// specific constraints should be applied.
+//
+// checkPath returns an error describing why the path is not valid.
+// Because these checks apply to module, import, and file paths,
+// and because other checks may be applied, the caller is expected to wrap
+// this error with [InvalidPathError].
+func checkPath(path string, kind pathKind) error {
+	if !utf8.ValidString(path) {
+		return fmt.Errorf("invalid UTF-8")
+	}
+	if path == "" {
+		return fmt.Errorf("empty string")
+	}
+	if path[0] == '-' && kind != filePath {
+		return fmt.Errorf("leading dash")
+	}
+	if strings.Contains(path, "//") {
+		return fmt.Errorf("double slash")
+	}
+	if path[len(path)-1] == '/' {
+		return fmt.Errorf("trailing slash")
+	}
+	elemStart := 0
+	for i, r := range path {
+		if r == '/' {
+			if err := checkElem(path[elemStart:i], kind); err != nil {
+				return err
+			}
+			elemStart = i + 1
+		}
+	}
+	if err := checkElem(path[elemStart:], kind); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkElem checks whether an individual path element is valid.
+func checkElem(elem string, kind pathKind) error {
+	if elem == "" {
+		return fmt.Errorf("empty path element")
+	}
+	if strings.Count(elem, ".") == len(elem) {
+		return fmt.Errorf("invalid path element %q", elem)
+	}
+	if elem[0] == '.' && kind == modulePath {
+		return fmt.Errorf("leading dot in path element")
+	}
+	if elem[len(elem)-1] == '.' {
+		return fmt.Errorf("trailing dot in path element")
+	}
+	for _, r := range elem {
+		ok := false
+		switch kind {
+		case modulePath:
+			ok = modPathOK(r)
+		case importPath:
+			ok = importPathOK(r)
+		case filePath:
+			ok = fileNameOK(r)
+		default:
+			panic(fmt.Sprintf("internal error: invalid kind %v", kind))
+		}
+		if !ok {
+			return fmt.Errorf("invalid char %q", r)
+		}
+	}
+
+	// Windows disallows a bunch of path elements, sadly.
+	// See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file
+	short := elem
+	if i := strings.Index(short, "."); i >= 0 {
+		short = short[:i]
+	}
+	for _, bad := range badWindowsNames {
+		if strings.EqualFold(bad, short) {
+			return fmt.Errorf("%q disallowed as path element component on Windows", short)
+		}
+	}
+
+	if kind == filePath {
+		// don't check for Windows short-names in file names. They're
+		// only an issue for import paths.
+		return nil
+	}
+
+	// Reject path components that look like Windows short-names.
+	// Those usually end in a tilde followed by one or more ASCII digits.
+	if tilde := strings.LastIndexByte(short, '~'); tilde >= 0 && tilde < len(short)-1 {
+		suffix := short[tilde+1:]
+		suffixIsDigits := true
+		for _, r := range suffix {
+			if r < '0' || r > '9' {
+				suffixIsDigits = false
+				break
+			}
+		}
+		if suffixIsDigits {
+			return fmt.Errorf("trailing tilde and digits in path element")
+		}
+	}
+
+	return nil
+}
+
+// CheckFilePath checks that a slash-separated file path is valid.
+// The definition of a valid file path is the same as the definition
+// of a valid import path except that the set of allowed characters is larger:
+// all Unicode letters, ASCII digits, the ASCII space character (U+0020),
+// and the ASCII punctuation characters
+// “!#$%&()+,-.=@[]^_{}~”.
+// (The excluded punctuation characters, " * < > ? ` ' | / \ and :,
+// have special meanings in certain shells or operating systems.)
+//
+// CheckFilePath may be less restrictive in the future, but see the
+// top-level package documentation for additional information about
+// subtleties of Unicode.
+func CheckFilePath(path string) error {
+	if err := checkPath(path, filePath); err != nil {
+		return &InvalidPathError{Kind: "file", Path: path, Err: err}
+	}
+	return nil
+}
+
+// badWindowsNames are the reserved file path elements on Windows.
+// See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file
+var badWindowsNames = []string{
+	"CON",
+	"PRN",
+	"AUX",
+	"NUL",
+	"COM1",
+	"COM2",
+	"COM3",
+	"COM4",
+	"COM5",
+	"COM6",
+	"COM7",
+	"COM8",
+	"COM9",
+	"LPT1",
+	"LPT2",
+	"LPT3",
+	"LPT4",
+	"LPT5",
+	"LPT6",
+	"LPT7",
+	"LPT8",
+	"LPT9",
+}
+
+// SplitPathVersion returns prefix and major version such that prefix+pathMajor == path
+// and version is either empty or "/vN" for N >= 2.
+// As a special case, gopkg.in paths are recognized directly;
+// they require ".vN" instead of "/vN", and for all N, not just N >= 2.
+// SplitPathVersion returns with ok = false when presented with
+// a path whose last path element does not satisfy the constraints
+// applied by [CheckPath], such as "example.com/pkg/v1" or "example.com/pkg/v1.2".
+func SplitPathVersion(path string) (prefix, pathMajor string, ok bool) {
+	if strings.HasPrefix(path, "gopkg.in/") {
+		return splitGopkgIn(path)
+	}
+
+	i := len(path)
+	dot := false
+	for i > 0 && ('0' <= path[i-1] && path[i-1] <= '9' || path[i-1] == '.') {
+		if path[i-1] == '.' {
+			dot = true
+		}
+		i--
+	}
+	if i <= 1 || i == len(path) || path[i-1] != 'v' || path[i-2] != '/' {
+		return path, "", true
+	}
+	prefix, pathMajor = path[:i-2], path[i-2:]
+	if dot || len(pathMajor) <= 2 || pathMajor[2] == '0' || pathMajor == "/v1" {
+		return path, "", false
+	}
+	return prefix, pathMajor, true
+}
+
+// splitGopkgIn is like SplitPathVersion but only for gopkg.in paths.
+func splitGopkgIn(path string) (prefix, pathMajor string, ok bool) {
+	if !strings.HasPrefix(path, "gopkg.in/") {
+		return path, "", false
+	}
+	i := len(path)
+	if strings.HasSuffix(path, "-unstable") {
+		i -= len("-unstable")
+	}
+	for i > 0 && ('0' <= path[i-1] && path[i-1] <= '9') {
+		i--
+	}
+	if i <= 1 || path[i-1] != 'v' || path[i-2] != '.' {
+		// All gopkg.in paths must end in vN for some N.
+		return path, "", false
+	}
+	prefix, pathMajor = path[:i-2], path[i-2:]
+	if len(pathMajor) <= 2 || pathMajor[2] == '0' && pathMajor != ".v0" {
+		return path, "", false
+	}
+	return prefix, pathMajor, true
+}
+
+// MatchPathMajor reports whether the semantic version v
+// matches the path major version pathMajor.
+//
+// MatchPathMajor returns true if and only if [CheckPathMajor] returns nil.
+func MatchPathMajor(v, pathMajor string) bool {
+	return CheckPathMajor(v, pathMajor) == nil
+}
+
+// CheckPathMajor returns a non-nil error if the semantic version v
+// does not match the path major version pathMajor.
+func CheckPathMajor(v, pathMajor string) error {
+	// TODO(jayconrod): return errors or panic for invalid inputs. This function
+	// (and others) was covered by integration tests for cmd/go, and surrounding
+	// code protected against invalid inputs like non-canonical versions.
+	if strings.HasPrefix(pathMajor, ".v") && strings.HasSuffix(pathMajor, "-unstable") {
+		pathMajor = strings.TrimSuffix(pathMajor, "-unstable")
+	}
+	if strings.HasPrefix(v, "v0.0.0-") && pathMajor == ".v1" {
+		// Allow old bug in pseudo-versions that generated v0.0.0- pseudoversion for gopkg .v1.
+		// For example, gopkg.in/yaml.v2@v2.2.1's go.mod requires gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405.
+		return nil
+	}
+	m := semver.Major(v)
+	if pathMajor == "" {
+		if m == "v0" || m == "v1" || semver.Build(v) == "+incompatible" {
+			return nil
+		}
+		pathMajor = "v0 or v1"
+	} else if pathMajor[0] == '/' || pathMajor[0] == '.' {
+		if m == pathMajor[1:] {
+			return nil
+		}
+		pathMajor = pathMajor[1:]
+	}
+	return &InvalidVersionError{
+		Version: v,
+		Err:     fmt.Errorf("should be %s, not %s", pathMajor, semver.Major(v)),
+	}
+}
+
+// PathMajorPrefix returns the major-version tag prefix implied by pathMajor.
+// An empty PathMajorPrefix allows either v0 or v1.
+//
+// Note that [MatchPathMajor] may accept some versions that do not actually begin
+// with this prefix: namely, it accepts a 'v0.0.0-' prefix for a '.v1'
+// pathMajor, even though that pathMajor implies 'v1' tagging.
+func PathMajorPrefix(pathMajor string) string {
+	if pathMajor == "" {
+		return ""
+	}
+	if pathMajor[0] != '/' && pathMajor[0] != '.' {
+		panic("pathMajor suffix " + pathMajor + " passed to PathMajorPrefix lacks separator")
+	}
+	if strings.HasPrefix(pathMajor, ".v") && strings.HasSuffix(pathMajor, "-unstable") {
+		pathMajor = strings.TrimSuffix(pathMajor, "-unstable")
+	}
+	m := pathMajor[1:]
+	if m != semver.Major(m) {
+		panic("pathMajor suffix " + pathMajor + "passed to PathMajorPrefix is not a valid major version")
+	}
+	return m
+}
+
+// CanonicalVersion returns the canonical form of the version string v.
+// It is the same as [semver.Canonical] except that it preserves the special build suffix "+incompatible".
+func CanonicalVersion(v string) string {
+	cv := semver.Canonical(v)
+	if semver.Build(v) == "+incompatible" {
+		cv += "+incompatible"
+	}
+	return cv
+}
+
+// Sort sorts the list by Path, breaking ties by comparing [Version] fields.
+// The Version fields are interpreted as semantic versions (using [semver.Compare])
+// optionally followed by a tie-breaking suffix introduced by a slash character,
+// like in "v0.0.1/go.mod".
+func Sort(list []Version) {
+	slices.SortFunc(list, func(i, j Version) int {
+		if i.Path != j.Path {
+			return strings.Compare(i.Path, j.Path)
+		}
+		// To help go.sum formatting, allow version/file.
+		// Compare semver prefix by semver rules,
+		// file by string order.
+		vi := i.Version
+		vj := j.Version
+		var fi, fj string
+		if k := strings.Index(vi, "/"); k >= 0 {
+			vi, fi = vi[:k], vi[k:]
+		}
+		if k := strings.Index(vj, "/"); k >= 0 {
+			vj, fj = vj[:k], vj[k:]
+		}
+		if vi != vj {
+			return semver.Compare(vi, vj)
+		}
+		return cmp.Compare(fi, fj)
+	})
+}
+
+// EscapePath returns the escaped form of the given module path.
+// It fails if the module path is invalid.
+func EscapePath(path string) (escaped string, err error) {
+	if err := CheckPath(path); err != nil {
+		return "", err
+	}
+
+	return escapeString(path)
+}
+
+// EscapeVersion returns the escaped form of the given module version.
+// Versions are allowed to be in non-semver form but must be valid file names
+// and not contain exclamation marks.
+func EscapeVersion(v string) (escaped string, err error) {
+	if err := checkElem(v, filePath); err != nil || strings.Contains(v, "!") {
+		return "", &InvalidVersionError{
+			Version: v,
+			Err:     fmt.Errorf("disallowed version string"),
+		}
+	}
+	return escapeString(v)
+}
+
+func escapeString(s string) (escaped string, err error) {
+	haveUpper := false
+	for _, r := range s {
+		if r == '!' || r >= utf8.RuneSelf {
+			// This should be disallowed by CheckPath, but diagnose anyway.
+			// The correctness of the escaping loop below depends on it.
+			return "", fmt.Errorf("internal error: inconsistency in EscapePath")
+		}
+		if 'A' <= r && r <= 'Z' {
+			haveUpper = true
+		}
+	}
+
+	if !haveUpper {
+		return s, nil
+	}
+
+	var buf []byte
+	for _, r := range s {
+		if 'A' <= r && r <= 'Z' {
+			buf = append(buf, '!', byte(r+'a'-'A'))
+		} else {
+			buf = append(buf, byte(r))
+		}
+	}
+	return string(buf), nil
+}
+
+// UnescapePath returns the module path for the given escaped path.
+// It fails if the escaped path is invalid or describes an invalid path.
+func UnescapePath(escaped string) (path string, err error) {
+	path, ok := unescapeString(escaped)
+	if !ok {
+		return "", fmt.Errorf("invalid escaped module path %q", escaped)
+	}
+	if err := CheckPath(path); err != nil {
+		return "", fmt.Errorf("invalid escaped module path %q: %v", escaped, err)
+	}
+	return path, nil
+}
+
+// UnescapeVersion returns the version string for the given escaped version.
+// It fails if the escaped form is invalid or describes an invalid version.
+// Versions are allowed to be in non-semver form but must be valid file names
+// and not contain exclamation marks.
+func UnescapeVersion(escaped string) (v string, err error) {
+	v, ok := unescapeString(escaped)
+	if !ok {
+		return "", fmt.Errorf("invalid escaped version %q", escaped)
+	}
+	if err := checkElem(v, filePath); err != nil {
+		return "", fmt.Errorf("invalid escaped version %q: %v", v, err)
+	}
+	return v, nil
+}
+
+func unescapeString(escaped string) (string, bool) {
+	var buf []byte
+
+	bang := false
+	for _, r := range escaped {
+		if r >= utf8.RuneSelf {
+			return "", false
+		}
+		if bang {
+			bang = false
+			if r < 'a' || 'z' < r {
+				return "", false
+			}
+			buf = append(buf, byte(r+'A'-'a'))
+			continue
+		}
+		if r == '!' {
+			bang = true
+			continue
+		}
+		if 'A' <= r && r <= 'Z' {
+			return "", false
+		}
+		buf = append(buf, byte(r))
+	}
+	if bang {
+		return "", false
+	}
+	return string(buf), true
+}
+
+// MatchPrefixPatterns reports whether any path prefix of target matches one of
+// the glob patterns (as defined by [path.Match]) in the comma-separated globs
+// list. This implements the algorithm used when matching a module path to the
+// GOPRIVATE environment variable, as described by 'go help module-private'.
+//
+// It ignores any empty or malformed patterns in the list.
+// Trailing slashes on patterns are ignored.
+func MatchPrefixPatterns(globs, target string) bool {
+	for globs != "" {
+		// Extract next non-empty glob in comma-separated list.
+		var glob string
+		if before, after, ok := strings.Cut(globs, ","); ok {
+			glob, globs = before, after
+		} else {
+			glob, globs = globs, ""
+		}
+		glob = strings.TrimSuffix(glob, "/")
+		if glob == "" {
+			continue
+		}
+
+		// A glob with N+1 path elements (N slashes) needs to be matched
+		// against the first N+1 path elements of target,
+		// which end just before the N+1'th slash.
+		n := strings.Count(glob, "/")
+		prefix := target
+		// Walk target, counting slashes, truncating at the N+1'th slash.
+		for i := 0; i < len(target); i++ {
+			if target[i] == '/' {
+				if n == 0 {
+					prefix = target[:i]
+					break
+				}
+				n--
+			}
+		}
+		if n > 0 {
+			// Not enough prefix elements.
+			continue
+		}
+		matched, _ := path.Match(glob, prefix)
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/golang.org/x/mod/module/pseudo.go
+++ b/vendor/golang.org/x/mod/module/pseudo.go
@@ -1,0 +1,250 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Pseudo-versions
+//
+// Code authors are expected to tag the revisions they want users to use,
+// including prereleases. However, not all authors tag versions at all,
+// and not all commits a user might want to try will have tags.
+// A pseudo-version is a version with a special form that allows us to
+// address an untagged commit and order that version with respect to
+// other versions we might encounter.
+//
+// A pseudo-version takes one of the general forms:
+//
+//	(1) vX.0.0-yyyymmddhhmmss-abcdef123456
+//	(2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+//	(3) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456+incompatible
+//	(4) vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456
+//	(5) vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456+incompatible
+//
+// If there is no recently tagged version with the right major version vX,
+// then form (1) is used, creating a space of pseudo-versions at the bottom
+// of the vX version range, less than any tagged version, including the unlikely v0.0.0.
+//
+// If the most recent tagged version before the target commit is vX.Y.Z or vX.Y.Z+incompatible,
+// then the pseudo-version uses form (2) or (3), making it a prerelease for the next
+// possible semantic version after vX.Y.Z. The leading 0 segment in the prerelease string
+// ensures that the pseudo-version compares less than possible future explicit prereleases
+// like vX.Y.(Z+1)-rc1 or vX.Y.(Z+1)-1.
+//
+// If the most recent tagged version before the target commit is vX.Y.Z-pre or vX.Y.Z-pre+incompatible,
+// then the pseudo-version uses form (4) or (5), making it a slightly later prerelease.
+
+package module
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/internal/lazyregexp"
+	"golang.org/x/mod/semver"
+)
+
+var pseudoVersionRE = lazyregexp.New(`^v[0-9]+\.(0\.0-|\d+\.\d+-([^+]*\.)?0\.)\d{14}-[A-Za-z0-9]+(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$`)
+
+const PseudoVersionTimestampFormat = "20060102150405"
+
+// PseudoVersion returns a pseudo-version for the given major version ("v1")
+// preexisting older tagged version ("" or "v1.2.3" or "v1.2.3-pre"), revision time,
+// and revision identifier (usually a 12-byte commit hash prefix).
+func PseudoVersion(major, older string, t time.Time, rev string) string {
+	if major == "" {
+		major = "v0"
+	}
+	segment := fmt.Sprintf("%s-%s", t.UTC().Format(PseudoVersionTimestampFormat), rev)
+	build := semver.Build(older)
+	older = semver.Canonical(older)
+	if older == "" {
+		return major + ".0.0-" + segment // form (1)
+	}
+	if semver.Prerelease(older) != "" {
+		return older + ".0." + segment + build // form (4), (5)
+	}
+
+	// Form (2), (3).
+	// Extract patch from vMAJOR.MINOR.PATCH
+	i := strings.LastIndex(older, ".") + 1
+	v, patch := older[:i], older[i:]
+
+	// Reassemble.
+	return v + incDecimal(patch) + "-0." + segment + build
+}
+
+// ZeroPseudoVersion returns a pseudo-version with a zero timestamp and
+// revision, which may be used as a placeholder.
+func ZeroPseudoVersion(major string) string {
+	return PseudoVersion(major, "", time.Time{}, "000000000000")
+}
+
+// incDecimal returns the decimal string incremented by 1.
+func incDecimal(decimal string) string {
+	// Scan right to left turning 9s to 0s until you find a digit to increment.
+	digits := []byte(decimal)
+	i := len(digits) - 1
+	for ; i >= 0 && digits[i] == '9'; i-- {
+		digits[i] = '0'
+	}
+	if i >= 0 {
+		digits[i]++
+	} else {
+		// digits is all zeros
+		digits[0] = '1'
+		digits = append(digits, '0')
+	}
+	return string(digits)
+}
+
+// decDecimal returns the decimal string decremented by 1, or the empty string
+// if the decimal is all zeroes.
+func decDecimal(decimal string) string {
+	// Scan right to left turning 0s to 9s until you find a digit to decrement.
+	digits := []byte(decimal)
+	i := len(digits) - 1
+	for ; i >= 0 && digits[i] == '0'; i-- {
+		digits[i] = '9'
+	}
+	if i < 0 {
+		// decimal is all zeros
+		return ""
+	}
+	if i == 0 && digits[i] == '1' && len(digits) > 1 {
+		digits = digits[1:]
+	} else {
+		digits[i]--
+	}
+	return string(digits)
+}
+
+// IsPseudoVersion reports whether v is a pseudo-version.
+func IsPseudoVersion(v string) bool {
+	return strings.Count(v, "-") >= 2 && semver.IsValid(v) && pseudoVersionRE.MatchString(v)
+}
+
+// IsZeroPseudoVersion returns whether v is a pseudo-version with a zero base,
+// timestamp, and revision, as returned by [ZeroPseudoVersion].
+func IsZeroPseudoVersion(v string) bool {
+	return v == ZeroPseudoVersion(semver.Major(v))
+}
+
+// PseudoVersionTime returns the time stamp of the pseudo-version v.
+// It returns an error if v is not a pseudo-version or if the time stamp
+// embedded in the pseudo-version is not a valid time.
+func PseudoVersionTime(v string) (time.Time, error) {
+	_, timestamp, _, _, err := parsePseudoVersion(v)
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := time.Parse("20060102150405", timestamp)
+	if err != nil {
+		return time.Time{}, &InvalidVersionError{
+			Version: v,
+			Pseudo:  true,
+			Err:     fmt.Errorf("malformed time %q", timestamp),
+		}
+	}
+	return t, nil
+}
+
+// PseudoVersionRev returns the revision identifier of the pseudo-version v.
+// It returns an error if v is not a pseudo-version.
+func PseudoVersionRev(v string) (rev string, err error) {
+	_, _, rev, _, err = parsePseudoVersion(v)
+	return
+}
+
+// PseudoVersionBase returns the canonical parent version, if any, upon which
+// the pseudo-version v is based.
+//
+// If v has no parent version (that is, if it is "vX.0.0-[…]"),
+// PseudoVersionBase returns the empty string and a nil error.
+func PseudoVersionBase(v string) (string, error) {
+	base, _, _, build, err := parsePseudoVersion(v)
+	if err != nil {
+		return "", err
+	}
+
+	switch pre := semver.Prerelease(base); pre {
+	case "":
+		// vX.0.0-yyyymmddhhmmss-abcdef123456 → ""
+		if build != "" {
+			// Pseudo-versions of the form vX.0.0-yyyymmddhhmmss-abcdef123456+incompatible
+			// are nonsensical: the "vX.0.0-" prefix implies that there is no parent tag,
+			// but the "+incompatible" suffix implies that the major version of
+			// the parent tag is not compatible with the module's import path.
+			//
+			// There are a few such entries in the index generated by proxy.golang.org,
+			// but we believe those entries were generated by the proxy itself.
+			return "", &InvalidVersionError{
+				Version: v,
+				Pseudo:  true,
+				Err:     fmt.Errorf("lacks base version, but has build metadata %q", build),
+			}
+		}
+		return "", nil
+
+	case "-0":
+		// vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456 → vX.Y.Z
+		// vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456+incompatible → vX.Y.Z+incompatible
+		base = strings.TrimSuffix(base, pre)
+		i := strings.LastIndexByte(base, '.')
+		if i < 0 {
+			panic("base from parsePseudoVersion missing patch number: " + base)
+		}
+		patch := decDecimal(base[i+1:])
+		if patch == "" {
+			// vX.0.0-0 is invalid, but has been observed in the wild in the index
+			// generated by requests to proxy.golang.org.
+			//
+			// NOTE(bcmills): I cannot find a historical bug that accounts for
+			// pseudo-versions of this form, nor have I seen such versions in any
+			// actual go.mod files. If we find actual examples of this form and a
+			// reasonable theory of how they came into existence, it seems fine to
+			// treat them as equivalent to vX.0.0 (especially since the invalid
+			// pseudo-versions have lower precedence than the real ones). For now, we
+			// reject them.
+			return "", &InvalidVersionError{
+				Version: v,
+				Pseudo:  true,
+				Err:     fmt.Errorf("version before %s would have negative patch number", base),
+			}
+		}
+		return base[:i+1] + patch + build, nil
+
+	default:
+		// vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456 → vX.Y.Z-pre
+		// vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456+incompatible → vX.Y.Z-pre+incompatible
+		if !strings.HasSuffix(base, ".0") {
+			panic(`base from parsePseudoVersion missing ".0" before date: ` + base)
+		}
+		return strings.TrimSuffix(base, ".0") + build, nil
+	}
+}
+
+var errPseudoSyntax = errors.New("syntax error")
+
+func parsePseudoVersion(v string) (base, timestamp, rev, build string, err error) {
+	if !IsPseudoVersion(v) {
+		return "", "", "", "", &InvalidVersionError{
+			Version: v,
+			Pseudo:  true,
+			Err:     errPseudoSyntax,
+		}
+	}
+	build = semver.Build(v)
+	v = strings.TrimSuffix(v, build)
+	j := strings.LastIndex(v, "-")
+	v, rev = v[:j], v[j+1:]
+	i := strings.LastIndex(v, "-")
+	if j := strings.LastIndex(v, "."); j > i {
+		base = v[:j] // "vX.Y.Z-pre.0" or "vX.Y.(Z+1)-0"
+		timestamp = v[j+1:]
+	} else {
+		base = v[:i] // "vX.0.0"
+		timestamp = v[i+1:]
+	}
+	return base, timestamp, rev, build, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,6 +68,9 @@ github.com/wk8/go-ordered-map/v2
 golang.org/x/exp/constraints
 # golang.org/x/mod v0.32.0
 ## explicit; go 1.24.0
+golang.org/x/mod/internal/lazyregexp
+golang.org/x/mod/modfile
+golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/sync v0.19.0
 ## explicit; go 1.24.0


### PR DESCRIPTION
## Summary

- Adds `WorkspacePatterns()` that detects `go.work`, parses `use` directives via `golang.org/x/mod/modfile`, and generates per-module load patterns for `go/packages`
- Wires into `cmd/index.go` (primary, fail-loud) and `internal/index/loader.go` (defensive fallback)
- Before: `snipe index` on a go.work workspace loaded 2 packages (root module only)
- After: loads 108 packages across all 7 workspace modules (verified on trixi)

Closes #132

## Test plan

- [x] 5 unit tests for `WorkspacePatterns` (go.work present, absent, malformed, empty use, nonexistent dir)
- [x] Blackbox test: multi-module workspace fixture, index + `def` cross-module lookup
- [x] `mage qa` passes (488 unit + 93 blackbox tests, race detector clean)
- [x] Manual verification on trixi: 108 packages, 5255 symbols, cross-module `def Store` resolves to `store/store.go`