### PR TITLE
test(cmd): add behavioral tests for lits command

### DIFF
--- a/cmd/lits_test.go
+++ b/cmd/lits_test.go
@@ -1,7 +1,16 @@
 package cmd
 
 import (
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dkoosis/snipe/internal/store"
 )
 
 func TestLitsCmd_Registered(t *testing.T) {
@@ -11,4 +20,198 @@ func TestLitsCmd_Registered(t *testing.T) {
 		}
 	}
 	t.Error("lits command not registered")
+}
+
+func TestLitsCommand_RequiresExactlyOneArgument(t *testing.T) {
+	stdout, stderr, err := executeCommand(newRootCommandForTest(t), "lits")
+	if err == nil {
+		t.Fatal("expected error when lits is called without required argument")
+	}
+	if !strings.Contains(stdout, "Usage:") {
+		t.Fatalf("stdout = %q, want usage output", stdout)
+	}
+	if !strings.Contains(stderr, "accepts 1 arg(s)") {
+		t.Fatalf("stderr = %q, want it to mention required arg count", stderr)
+	}
+}
+
+func TestLitsCommand_ReturnsMissingIndexError_WhenIndexDoesNotExist(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	stdout, stderr, err := executeCommandWithStdIO(t, newRootCommandForTest(t), "lits", "MY_KEY")
+	if err == nil {
+		t.Fatal("expected error when index is missing")
+	}
+	if !strings.Contains(stderr, "index missing") {
+		t.Fatalf("stderr = %q, want index missing message", stderr)
+	}
+	if !strings.Contains(stdout, "No index found") {
+		t.Fatalf("stdout = %q, want missing index guidance", stdout)
+	}
+}
+
+func TestLitsCommand_ReturnsNotFoundResponse_WhenLiteralIsAbsent(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	createLitsIndex(t, root, []literalRefRow{{
+		id:          "aaaa1111",
+		value:       "EXISTING_KEY",
+		name:        "EXISTING_KEY",
+		kind:        "env",
+		filePath:    filepath.Join(root, "main.go"),
+		filePathRel: "main.go",
+		line:        3,
+		col:         10,
+		snippet:     `os.Getenv("EXISTING_KEY")`,
+	}})
+
+	stdout, stderr, err := executeCommandWithStdIO(t, newRootCommandForTest(t), "lits", "MISSING_KEY")
+	if err != nil {
+		t.Fatalf("expected nil error for not found response envelope, got %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `error: no string refs found for "MISSING_KEY"`) {
+		t.Fatalf("stdout = %q, want not-found message", stdout)
+	}
+}
+
+func TestLitsCommand_AppliesValueMatchingAndPagination(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	createLitsIndex(t, root, []literalRefRow{
+		{
+			id:          "id-001",
+			value:       "TARGET",
+			name:        "FIRST_TARGET",
+			kind:        "env",
+			filePath:    filepath.Join(root, "a.go"),
+			filePathRel: "a.go",
+			line:        2,
+			col:         7,
+			snippet:     `os.Getenv("TARGET")`,
+		},
+		{
+			id:          "id-002",
+			value:       "TARGET",
+			name:        "SECOND_TARGET",
+			kind:        "const",
+			filePath:    filepath.Join(root, "b.go"),
+			filePathRel: "b.go",
+			line:        9,
+			col:         3,
+			snippet:     `const second = "TARGET"`,
+		},
+		{
+			id:          "id-003",
+			value:       "OTHER",
+			name:        "OTHER",
+			kind:        "const",
+			filePath:    filepath.Join(root, "c.go"),
+			filePathRel: "c.go",
+			line:        12,
+			col:         1,
+			snippet:     `const other = "OTHER"`,
+		},
+	})
+
+	stdout, stderr, err := executeCommandWithStdIO(t, newRootCommandForTest(t), "--offset", "1", "--limit", "1", "lits", "TARGET")
+	if err != nil {
+		t.Fatalf("lits TARGET returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "SECOND_TARGET") {
+		t.Fatalf("stdout = %q, want paginated second match", stdout)
+	}
+	if strings.Contains(stdout, "FIRST_TARGET") {
+		t.Fatalf("stdout = %q, did not expect first match after offset", stdout)
+	}
+	if strings.Contains(stdout, "OTHER") {
+		t.Fatalf("stdout = %q, did not expect non-matching value", stdout)
+	}
+}
+
+type literalRefRow struct {
+	id          string
+	value       string
+	name        string
+	kind        string
+	filePath    string
+	filePathRel string
+	line        int
+	col         int
+	enclosingID string
+	snippet     string
+}
+
+func createLitsIndex(t *testing.T, root string, rows []literalRefRow) {
+	t.Helper()
+
+	indexPath := store.DefaultIndexPath(root)
+	s, err := store.Open(indexPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+
+	for _, row := range rows {
+		_, err := s.DB().Exec(`
+			INSERT INTO string_refs (id, value, name, kind, file_path, file_path_rel, line, col, enclosing_id, snippet)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, row.id, row.value, row.name, row.kind, row.filePath, row.filePathRel, row.line, row.col, nullableString(row.enclosingID), nullableString(row.snippet))
+		if err != nil {
+			t.Fatalf("insert string_ref %q: %v", row.id, err)
+		}
+	}
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return s
+}
+
+func executeCommandWithStdIO(t *testing.T, root *cobra.Command, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	root.SetArgs(args)
+	_, err = root.ExecuteC()
+
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	os.Stdout = origStdout
+	os.Stderr = origStderr
+
+	stdoutBytes, readErr := io.ReadAll(stdoutR)
+	if readErr != nil {
+		t.Fatalf("read stdout: %v", readErr)
+	}
+	stderrBytes, readErr := io.ReadAll(stderrR)
+	if readErr != nil {
+		t.Fatalf("read stderr: %v", readErr)
+	}
+	_ = stdoutR.Close()
+	_ = stderrR.Close()
+
+	return string(stdoutBytes), string(stderrBytes), err
 }


### PR DESCRIPTION
### Motivation
- Add focused behavioral tests for the existing `lits` Cobra command (the same utility already covered by help golden tests) to verify runtime behavior like arg validation, missing-index handling, not-found responses, and pagination. 
- Make tests deterministic and independent of developer machine state by creating explicit in-test fixtures and using temporary directories. 

### Description
- Add new behavioral tests in `cmd/lits_test.go` covering required-argument validation (`TestLitsCommand_RequiresExactlyOneArgument`), missing-index error path (`TestLitsCommand_ReturnsMissingIndexError_WhenIndexDoesNotExist`), not-found response envelope (`TestLitsCommand_ReturnsNotFoundResponse_WhenLiteralIsAbsent`), and pagination/filtering (`TestLitsCommand_AppliesValueMatchingAndPagination`).
- Add a small in-test fixture and helper surface: `literalRefRow` and `createLitsIndex` to create a `.snipe/index.db` and insert deterministic `string_refs` rows, and `nullableString` to ease inserts. 
- Add `executeCommandWithStdIO` to capture process-level `os.Stdout`/`os.Stderr` for commands that write directly to stdio (used alongside the existing `executeCommand` help harness). 
- Tests use `t.TempDir()`, `t.Chdir()` and `store.DefaultIndexPath`/`store.Open` to isolate state; no production code or help golden harness changes were made. 

### Testing
- Ran `go test ./cmd -run TestLits -v` and the new `lits` tests passed. 
- Ran `go test ./...` which failed due to a pre-existing `TestHelpGolden/index` mismatch in `cmd/help_golden_test.go` that is unrelated to these behavioral tests. 
- Ran `make audit` which did not complete cleanly due to `golangci-lint` panicking from a toolchain Go version mismatch in the environment (not caused by these test changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ec64ee788325a717252b8201264c)