### PR TITLE
feat: emit detected SQLite schema in snipe context

### DIFF
--- a/.claude/rules/CLAUDE.md
+++ b/.claude/rules/CLAUDE.md
@@ -31,7 +31,8 @@ snipe def --at file:L:C      # definition at position
 snipe refs/callers/callees   # graph traversal
 snipe show <hex-id>          # expand by 16-char ID
 snipe search "pattern"       # ripgrep fallback
-snipe context --boot         # LLM boot context with entry points, flows, boundaries
+snipe context                # Claude-optimized orientation (entry points, flows, boundaries)
+snipe context --full         # Full architecture dump
 ```
 
 ## focus

--- a/BASELINE_ORCA.json
+++ b/BASELINE_ORCA.json
@@ -1,35 +1,37 @@
 {
-  "timestamp": "2026-03-08T18:13:11Z",
-  "git_commit": "511eee08",
-  "go_version": "go1.25.8",
+  "timestamp": "2026-04-16T15:34:57Z",
+  "git_commit": "972a433e",
+  "go_version": "go1.26.2",
   "codebase": {
-    "go_files": 428,
-    "symbols": 7732,
-    "refs": 22538,
-    "call_edges": 8236,
-    "db_size_kb": 27072
+    "name": "orca",
+    "path": "/Users/vcto/projects/orca",
+    "go_files": 427,
+    "symbols": 7690,
+    "refs": 22369,
+    "call_edges": 7945,
+    "db_size_kb": 26800
   },
   "index": {
-    "total_ms": 60942,
-    "load_ms": 30542,
-    "extract_ms": 16392,
-    "persist_ms": 13804,
-    "peak_mem_mb": 1566
+    "total_ms": 5433,
+    "load_ms": 3375,
+    "extract_ms": 1098,
+    "persist_ms": 951,
+    "peak_mem_mb": 1108
   },
   "query": {
-    "def_by_name_ms": 1.02632,
-    "def_by_pos_ms": 2.22699,
-    "refs_by_id_ms": 2.04711
+    "def_by_name_ms": 0.03616,
+    "def_by_pos_ms": 0.01409,
+    "refs_by_id_ms": 0.09888
   },
   "search": {
-    "simple_pattern_ms": 11.497399999999999,
-    "regex_pattern_ms": 18.41087
+    "simple_pattern_ms": 11.695229999999999,
+    "regex_pattern_ms": 20.85208
   },
   "quality": {
-    "symbols_with_doc": 4533,
-    "symbols_with_sig": 7732,
-    "doc_coverage_pct": 58.62648732540093,
-    "refs_per_symbol": 2.9148991205380237,
-    "callgraph_coverage_pct": 126.9208549971115
+    "symbols_with_doc": 4507,
+    "symbols_with_sig": 7690,
+    "doc_coverage_pct": 58.60858257477243,
+    "refs_per_symbol": 2.9088426527958386,
+    "callgraph_coverage_pct": 125.60693641618496
   }
 }

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The optional enrichment layer adds semantic embeddings (for similarity search) a
 | `pack [symbol]` | Definition + refs + callers + callees + role + purpose |
 | `sym [symbol]` | Definition + refs + callers + callees |
 | `explain [symbol]` | Structured function explanation with mechanism steps |
-| `context [path]` | LLM-optimized project architecture summary |
+| `context [path]` | Claude-optimized orientation (~5k tokens); `--full` for full architecture dump |
 
 ### Type system
 
@@ -139,14 +139,14 @@ snipe index --force                            # Force full re-index
 |------|--------|
 | `--at file:line:col` | Query by source position |
 | `--with-body` | Include full function/method body |
-| `--limit N` | Cap results (default: 50) |
+| `--limit N` | Cap results (default: 10) |
 | `--offset N` | Skip first N results |
-| `--context N` | Surrounding lines per match (default: 3) |
-| `--format` | `concise` (default), `detailed`, or `summary` |
+| `--context N` | Surrounding lines per match (default: 2) |
+| `--format` | `concise` (default), `detailed`, `summary`, or `json` |
 | `--select` | `all` (default), `best`, `top3`, `top5` |
 | `--max-tokens N` | Truncate output to fit a token budget |
 | `--signature-only` | Signature only, no body or context |
-| `--human` | Pretty-print for terminal use |
+| `--no-body` | Exclude function body |
 
 ## Output format
 

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -45,7 +45,7 @@ Examples:
 }
 
 func init() {
-	contextCmd.Flags().StringVar(&contextFormat, "format", "json", "Output format: json or yaml")
+	contextCmd.Flags().StringVar(&contextFormat, "format", "", "Structured output format: json or yaml (default: claudish text)")
 	contextCmd.Flags().BoolVar(&contextFull, "full", false, "Full architecture dump (all components, flows, boundaries)")
 	contextCmd.Flags().BoolVar(&contextOrient, "orient", false, "Claude-optimized orientation (default)")
 	contextCmd.Flags().BoolVar(&contextOutputNug, "output-nug", false, "Output as Orca nugget YAML (for save_nug)")

--- a/cmd/def.go
+++ b/cmd/def.go
@@ -54,8 +54,8 @@ func runDef(cmd *cobra.Command, args []string) error {
 	compact, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
 	format := GetResponseFormat()
 
-	// Apply format overrides
-	withBody, withSiblings, contextLines = ApplyFormatOverrides(format, withBody, withSiblings, contextLines)
+	// Apply format overrides; def always shows body unless --no-body is explicit.
+	_, withSiblings, contextLines = ApplyFormatOverrides(format, withBody, withSiblings, contextLines)
 
 	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
 

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -44,9 +44,9 @@ Examples:
 
 func init() {
 	packCmd.Flags().StringVar(&packAt, "at", "", "Position to look up (file:line:col)")
-	packCmd.Flags().IntVar(&packRefsLimit, "refs-limit", 20, "Maximum references to return")
-	packCmd.Flags().IntVar(&packCallersLimit, "callers-limit", 10, "Maximum callers to return")
-	packCmd.Flags().IntVar(&packCalleesLimit, "callees-limit", 10, "Maximum callees to return")
+	packCmd.Flags().IntVar(&packRefsLimit, "refs-limit", 5, "Maximum references to return")
+	packCmd.Flags().IntVar(&packCallersLimit, "callers-limit", 5, "Maximum callers to return")
+	packCmd.Flags().IntVar(&packCalleesLimit, "callees-limit", 5, "Maximum callees to return")
 	rootCmd.AddCommand(packCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,9 @@ var (
 	// KG integration
 	withKGHints bool
 
+	// Opt-in suggestion output (off by default in Claude mode)
+	showSuggestions bool
+
 	// Selection mode for multi-result commands
 	selectMode string
 
@@ -111,6 +114,9 @@ var rootCmd = &cobra.Command{
 		// Auto-compact when output is piped (not a TTY)
 		autoCompact = true
 
+		// Wire suggestion opt-in into output package
+		output.SetShowSuggestions(showSuggestions)
+
 		return nil
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -178,15 +184,16 @@ func init() {
 		&cobra.Group{ID: "advanced", Title: "Advanced Commands:"},
 	)
 
-	rootCmd.PersistentFlags().IntVar(&limit, "limit", 50, "Cap results")
+	rootCmd.PersistentFlags().IntVar(&limit, "limit", 10, "Cap results")
 	rootCmd.PersistentFlags().IntVar(&offset, "offset", 0, "Pagination offset")
-	rootCmd.PersistentFlags().IntVar(&contextLines, "context", 3, "Context lines around match")
+	rootCmd.PersistentFlags().IntVar(&contextLines, "context", 2, "Context lines around match")
 	rootCmd.PersistentFlags().BoolVar(&noBody, "no-body", false, "Exclude function body")
 	rootCmd.PersistentFlags().BoolVar(&noSiblings, "no-siblings", false, "Exclude sibling declarations")
 	rootCmd.PersistentFlags().BoolVar(&signatureOnly, "signature-only", false, "Return only signature (no body, no context)")
 	rootCmd.PersistentFlags().IntVar(&maxTokens, "max-tokens", 0, "Token budget (0 = unlimited)")
-	rootCmd.PersistentFlags().StringVar(&responseFormat, "format", "", "concise | detailed | summary | json")
+	rootCmd.PersistentFlags().StringVar(&responseFormat, "format", "concise", "concise | detailed | summary | json")
 	rootCmd.PersistentFlags().BoolVar(&withKGHints, "kg-hints", false, "Include Orca KG hints")
+	rootCmd.PersistentFlags().BoolVar(&showSuggestions, "suggestions", false, "Include next-step suggestions in Claude output")
 	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 0, "Timeout for command (e.g., 30s, 5m)")
 	rootCmd.PersistentFlags().StringVar(&selectMode, "select", "all", "Result selection: all, best, top3, top5")
 	// Reserved for orca telemetry — hidden until persistToolCall is wired.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -9,7 +9,7 @@ Go code nav CLI for LLMs. Static indexing, <50ms queries, Claude-optimized outpu
 Goal: replace `go_symbol()` + Explore agents in orca.
 
 Integration: orca calls snipe as subprocess. Commands consumed:
-`def`, `refs`, `callers`, `callees`, `search`, `pack`, `show`, `context --boot`.
+`def`, `refs`, `callers`, `callees`, `search`, `pack`, `show`, `context`.
 
 ---
 
@@ -193,6 +193,19 @@ Default output changed from JSON envelope to Claude-optimized structured text.
 | #123 | index: repo root detection causes misleading MISSING_INDEX errors | #130 | FindProjectRoot in internal/util, OpenStore resolves git root, doctor mismatch check, blackbox test |
 | #121 | search: 0 results with no_index degradation after indexing | #131 | LookupByName fallback between rg and semantic, renamed no_index → rg_only |
 | — | simplify review | c344076 | search.go resolves git root for store, cached Exists in OpenStore, renamed usedIndexFallback → indexFallbackFound |
+
+---
+
+## Context output quality (2026-04-16)
+
+| Change | Commit | Notes |
+|--------|--------|-------|
+| Command purposes, flow diversity, callee ranking | ad42a17 | context.go enrichment improvements |
+| Test exclusion, placeholder purposes, truncation | 76c518e | cleaner boot context output |
+| format_text.go: compact claudish rendering | 5bcb91a | no markdown tables, emDash→∅ |
+| LLM-optimal defaults (#136) | 5bcb91a | --limit 10, --context 2, --format concise; pack sub-limits 5/5/5 |
+| def: preserve body with --format concise | 5bcb91a | def always shows body unless --no-body |
+| Closed #134 | — | --boot→--orient already done in code |
 
 ---
 

--- a/internal/context/conventions_test.go
+++ b/internal/context/conventions_test.go
@@ -290,6 +290,7 @@ func TestDetectFileOrg_NearEqual(t *testing.T) {
 	result := detectFileOrg(db)
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 	// 3 single vs 2 multi — ratio = 3/5 = 0.60, below 70% threshold → mixed
 	if result.Pattern != patternMixed {

--- a/internal/context/dbschema.go
+++ b/internal/context/dbschema.go
@@ -103,6 +103,11 @@ func detectMigrations(repoRoot string) (DBSchema, bool) {
 			buf.WriteString("-- " + filepath.Base(f) + "\n")
 			buf.Write(content)
 		}
+		// Skip directories containing only DML/seed data — no CREATE statements
+		// means nothing Claude can use to reason about schema.
+		if !ddlRe.MatchString(buf.String()) {
+			continue
+		}
 		return DBSchema{
 			Source: relPath(repoRoot, dir),
 			Name:   "migrations",
@@ -173,24 +178,74 @@ func detectEmbeddedGo(repoRoot string) []DBSchema {
 
 // extractGoDDL pulls the contents of every backtick raw string literal in src
 // that contains a CREATE statement. Returns concatenated DDL, or "" if none.
+//
+// The scanner skips backticks inside line comments (// ... \n), block comments
+// (/* ... */), and double-quoted strings ("..."), which prevents a stray
+// backtick in a doc comment above a DDL constant from swallowing the real
+// literal.
 func extractGoDDL(src string) string {
 	var parts []string
-	remaining := src
-	for {
-		start := strings.IndexByte(remaining, '`')
-		if start < 0 {
-			break
+	i := 0
+	for i < len(src) {
+		c := src[i]
+		switch {
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			// Line comment — skip to newline.
+			if nl := strings.IndexByte(src[i:], '\n'); nl >= 0 {
+				i += nl + 1
+			} else {
+				i = len(src)
+			}
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			// Block comment — skip to closing */.
+			if end := strings.Index(src[i+2:], "*/"); end >= 0 {
+				i += end + 4
+			} else {
+				i = len(src)
+			}
+		case c == '"':
+			// Double-quoted string — skip to matching quote, honoring backslash escapes.
+			j := i + 1
+			for j < len(src) {
+				if src[j] == '\\' && j+1 < len(src) {
+					j += 2
+					continue
+				}
+				if src[j] == '"' || src[j] == '\n' {
+					break
+				}
+				j++
+			}
+			i = j + 1
+		case c == '\'':
+			// Rune literal — same skip-with-escape logic.
+			j := i + 1
+			for j < len(src) {
+				if src[j] == '\\' && j+1 < len(src) {
+					j += 2
+					continue
+				}
+				if src[j] == '\'' || src[j] == '\n' {
+					break
+				}
+				j++
+			}
+			i = j + 1
+		case c == '`':
+			// Raw string literal — content runs until next backtick (no escapes).
+			end := strings.IndexByte(src[i+1:], '`')
+			if end < 0 {
+				i = len(src)
+				continue
+			}
+			literal := src[i+1 : i+1+end]
+			if ddlRe.MatchString(literal) {
+				parts = append(parts, dedentString(literal))
+			}
+			i += end + 2
+		default:
+			i++
 		}
-		rest := remaining[start+1:]
-		end := strings.IndexByte(rest, '`')
-		if end < 0 {
-			break
-		}
-		literal := rest[:end]
-		if ddlRe.MatchString(literal) {
-			parts = append(parts, dedentString(literal))
-		}
-		remaining = rest[end+1:]
 	}
 	if len(parts) == 0 {
 		return ""
@@ -231,7 +286,6 @@ func compactDDL(ddl string) string {
 		kept = append(kept, trimmed)
 		prevBlank = false
 	}
-	kept = dedentLines(kept)
 	out := strings.TrimSpace(strings.Join(kept, "\n"))
 	if len(out) > maxDDLBytes {
 		out = out[:maxDDLBytes] + "\n-- ... (truncated; see source file for full DDL)"

--- a/internal/context/dbschema.go
+++ b/internal/context/dbschema.go
@@ -1,0 +1,303 @@
+package context
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DBSchema is a detected SQLite schema definition from a static source in the repo.
+type DBSchema struct {
+	// Source is the repo-relative path the DDL was read from.
+	Source string `json:"source" yaml:"source"`
+	// Name is a short label for the schema (package name, "migrations", or "schema").
+	Name string `json:"name" yaml:"name"`
+	// DDL is the compacted CREATE TABLE / INDEX / VIEW statements.
+	DDL string `json:"ddl" yaml:"ddl"`
+}
+
+// maxDDLBytes caps per-schema DDL output to keep the context token budget sane.
+// Large schemas truncate with a pointer to the source.
+const maxDDLBytes = 6000
+
+// skipDirs are walk directories that never contain authoritative DDL.
+var skipDirs = map[string]bool{
+	".git":         true,
+	"vendor":       true,
+	"node_modules": true,
+	"testdata":     true,
+	".sandbox":     true,
+	".quality":     true,
+	".snipe":       true,
+	".cache":       true,
+	"dist":         true,
+	"bin":          true,
+}
+
+// ddlRe matches CREATE TABLE|INDEX|VIEW|TRIGGER statements (case-insensitive).
+// Used to decide whether a string literal or .sql file contains DDL worth emitting.
+var ddlRe = regexp.MustCompile(`(?i)\bCREATE\s+(TABLE|INDEX|UNIQUE\s+INDEX|VIEW|TRIGGER)\b`)
+
+// DetectDBSchemas returns all SQLite schemas statically detectable from the repo.
+// Sources, in precedence order for any given root:
+//  1. migrations/*.sql or db/migrations/*.sql directories (coalesced)
+//  2. schema.sql, db/schema.sql, sql/schema.sql at repo root
+//  3. Embedded CREATE TABLE|INDEX|VIEW literals in Go source files
+//
+// Migrations at the root suppress a top-level schema.sql at the same root (they
+// typically document the same database). Embedded Go DDL is always emitted —
+// it commonly represents independent databases in separate packages.
+func DetectDBSchemas(repoRoot string) []DBSchema {
+	var out []DBSchema
+
+	migrationsFound := false
+	if s, ok := detectMigrations(repoRoot); ok {
+		out = append(out, s)
+		migrationsFound = true
+	}
+
+	if !migrationsFound {
+		if s, ok := detectTopLevelSQL(repoRoot); ok {
+			out = append(out, s)
+		}
+	}
+
+	out = append(out, detectEmbeddedGo(repoRoot)...)
+
+	return out
+}
+
+// detectMigrations coalesces .sql files from a migrations/ or db/migrations/ directory.
+func detectMigrations(repoRoot string) (DBSchema, bool) {
+	for _, candidate := range []string{"migrations", "db/migrations", "sql/migrations"} {
+		dir := filepath.Join(repoRoot, candidate)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		var files []string
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if strings.HasSuffix(strings.ToLower(e.Name()), ".sql") {
+				files = append(files, filepath.Join(dir, e.Name()))
+			}
+		}
+		if len(files) == 0 {
+			continue
+		}
+		sort.Strings(files)
+		var buf strings.Builder
+		for _, f := range files {
+			content, err := os.ReadFile(f)
+			if err != nil {
+				continue
+			}
+			if buf.Len() > 0 {
+				buf.WriteString("\n\n")
+			}
+			buf.WriteString("-- " + filepath.Base(f) + "\n")
+			buf.Write(content)
+		}
+		return DBSchema{
+			Source: relPath(repoRoot, dir),
+			Name:   "migrations",
+			DDL:    compactDDL(buf.String()),
+		}, true
+	}
+	return DBSchema{}, false
+}
+
+// detectTopLevelSQL looks for a standalone schema.sql file.
+func detectTopLevelSQL(repoRoot string) (DBSchema, bool) {
+	for _, candidate := range []string{"schema.sql", "db/schema.sql", "sql/schema.sql"} {
+		path := filepath.Join(repoRoot, candidate)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if !ddlRe.MatchString(string(content)) {
+			continue
+		}
+		name := strings.TrimSuffix(filepath.Base(candidate), ".sql")
+		return DBSchema{
+			Source: relPath(repoRoot, path),
+			Name:   name,
+			DDL:    compactDDL(string(content)),
+		}, true
+	}
+	return DBSchema{}, false
+}
+
+// detectEmbeddedGo walks .go files and extracts DDL from backtick string literals.
+// Each file containing DDL produces one DBSchema, named after its parent directory.
+func detectEmbeddedGo(repoRoot string) []DBSchema {
+	var out []DBSchema
+	_ = filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		ddl := extractGoDDL(string(content))
+		if ddl == "" {
+			return nil
+		}
+		name := filepath.Base(filepath.Dir(path))
+		out = append(out, DBSchema{
+			Source: relPath(repoRoot, path),
+			Name:   name,
+			DDL:    compactDDL(ddl),
+		})
+		return nil
+	})
+	// Stable order so multi-schema output is deterministic.
+	sort.Slice(out, func(i, j int) bool { return out[i].Source < out[j].Source })
+	return out
+}
+
+// extractGoDDL pulls the contents of every backtick raw string literal in src
+// that contains a CREATE statement. Returns concatenated DDL, or "" if none.
+func extractGoDDL(src string) string {
+	var parts []string
+	remaining := src
+	for {
+		start := strings.IndexByte(remaining, '`')
+		if start < 0 {
+			break
+		}
+		rest := remaining[start+1:]
+		end := strings.IndexByte(rest, '`')
+		if end < 0 {
+			break
+		}
+		literal := rest[:end]
+		if ddlRe.MatchString(literal) {
+			parts = append(parts, dedentString(literal))
+		}
+		remaining = rest[end+1:]
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// dedentString applies dedentLines to a single string blob.
+func dedentString(s string) string {
+	return strings.Join(dedentLines(strings.Split(s, "\n")), "\n")
+}
+
+// compactDDL normalizes whitespace, strips comments, and truncates if huge.
+func compactDDL(ddl string) string {
+	lines := strings.Split(ddl, "\n")
+	var kept []string
+	prevBlank := true
+	for _, ln := range lines {
+		// Strip -- line comments but preserve content before them.
+		if idx := strings.Index(ln, "--"); idx >= 0 {
+			// Keep only our own file-header marker comments (-- filename.sql).
+			if idx == 0 {
+				kept = append(kept, ln)
+				prevBlank = false
+				continue
+			}
+			ln = ln[:idx]
+		}
+		trimmed := strings.TrimRight(ln, " \t")
+		if strings.TrimSpace(trimmed) == "" {
+			if prevBlank {
+				continue
+			}
+			kept = append(kept, "")
+			prevBlank = true
+			continue
+		}
+		kept = append(kept, trimmed)
+		prevBlank = false
+	}
+	kept = dedentLines(kept)
+	out := strings.TrimSpace(strings.Join(kept, "\n"))
+	if len(out) > maxDDLBytes {
+		out = out[:maxDDLBytes] + "\n-- ... (truncated; see source file for full DDL)"
+	}
+	return out
+}
+
+// dedentLines strips the longest common leading-whitespace prefix from all
+// non-blank lines. Embedded DDL from Go string literals often carries the
+// source file's indentation; removing it cuts tokens and improves readability.
+func dedentLines(lines []string) []string {
+	common := ""
+	first := true
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		prefix := leadingWhitespace(ln)
+		if first {
+			common = prefix
+			first = false
+			continue
+		}
+		common = commonPrefix(common, prefix)
+		if common == "" {
+			return lines
+		}
+	}
+	if common == "" {
+		return lines
+	}
+	out := make([]string, len(lines))
+	for i, ln := range lines {
+		out[i] = strings.TrimPrefix(ln, common)
+	}
+	return out
+}
+
+func leadingWhitespace(s string) string {
+	for i, r := range s {
+		if r != ' ' && r != '\t' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func commonPrefix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:n]
+}
+
+// relPath returns path relative to repoRoot using forward slashes, falling back
+// to the absolute path if relative resolution fails.
+func relPath(repoRoot, path string) string {
+	rel, err := filepath.Rel(repoRoot, path)
+	if err != nil {
+		return path
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/context/dbschema_test.go
+++ b/internal/context/dbschema_test.go
@@ -81,6 +81,16 @@ func TestDetectDBSchemas_Migrations(t *testing.T) {
 	}
 }
 
+func TestDetectDBSchemas_BacktickInComment(t *testing.T) {
+	got := DetectDBSchemas("testdata/dbschema/backtick-in-comment")
+	if len(got) != 1 {
+		t.Fatalf("want 1 schema, got %d", len(got))
+	}
+	if !strings.Contains(got[0].DDL, "CREATE TABLE IF NOT EXISTS widgets") {
+		t.Errorf("scanner consumed by comment/string backticks; DDL: %q", got[0].DDL)
+	}
+}
+
 func TestDetectDBSchemas_None(t *testing.T) {
 	got := DetectDBSchemas("testdata/dbschema/none")
 	if len(got) != 0 {

--- a/internal/context/dbschema_test.go
+++ b/internal/context/dbschema_test.go
@@ -1,0 +1,114 @@
+package context
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectDBSchemas_TopLevelSQL(t *testing.T) {
+	got := DetectDBSchemas("testdata/dbschema/top-level-sql")
+	if len(got) != 1 {
+		t.Fatalf("want 1 schema, got %d", len(got))
+	}
+	s := got[0]
+	if !strings.HasSuffix(s.Source, "schema.sql") {
+		t.Errorf("source: want ends with schema.sql, got %q", s.Source)
+	}
+	if !strings.Contains(s.DDL, "CREATE TABLE queue") {
+		t.Errorf("DDL missing queue table: %q", s.DDL)
+	}
+	if !strings.Contains(s.DDL, "CREATE INDEX idx_queue_path") {
+		t.Errorf("DDL missing queue index: %q", s.DDL)
+	}
+}
+
+func TestDetectDBSchemas_EmbeddedGo(t *testing.T) {
+	got := DetectDBSchemas("testdata/dbschema/embedded-go")
+	if len(got) != 1 {
+		t.Fatalf("want 1 schema, got %d", len(got))
+	}
+	s := got[0]
+	if !strings.HasSuffix(s.Source, "store.go") {
+		t.Errorf("source: want ends with store.go, got %q", s.Source)
+	}
+	if !strings.Contains(s.DDL, "CREATE TABLE IF NOT EXISTS symbols") {
+		t.Errorf("DDL missing symbols table: %q", s.DDL)
+	}
+	if !strings.Contains(s.DDL, "CREATE INDEX idx_symbols_name") {
+		t.Errorf("DDL missing index: %q", s.DDL)
+	}
+}
+
+func TestDetectDBSchemas_MultiSchemaGo(t *testing.T) {
+	got := DetectDBSchemas("testdata/dbschema/multi-schema-go")
+	if len(got) != 3 {
+		t.Fatalf("want 3 schemas (store, cclog, metrics), got %d", len(got))
+	}
+
+	names := make(map[string]bool)
+	for _, s := range got {
+		names[s.Name] = true
+		if s.DDL == "" {
+			t.Errorf("schema %q has empty DDL", s.Name)
+		}
+	}
+	for _, want := range []string{"store", "cclog", "metrics"} {
+		if !names[want] {
+			t.Errorf("missing schema %q; got names: %v", want, names)
+		}
+	}
+}
+
+func TestDetectDBSchemas_Migrations(t *testing.T) {
+	got := DetectDBSchemas("testdata/dbschema/migrations")
+	if len(got) != 1 {
+		t.Fatalf("want 1 coalesced migrations schema, got %d", len(got))
+	}
+	s := got[0]
+	if !strings.Contains(s.Source, "migrations") {
+		t.Errorf("source: want contains 'migrations', got %q", s.Source)
+	}
+	if !strings.Contains(s.DDL, "CREATE TABLE users") {
+		t.Errorf("DDL missing users (migration 1): %q", s.DDL)
+	}
+	if !strings.Contains(s.DDL, "CREATE TABLE posts") {
+		t.Errorf("DDL missing posts (migration 2): %q", s.DDL)
+	}
+	usersIdx := strings.Index(s.DDL, "CREATE TABLE users")
+	postsIdx := strings.Index(s.DDL, "CREATE TABLE posts")
+	if usersIdx > postsIdx {
+		t.Errorf("migrations not in order: users at %d, posts at %d", usersIdx, postsIdx)
+	}
+}
+
+func TestDetectDBSchemas_None(t *testing.T) {
+	got := DetectDBSchemas("testdata/dbschema/none")
+	if len(got) != 0 {
+		t.Fatalf("want 0 schemas, got %d: %+v", len(got), got)
+	}
+}
+
+func TestDetectDBSchemas_SnipeItself(t *testing.T) {
+	got := DetectDBSchemas("../..")
+	if len(got) == 0 {
+		t.Fatalf("want at least 1 schema from snipe's own repo, got 0")
+	}
+	var found bool
+	for _, s := range got {
+		if strings.Contains(s.Source, "store/schema.go") && strings.Contains(s.DDL, "CREATE TABLE IF NOT EXISTS symbols") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected to find internal/store/schema.go with symbols table; got sources: %v", sources(got))
+	}
+}
+
+func sources(schemas []DBSchema) []string {
+	out := make([]string, len(schemas))
+	for i, s := range schemas {
+		out[i] = s.Source
+	}
+	return out
+}

--- a/internal/context/flows_test.go
+++ b/internal/context/flows_test.go
@@ -17,6 +17,7 @@ func TestCompressToCommandTable_BoilerplateDetection(t *testing.T) {
 
 	if table == nil {
 		t.Fatal("expected non-nil command table")
+		return
 	}
 
 	// Boilerplate should contain the common callees
@@ -45,6 +46,7 @@ func TestCompressToCommandTable_BoilerplateDetection(t *testing.T) {
 	}
 	if contextCmd == nil {
 		t.Fatal("expected runContext in commands")
+		return
 	}
 	if len(contextCmd.Callees) == 0 {
 		t.Error("runContext should have notable callees (non-boilerplate)")
@@ -85,6 +87,7 @@ func TestCompressToCommandTable_DeduplicatesCallees(t *testing.T) {
 	table := compressToCommandTable(details)
 	if table == nil {
 		t.Fatal("expected non-nil")
+		return
 	}
 	for _, cmd := range table.Commands {
 		seen := make(map[string]bool)

--- a/internal/context/format_text.go
+++ b/internal/context/format_text.go
@@ -83,6 +83,9 @@ func FormatText(bc *BootContext) string {
 		formatConventions(&b, conv)
 	}
 
+	// DB schemas
+	formatDBSchemas(&b, bc.DBSchemas)
+
 	// Active work
 	if aw := bc.ActiveWork; aw != nil {
 		b.WriteString("\n## active work\n")
@@ -95,6 +98,20 @@ func FormatText(bc *BootContext) string {
 	}
 
 	return b.String()
+}
+
+// formatDBSchemas emits one "## db schema" section per detected schema.
+// Source and name are shown in the header; DDL follows in a fenced sql block.
+func formatDBSchemas(b *strings.Builder, schemas []DBSchema) {
+	for _, s := range schemas {
+		fmt.Fprintf(b, "\n## db schema: %s (%s)\n", s.Name, s.Source)
+		b.WriteString("```sql\n")
+		b.WriteString(s.DDL)
+		if !strings.HasSuffix(s.DDL, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteString("```\n")
+	}
 }
 
 func formatCommands(b *strings.Builder, ct *CommandTable) {

--- a/internal/context/format_text.go
+++ b/internal/context/format_text.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const emDash = "—"
+const empty = "∅"
 
 // FormatText renders a BootContext as compact claudish text.
 // Optimized for Claude consumption: tables, fragments, minimal noise.
@@ -48,15 +48,13 @@ func FormatText(bc *BootContext) string {
 	// Key symbols
 	if len(bc.KeySymbols) > 0 {
 		b.WriteString("\n## key symbols\n")
-		b.WriteString("| Name | Location | Role | Purpose |\n")
-		b.WriteString("|------|----------|------|---------|\n")
 		for _, s := range bc.KeySymbols {
 			loc := fmt.Sprintf("%s:%d", s.File, s.Line)
-			purpose := s.Purpose
-			if purpose == "" {
-				purpose = emDash
+			if s.Purpose != "" {
+				fmt.Fprintf(&b, "%s (%s) %s — %s\n", s.Name, loc, s.Role, s.Purpose)
+			} else {
+				fmt.Fprintf(&b, "%s (%s) %s\n", s.Name, loc, s.Role)
 			}
-			fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", s.Name, loc, s.Role, purpose)
 		}
 	}
 
@@ -71,14 +69,12 @@ func FormatText(bc *BootContext) string {
 	// Packages
 	if len(bc.Packages) > 0 {
 		b.WriteString("\n## packages\n")
-		b.WriteString("| Package | Purpose |\n")
-		b.WriteString("|---------|----------|\n")
 		for _, p := range bc.Packages {
-			purpose := p.Purpose
-			if purpose == "" {
-				purpose = emDash
+			if p.Purpose != "" {
+				fmt.Fprintf(&b, "%s: %s\n", p.Name, p.Purpose)
+			} else {
+				fmt.Fprintf(&b, "%s: %s\n", p.Name, empty)
 			}
-			fmt.Fprintf(&b, "| %s | %s |\n", p.Name, purpose)
 		}
 	}
 
@@ -109,18 +105,15 @@ func formatCommands(b *strings.Builder, ct *CommandTable) {
 	if len(ct.BoilerplatePattern) > 0 {
 		fmt.Fprintf(b, "‡ boilerplate: %s\n", strings.Join(ct.BoilerplatePattern, ", "))
 	}
-	b.WriteString("| Cmd | Purpose | → Callees |\n")
-	b.WriteString("|-----|---------|----------|\n")
 	for _, c := range ct.Commands {
-		purpose := c.Purpose
-		if purpose == "" {
-			continue // skip purposeless commands
+		if c.Purpose == "" {
+			continue
 		}
-		callees := emDash
 		if len(c.Callees) > 0 {
-			callees = strings.Join(c.Callees, ", ")
+			fmt.Fprintf(b, "%s — %s → %s\n", c.Name, c.Purpose, strings.Join(c.Callees, ", "))
+		} else {
+			fmt.Fprintf(b, "%s — %s\n", c.Name, c.Purpose)
 		}
-		fmt.Fprintf(b, "| %s | %s | %s |\n", c.Name, purpose, callees)
 	}
 }
 
@@ -150,58 +143,73 @@ func formatInterfaces(b *strings.Builder, ifaces []InterfaceEntry) {
 		return
 	}
 	b.WriteString("\n## interfaces\n")
-	b.WriteString("| Interface | Location | Methods | → Implementors |\n")
-	b.WriteString("|-----------|----------|---------|----------------|\n")
 	for _, i := range ifaces {
 		loc := fmt.Sprintf("%s:%d", i.File, i.Line)
-		methods := emDash
+		var methods string
 		if len(i.Methods) > 0 {
-			methods = strings.Join(i.Methods, ", ")
-			if len(methods) > 40 {
-				// Truncate long method lists
-				methods = strings.Join(i.Methods[:min(3, len(i.Methods))], ", ")
-				if len(i.Methods) > 3 {
-					methods += fmt.Sprintf(" +%d", len(i.Methods)-3)
-				}
+			shown := i.Methods[:min(3, len(i.Methods))]
+			methods = strings.Join(shown, ", ")
+			if len(i.Methods) > 3 {
+				methods += fmt.Sprintf(" +%d", len(i.Methods)-3)
 			}
 		}
-		impls := emDash
 		if len(i.Implementors) > 0 {
 			names := make([]string, len(i.Implementors))
 			for j, imp := range i.Implementors {
 				names[j] = imp.Name
 			}
-			impls = strings.Join(names, ", ")
+			if methods != "" {
+				fmt.Fprintf(b, "%s (%s): %s → %s\n", i.Interface, loc, methods, strings.Join(names, ", "))
+			} else {
+				fmt.Fprintf(b, "%s (%s) → %s\n", i.Interface, loc, strings.Join(names, ", "))
+			}
+		} else {
+			if methods != "" {
+				fmt.Fprintf(b, "%s (%s): %s\n", i.Interface, loc, methods)
+			} else {
+				fmt.Fprintf(b, "%s (%s)\n", i.Interface, loc)
+			}
 		}
-		fmt.Fprintf(b, "| %s | %s | %s | %s |\n", i.Interface, loc, methods, impls)
+	}
+}
+
+// confSym maps confidence string to claudish symbol.
+func confSym(confidence string) string {
+	switch confidence {
+	case "high":
+		return "✓"
+	case "medium":
+		return "≈"
+	default:
+		return confidence
 	}
 }
 
 func formatConventions(b *strings.Builder, conv *Conventions) {
 	b.WriteString("\n## conventions\n")
 	if c := conv.Constructors; c != nil {
-		fmt.Fprintf(b, "constructors: %s [%d total, %d err] (%s)\n",
-			c.Pattern, c.Total, c.WithError, c.Confidence)
+		fmt.Fprintf(b, "constructors: %s %d/%d %s\n",
+			c.Pattern, c.Total, c.WithError, confSym(c.Confidence))
 	}
 	if c := conv.Receivers; c != nil {
 		pct := int(math.Round(c.PointerPct))
-		fmt.Fprintf(b, "receivers: %s, %d%% ptr [%d] (%s)\n",
-			c.Pattern, pct, c.Total, c.Confidence)
+		fmt.Fprintf(b, "receivers: %s %d%%ptr/%d %s\n",
+			c.Pattern, pct, c.Total, confSym(c.Confidence))
 	}
 	if c := conv.Testing; c != nil {
-		fmt.Fprintf(b, "testing: %s [%d files, %d helpers] (%s)\n",
-			c.Pattern, c.TestFiles, c.Helpers, c.Confidence)
+		fmt.Fprintf(b, "testing: %s %df/%dh %s\n",
+			c.Pattern, c.TestFiles, c.Helpers, confSym(c.Confidence))
 	}
 	if c := conv.Interfaces; c != nil {
-		fmt.Fprintf(b, "interfaces: %s [%d total, %d -er] (%s)\n",
-			c.Pattern, c.Total, c.ErSuffix, c.Confidence)
+		fmt.Fprintf(b, "interfaces: %s %d/%d-er %s\n",
+			c.Pattern, c.Total, c.ErSuffix, confSym(c.Confidence))
 	}
 	if c := conv.ErrorHandling; c != nil {
-		fmt.Fprintf(b, "errors: %s [%d sentinels, %d err funcs] (%s)\n",
-			c.Pattern, c.Sentinels, c.ErrorFuncs, c.Confidence)
+		fmt.Fprintf(b, "errors: %s %d/%d %s\n",
+			c.Pattern, c.Sentinels, c.ErrorFuncs, confSym(c.Confidence))
 	}
 	if c := conv.FileOrg; c != nil {
-		fmt.Fprintf(b, "file org: %s [%.1f avg types/file] (%s)\n",
-			c.Pattern, c.AvgTypesFile, c.Confidence)
+		fmt.Fprintf(b, "file org: %s %.1ft/f %s\n",
+			c.Pattern, c.AvgTypesFile, confSym(c.Confidence))
 	}
 }

--- a/internal/context/generate.go
+++ b/internal/context/generate.go
@@ -41,6 +41,7 @@ func Generate(cfg GenerateConfig) (*ProjectContext, error) {
 		Architecture: generateArchitecture(cfg.DB, cfg.RepoRoot),
 		Files:        generateFiles(cfg.DB, cfg.RepoRoot),
 		Symbols:      generateSymbols(cfg.DB, cfg.RepoRoot, cfg.Full, cfg.MaxSymbols),
+		DBSchemas:    DetectDBSchemas(cfg.RepoRoot),
 		Meta:         generateMeta(cfg.DB),
 	}
 
@@ -112,6 +113,7 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 		BootViews:   bootViews,
 		Packages:    packages,
 		Conventions: conventions,
+		DBSchemas:   DetectDBSchemas(cfg.RepoRoot),
 	}, nil
 }
 

--- a/internal/context/session_test.go
+++ b/internal/context/session_test.go
@@ -152,6 +152,7 @@ func TestGetActiveWork_KeepsFeatureBranch(t *testing.T) {
 	aw := s.GetActiveWork()
 	if aw == nil {
 		t.Fatal("expected non-nil ActiveWork")
+		return
 	}
 	if aw.Branch != "feat/context-improvements" {
 		t.Errorf("branch should be kept for feature branch, got %q", aw.Branch)

--- a/internal/context/testdata/dbschema/backtick-in-comment/store.go
+++ b/internal/context/testdata/dbschema/backtick-in-comment/store.go
@@ -1,0 +1,13 @@
+package store
+
+// Use `go test` to run tests; use `mage qa` for the full quality gate.
+// A stray `backtick` in a comment must not swallow the real DDL below.
+const schema = `
+CREATE TABLE IF NOT EXISTS widgets (
+    id   TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+`
+
+// query uses a double-quoted string with an embedded backtick: "`SELECT 1`".
+var query = "`SELECT 1`"

--- a/internal/context/testdata/dbschema/embedded-go/store.go
+++ b/internal/context/testdata/dbschema/embedded-go/store.go
@@ -1,0 +1,11 @@
+package store
+
+const schema = `
+CREATE TABLE IF NOT EXISTS symbols (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL
+);
+
+CREATE INDEX idx_symbols_name ON symbols(name);
+`

--- a/internal/context/testdata/dbschema/migrations/migrations/001_init.sql
+++ b/internal/context/testdata/dbschema/migrations/migrations/001_init.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+    id    INTEGER PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL
+);

--- a/internal/context/testdata/dbschema/migrations/migrations/002_add_posts.sql
+++ b/internal/context/testdata/dbschema/migrations/migrations/002_add_posts.sql
@@ -1,0 +1,8 @@
+CREATE TABLE posts (
+    id      INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    body    TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE INDEX idx_posts_user ON posts(user_id);

--- a/internal/context/testdata/dbschema/multi-schema-go/cclog/schema.go
+++ b/internal/context/testdata/dbschema/multi-schema-go/cclog/schema.go
@@ -1,0 +1,14 @@
+package cclog
+
+const cclogSchema = `
+CREATE TABLE sessions (
+    id   TEXT PRIMARY KEY,
+    started_at INT NOT NULL
+);
+
+CREATE TABLE messages (
+    id   TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    body TEXT
+);
+`

--- a/internal/context/testdata/dbschema/multi-schema-go/metrics/store.go
+++ b/internal/context/testdata/dbschema/multi-schema-go/metrics/store.go
@@ -1,0 +1,6 @@
+package metrics
+
+const dailyMetricsTableSQL = `CREATE TABLE IF NOT EXISTS daily_metrics (
+    day       TEXT PRIMARY KEY,
+    count     INT NOT NULL
+);`

--- a/internal/context/testdata/dbschema/multi-schema-go/store/schema.go
+++ b/internal/context/testdata/dbschema/multi-schema-go/store/schema.go
@@ -1,0 +1,8 @@
+package store
+
+const storeSchema = `
+CREATE TABLE nugs (
+    id   TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+`

--- a/internal/context/testdata/dbschema/none/main.go
+++ b/internal/context/testdata/dbschema/none/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/internal/context/testdata/dbschema/top-level-sql/schema.sql
+++ b/internal/context/testdata/dbschema/top-level-sql/schema.sql
@@ -1,0 +1,8 @@
+-- test schema
+CREATE TABLE queue (
+  path      TEXT NOT NULL,
+  path_hash TEXT NOT NULL,
+  PRIMARY KEY (path_hash)
+);
+
+CREATE INDEX idx_queue_path ON queue(path);

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -7,6 +7,7 @@ type ProjectContext struct {
 	Architecture Architecture `json:"architecture" yaml:"architecture"`
 	Files        Files        `json:"files,omitempty" yaml:"files,omitempty"`
 	Symbols      Symbols      `json:"symbols" yaml:"symbols"`
+	DBSchemas    []DBSchema   `json:"db_schemas,omitempty" yaml:"db_schemas,omitempty"`
 	Meta         Meta         `json:"meta" yaml:"meta"`
 }
 
@@ -30,6 +31,9 @@ type BootContext struct {
 
 	// Conventions detected from index
 	Conventions *Conventions `json:"conventions,omitempty" yaml:"conventions,omitempty"`
+
+	// DBSchemas is statically-detected SQLite DDL (migrations, schema.sql, or embedded Go literals).
+	DBSchemas []DBSchema `json:"db_schemas,omitempty" yaml:"db_schemas,omitempty"`
 }
 
 // BootViews contains the three orientation views for LLM boot sequences.

--- a/internal/embed/search.go
+++ b/internal/embed/search.go
@@ -17,6 +17,11 @@ type searchResult struct {
 	similarity float32
 }
 
+// Embedder generates an embedding vector for a single text input.
+type Embedder interface {
+	EmbedOne(text, inputType string) ([]float32, error)
+}
+
 // Search embeds the query, compares against all stored embeddings,
 // and returns results above the threshold sorted by similarity descending.
 // Returns (nil, 0, nil) if no embeddings exist — caller decides how to handle.
@@ -25,7 +30,7 @@ type searchResult struct {
 // At 1024 dims × 4 bytes per float32, that's ~4KB per symbol. For 5,000 symbols
 // this is ~20MB — acceptable for current use. If this becomes a bottleneck,
 // the first optimization is an ANN index (HNSW or IVF) to avoid the full scan.
-func Search(queryText string, s *store.Store, client *Client, limit int, threshold float32) ([]output.Result, time.Duration, error) {
+func Search(queryText string, s *store.Store, client Embedder, limit int, threshold float32) ([]output.Result, time.Duration, error) {
 	start := time.Now()
 
 	count, err := s.CountEmbeddings()

--- a/internal/embed/search_test.go
+++ b/internal/embed/search_test.go
@@ -1,0 +1,121 @@
+package embed
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/index"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+type mockEmbedder struct {
+	vec []float32
+	err error
+}
+
+func (m *mockEmbedder) EmbedOne(_, _ string) ([]float32, error) {
+	return m.vec, m.err
+}
+
+func openSearchTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func writeSymbols(t *testing.T, s *store.Store, syms []index.Symbol) {
+	t.Helper()
+	if err := s.WriteIndex(syms, nil, nil); err != nil {
+		t.Fatalf("WriteIndex: %v", err)
+	}
+}
+
+func TestSearch_NoEmbeddings_ReturnsNil(t *testing.T) {
+	s := openSearchTestStore(t)
+	results, dur, err := Search("query", s, &mockEmbedder{vec: []float32{1, 0, 0}}, 10, 0.5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Fatalf("expected nil results, got %d", len(results))
+	}
+	_ = dur
+}
+
+func TestSearch_ThresholdFiltersAndSortsByScore(t *testing.T) {
+	s := openSearchTestStore(t)
+	writeSymbols(t, s, []index.Symbol{
+		{ID: "sym1", Name: "HighSim", Kind: index.KindFunc, FilePath: "/t.go", LineStart: 1, ColStart: 1, LineEnd: 5, ColEnd: 1, Signature: "func HighSim()"},
+		{ID: "sym2", Name: "LowSim", Kind: index.KindFunc, FilePath: "/t.go", LineStart: 10, ColStart: 1, LineEnd: 15, ColEnd: 1, Signature: "func LowSim()"},
+	})
+	// sym1: [1,0,0] — sim=1.0 with query [1,0,0]; sym2: [0,1,0] — sim=0.0
+	if err := s.SaveEmbedding("sym1", []float32{1, 0, 0}, "test"); err != nil {
+		t.Fatalf("SaveEmbedding sym1: %v", err)
+	}
+	if err := s.SaveEmbedding("sym2", []float32{0, 1, 0}, "test"); err != nil {
+		t.Fatalf("SaveEmbedding sym2: %v", err)
+	}
+
+	results, dur, err := Search("query", s, &mockEmbedder{vec: []float32{1, 0, 0}}, 10, 0.5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result above threshold 0.5, got %d", len(results))
+	}
+	if results[0].Name != "HighSim" {
+		t.Fatalf("expected HighSim, got %s", results[0].Name)
+	}
+	if dur <= 0 {
+		t.Fatal("expected duration > 0")
+	}
+}
+
+func TestSearch_RespectsLimit(t *testing.T) {
+	s := openSearchTestStore(t)
+	writeSymbols(t, s, []index.Symbol{
+		{ID: "sym1", Name: "A", Kind: index.KindFunc, FilePath: "/t.go", LineStart: 1, ColStart: 1, LineEnd: 2, ColEnd: 1},
+		{ID: "sym2", Name: "B", Kind: index.KindFunc, FilePath: "/t.go", LineStart: 3, ColStart: 1, LineEnd: 4, ColEnd: 1},
+		{ID: "sym3", Name: "C", Kind: index.KindFunc, FilePath: "/t.go", LineStart: 5, ColStart: 1, LineEnd: 6, ColEnd: 1},
+	})
+	for _, id := range []string{"sym1", "sym2", "sym3"} {
+		if err := s.SaveEmbedding(id, []float32{1, 0, 0}, "test"); err != nil {
+			t.Fatalf("SaveEmbedding %s: %v", id, err)
+		}
+	}
+
+	results, _, err := Search("query", s, &mockEmbedder{vec: []float32{1, 0, 0}}, 2, 0.5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (limit=2), got %d", len(results))
+	}
+}
+
+func TestSearch_EmbedderError_ReturnsError(t *testing.T) {
+	s := openSearchTestStore(t)
+	writeSymbols(t, s, []index.Symbol{
+		{ID: "sym1", Name: "F", Kind: index.KindFunc, FilePath: "/t.go", LineStart: 1, ColStart: 1, LineEnd: 2, ColEnd: 1},
+	})
+	if err := s.SaveEmbedding("sym1", []float32{1, 0, 0}, "test"); err != nil {
+		t.Fatalf("SaveEmbedding: %v", err)
+	}
+
+	emb := &mockEmbedder{err: errTest}
+	_, _, err := Search("query", s, emb, 10, 0.5)
+	if err == nil {
+		t.Fatal("expected error from embedder, got nil")
+	}
+}
+
+// errTest is a sentinel error for mock use.
+var errTest = &sentinelError{"embed failed"}
+
+type sentinelError struct{ msg string }
+
+func (e *sentinelError) Error() string { return e.msg }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -26,6 +26,14 @@ const (
 	OutputJSON OutputFormat = "json"
 )
 
+// showSuggestionsEnabled controls whether suggestions are emitted in Claude text mode.
+// Off by default — suggestions are toolchain metadata, not needed in Claude output.
+// Enable with --suggestions flag (SetShowSuggestions).
+var showSuggestionsEnabled = false
+
+// SetShowSuggestions configures suggestion output for Claude mode.
+func SetShowSuggestions(v bool) { showSuggestionsEnabled = v }
+
 // Writer handles output formatting for LLM consumers.
 type Writer struct {
 	out     io.Writer
@@ -199,13 +207,10 @@ func (w *Writer) writeClaudeMeta(b *strings.Builder, meta Meta) {
 	if len(meta.Degraded) > 0 {
 		parts = append(parts, meta.Degraded...)
 	}
-	if len(parts) > 0 {
-		b.WriteString("---\n")
-		for _, p := range parts {
-			b.WriteString("! ")
-			b.WriteString(p)
-			b.WriteString("\n")
-		}
+	for _, p := range parts {
+		b.WriteString("! ")
+		b.WriteString(p)
+		b.WriteString("\n")
 	}
 }
 
@@ -244,7 +249,7 @@ func (w *Writer) writeClaudeError(b *strings.Builder, err *Error) {
 }
 
 func writeClaudeSuggestions(b *strings.Builder, suggestions []Suggestion) {
-	if len(suggestions) == 0 {
+	if !showSuggestionsEnabled || len(suggestions) == 0 {
 		return
 	}
 	for _, s := range suggestions {


### PR DESCRIPTION
Closes #137.

## Summary
\`snipe context\` now emits static SQLite DDL so Claude stops guessing column names when querying project databases. Each detected schema gets its own labeled block.

Detection sources (precedence):
1. \`migrations/\` or \`db/migrations/*.sql\` (coalesced in order)
2. \`schema.sql\` / \`db/schema.sql\` / \`sql/schema.sql\`
3. backtick raw-string literals containing \`CREATE TABLE|INDEX|VIEW\` in \`.go\` source

Migrations at the root suppress a sibling \`schema.sql\`. Embedded Go DDL is always emitted — different packages often represent independent databases.

## Verification
Ran against the three issue targets:

- **snipe** (embedded Go, 1 schema) → \`## db schema: store (internal/store/schema.go)\`
- **next** (top-level \`schema.sql\`) → \`## db schema: schema (schema.sql)\`
- **trixi** (multi-schema) → three blocks: \`store\`, \`cclog\`, \`metrics\`

\`--format json\` includes \`db_schemas\` too, so orca integration picks it up.

## Test plan
- [x] \`make check\` green
- [x] 6 unit tests covering each detection path (incl. multi-schema, none, snipe-itself)
- [x] Verified end-to-end on snipe, next, trixi
- [x] JSON envelope includes \`db_schemas\` field

## Design notes
- D1: block uses compact dedented DDL, not verbose \`.schema\` dump
- D3: static sources only, rooted at git root (never reads live \`.db\`)
- D4: 6KB per-schema cap with truncation pointer; common-indent dedent cuts token cost
- Naming: \`cmd/schema.go\` already exists for JSON Schema output — used \`db_schemas\` / \`DBSchema\` to avoid collision