### PR TITLE
feat(guard): assert architecture boundaries from a spec

### DIFF
--- a/cmd/guard.go
+++ b/cmd/guard.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+)
+
+// errGuardFailed is the sentinel returned on any operator/spec error. guardCmd
+// sets SilenceErrors+SilenceUsage so the structured message (already written via
+// the output writer) is not duplicated; the sentinel only drives a non-zero exit.
+var errGuardFailed = errors.New("guard: spec or index error")
+
+// defaultGuardSpec is the spec read when no path arg is given.
+const defaultGuardSpec = ".snipe/boundaries.yml"
+
+var guardCmd = &cobra.Command{
+	Use:     "guard [spec]",
+	Short:   "Assert architecture boundary rules; exit non-zero on violation",
+	GroupID: categoryGraph,
+	Long: `Enforce declared architecture boundaries against the indexed reference graph.
+
+guard reads a spec of deny rules and fails (exit 1) if any reference crosses a
+forbidden boundary. Unlike import-only linters it works on the REFERENCE graph,
+so a rule can forbid calls while allowing type imports (kinds: [func, method]).
+It is package-grained (suffix match), so rules survive a module->package collapse.
+
+Spec (.snipe/boundaries.yml by default):
+
+  version: 1
+  rules:
+    - name: shell-not-store
+      from: "agent/shell/..."      # recursive: pkg + descendants
+      to:   "persistence/store/..."
+      desc: "shell must not depend on store"
+    - name: agent-core-not-store
+      from: "agent/..."
+      to:   "persistence/store/..."
+      kinds: [func, method]        # call-level only (imports of types still allowed)
+      allow:                       # ratchet: exempt existing sites by file suffix
+        - "agent/cost_budget.go"
+
+An unmatched from/to pattern is a hard error (no silent no-op), exit 1.
+
+Examples:
+  snipe guard
+  snipe guard .snipe/boundaries.yml
+  snipe guard --format json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runGuard,
+	// As a CI gate, guard writes its own structured output and signals failure
+	// via exit code; suppress cobra's duplicate error + usage dump.
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	rootCmd.AddCommand(guardCmd)
+}
+
+// guardFail writes a structured operator error and returns the sentinel so the
+// process exits non-zero (a gate must fail closed on spec/index problems).
+func guardFail(w *output.Writer, msg string) error {
+	_ = w.WriteError("guard", &output.Error{Code: output.ErrInternal, Message: msg})
+	return errGuardFailed
+}
+
+// guardSpec is the on-disk boundary policy.
+type guardSpec struct {
+	Version int         `yaml:"version"`
+	Rules   []guardRule `yaml:"rules"`
+}
+
+// guardRule denies references from one package set to another. Kinds, when set,
+// restrict the rule to those ref kinds (func|method|type|...); empty = all.
+// Allow lists file-path suffixes that are exempted (ratchet for known sites).
+type guardRule struct {
+	Name         string   `yaml:"name"`
+	From         string   `yaml:"from"`
+	To           string   `yaml:"to"`
+	Desc         string   `yaml:"desc"`
+	Kinds        []string `yaml:"kinds"`
+	Allow        []string `yaml:"allow"`
+	IncludeTests bool     `yaml:"include_tests"` // default false: _test.go sites are exempt
+}
+
+// guardViolation is one forbidden reference site.
+type guardViolation struct {
+	Rule    string `json:"rule"`
+	Desc    string `json:"desc"`
+	Symbol  string `json:"symbol"`
+	Kind    string `json:"kind"`
+	FromPkg string `json:"from_pkg"`
+	ToPkg   string `json:"to_pkg"`
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+}
+
+func runGuard(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+
+	specPath := defaultGuardSpec
+	if len(args) == 1 {
+		specPath = args[0]
+	}
+
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return guardFail(w, "read spec: "+err.Error())
+	}
+	var spec guardSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return guardFail(w, "parse spec: "+err.Error())
+	}
+	if len(spec.Rules) == 0 {
+		return guardFail(w, "spec has no rules: "+specPath)
+	}
+
+	s, dir, err := OpenStore(w, "guard")
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	universe, err := allPkgPaths(s.DB())
+	if err != nil {
+		return guardFail(w, err.Error())
+	}
+
+	violations, err := evalGuard(s.DB(), universe, spec.Rules)
+	if err != nil {
+		return guardFail(w, err.Error())
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		a, b := violations[i], violations[j]
+		if a.Rule != b.Rule {
+			return a.Rule < b.Rule
+		}
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		return a.Line < b.Line
+	})
+
+	if err := writeGuard(dir, specPath, spec.Rules, violations, start); err != nil {
+		return err
+	}
+	if len(violations) > 0 {
+		// Non-zero exit for CI gating. Message is short; detail is in the report.
+		return fmt.Errorf("guard: %d boundary violation(s)", len(violations))
+	}
+	return nil
+}
+
+// evalGuard resolves each rule and collects every forbidden reference site.
+// An unmatched from/to pattern is a hard error so rules never silently no-op.
+func evalGuard(db *sql.DB, universe []string, rules []guardRule) ([]guardViolation, error) {
+	var out []guardViolation
+	for _, r := range rules {
+		if r.From == "" || r.To == "" {
+			return nil, fmt.Errorf("rule %q: from and to are required", r.Name)
+		}
+		setFrom := query.MatchPackagePatterns(universe, []string{r.From})
+		setTo := query.MatchPackagePatterns(universe, []string{r.To})
+		if len(setFrom) == 0 {
+			return nil, fmt.Errorf("rule %q: from pattern matched no packages: %q", r.Name, r.From)
+		}
+		if len(setTo) == 0 {
+			return nil, fmt.Errorf("rule %q: to pattern matched no packages: %q", r.Name, r.To)
+		}
+
+		report, err := query.FindBoundaryCrossings(db, setFrom, setTo)
+		if err != nil {
+			return nil, fmt.Errorf("rule %q: %w", r.Name, err)
+		}
+		if err := query.PopulateBoundaryLocations(db, report); err != nil {
+			return nil, fmt.Errorf("rule %q: locations: %w", r.Name, err)
+		}
+
+		kinds := kindSet(r.Kinds)
+		for _, ref := range report.AToB { // from -> to is the forbidden direction
+			if len(kinds) > 0 && !kinds[ref.Kind] {
+				continue
+			}
+			out = append(out, refViolations(r, ref)...)
+		}
+	}
+	return out, nil
+}
+
+// refViolations expands one crossing into per-site violations, applying the
+// rule's allow-list (file-suffix exemptions). A crossing with no recorded
+// locations still yields one violation (file unknown) so it is never hidden.
+func refViolations(r guardRule, ref query.BoundaryRef) []guardViolation {
+	mk := func(file string, line int) guardViolation {
+		return guardViolation{
+			Rule: r.Name, Desc: r.Desc, Symbol: ref.Symbol, Kind: ref.Kind,
+			FromPkg: ref.SourcePkg, ToPkg: ref.TargetPkg, File: file, Line: line,
+		}
+	}
+	if len(ref.Locations) == 0 {
+		return []guardViolation{mk("", 0)}
+	}
+	var out []guardViolation
+	for _, loc := range ref.Locations {
+		if !r.IncludeTests && strings.HasSuffix(loc.File, "_test.go") {
+			continue
+		}
+		if allowed(r.Allow, loc.File) {
+			continue
+		}
+		out = append(out, mk(loc.File, loc.Line))
+	}
+	return out
+}
+
+func kindSet(kinds []string) map[string]bool {
+	if len(kinds) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		m[strings.TrimSpace(k)] = true
+	}
+	return m
+}
+
+// allowed reports whether file matches any allow-list suffix.
+func allowed(allow []string, file string) bool {
+	for _, a := range allow {
+		if a != "" && strings.HasSuffix(file, a) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeGuard(dir, specPath string, rules []guardRule, v []guardViolation, start time.Time) error {
+	if GetOutputFormat() == output.OutputJSON {
+		resp := output.Response[guardViolation]{
+			Protocol: output.ProtocolVersion,
+			Ok:       len(v) == 0,
+			Results:  v,
+			Meta: output.Meta{
+				Command:  "guard",
+				Query:    map[string]string{"spec": specPath},
+				RepoRoot: dir,
+				Ms:       time.Since(start).Milliseconds(),
+				Total:    len(v),
+			},
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp)
+	}
+
+	var b strings.Builder
+	if len(v) == 0 {
+		fmt.Fprintf(&b, "guard · %d rule(s) · ✓ no violations\n", len(rules))
+		_, err := os.Stdout.WriteString(b.String())
+		return err
+	}
+	fmt.Fprintf(&b, "guard · %d rule(s) · ✗ %d violation(s)\n", len(rules), len(v))
+	var lastRule string
+	for _, x := range v {
+		if x.Rule != lastRule {
+			fmt.Fprintf(&b, "\n  [%s] %s\n", x.Rule, x.Desc)
+			lastRule = x.Rule
+		}
+		loc := x.File
+		if x.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", x.File, x.Line)
+		}
+		if loc == "" {
+			loc = "(location unknown)"
+		}
+		fmt.Fprintf(&b, "    %s -> %s.%s [%s]\n      %s\n", x.FromPkg, x.ToPkg, x.Symbol, x.Kind, loc)
+	}
+	_, err := os.Stdout.WriteString(b.String())
+	return err
+}

--- a/cmd/guard.go
+++ b/cmd/guard.go
@@ -238,10 +238,14 @@ func kindSet(kinds []string) map[string]bool {
 	return m
 }
 
-// allowed reports whether file matches any allow-list suffix.
+// allowed reports whether file matches any allow-list suffix. The suffix must
+// align on a path boundary, so "db.go" matches "pkg/db.go" but not "validb.go".
 func allowed(allow []string, file string) bool {
 	for _, a := range allow {
-		if a != "" && strings.HasSuffix(file, a) {
+		if a == "" {
+			continue
+		}
+		if file == a || strings.HasSuffix(file, "/"+a) {
 			return true
 		}
 	}

--- a/cmd/guard_test.go
+++ b/cmd/guard_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/query"
+)
+
+func TestGuardAllowed(t *testing.T) {
+	allow := []string{"agent/cost_budget.go", "supervisor/reload.go"}
+	cases := map[string]bool{
+		"modules/agent/cost_budget.go":       true,
+		"modules/agent/supervisor/reload.go": true,
+		"modules/agent/agent.go":             false,
+		"":                                   false,
+	}
+	for file, want := range cases {
+		if got := allowed(allow, file); got != want {
+			t.Errorf("allowed(%q) = %v, want %v", file, got, want)
+		}
+	}
+	if allowed(nil, "any.go") {
+		t.Error("empty allow-list should exempt nothing")
+	}
+}
+
+func TestGuardKindSet(t *testing.T) {
+	if kindSet(nil) != nil {
+		t.Error("empty kinds must return nil (means: all kinds)")
+	}
+	m := kindSet([]string{"func", " method "})
+	if !m["func"] || !m["method"] {
+		t.Errorf("kindSet trimmed/parsed wrong: %v", m)
+	}
+	if m["type"] {
+		t.Error("type should not be in the set")
+	}
+}
+
+func TestRefViolations(t *testing.T) {
+	ref := func(kind string, files ...string) query.BoundaryRef {
+		locs := make([]query.BoundaryLoc, len(files))
+		for i, f := range files {
+			locs[i] = query.BoundaryLoc{File: f, Line: i + 1}
+		}
+		return query.BoundaryRef{Symbol: "New", Kind: kind, SourcePkg: "a", TargetPkg: "b", Locations: locs}
+	}
+
+	t.Run("test files excluded by default", func(t *testing.T) {
+		r := guardRule{Name: "x"}
+		got := refViolations(r, ref("func", "prod.go", "prod_test.go"))
+		if len(got) != 1 || got[0].File != "prod.go" {
+			t.Fatalf("expected only prod.go, got %+v", got)
+		}
+	})
+
+	t.Run("include_tests keeps test sites", func(t *testing.T) {
+		r := guardRule{Name: "x", IncludeTests: true}
+		if got := refViolations(r, ref("func", "prod.go", "prod_test.go")); len(got) != 2 {
+			t.Fatalf("expected 2 with include_tests, got %d", len(got))
+		}
+	})
+
+	t.Run("allow-list grandfathers a site", func(t *testing.T) {
+		r := guardRule{Name: "x", Allow: []string{"reload.go"}}
+		got := refViolations(r, ref("func", "agent/reload.go", "agent/other.go"))
+		if len(got) != 1 || got[0].File != "agent/other.go" {
+			t.Fatalf("allow-list should drop reload.go, got %+v", got)
+		}
+	})
+
+	t.Run("no locations still yields one violation", func(t *testing.T) {
+		if got := refViolations(guardRule{Name: "x"}, ref("func")); len(got) != 1 || got[0].File != "" {
+			t.Fatalf("fileless crossing must not be hidden, got %+v", got)
+		}
+	})
+}

--- a/cmd/guard_test.go
+++ b/cmd/guard_test.go
@@ -12,8 +12,11 @@ func TestGuardAllowed(t *testing.T) {
 		"modules/agent/cost_budget.go":       true,
 		"modules/agent/supervisor/reload.go": true,
 		"modules/agent/agent.go":             false,
+		"agent/cost_budget.go":               true,  // whole-path match, no leading segment
+		"modules/agent/validb.go":            false, // must not match a "db.go" suffix mid-name
 		"":                                   false,
 	}
+	allow = append(allow, "db.go")
 	for file, want := range cases {
 		if got := allowed(allow, file); got != want {
 			t.Errorf("allowed(%q) = %v, want %v", file, got, want)

--- a/cmd/testdata/help/guard.golden
+++ b/cmd/testdata/help/guard.golden
@@ -1,0 +1,48 @@
+Enforce declared architecture boundaries against the indexed reference graph.
+
+guard reads a spec of deny rules and fails (exit 1) if any reference crosses a
+forbidden boundary. Unlike import-only linters it works on the REFERENCE graph,
+so a rule can forbid calls while allowing type imports (kinds: [func, method]).
+It is package-grained (suffix match), so rules survive a module->package collapse.
+
+Spec (.snipe/boundaries.yml by default):
+
+  version: 1
+  rules:
+    - name: shell-not-store
+      from: "agent/shell/..."      # recursive: pkg + descendants
+      to:   "persistence/store/..."
+      desc: "shell must not depend on store"
+    - name: agent-core-not-store
+      from: "agent/..."
+      to:   "persistence/store/..."
+      kinds: [func, method]        # call-level only (imports of types still allowed)
+      allow:                       # ratchet: exempt existing sites by file suffix
+        - "agent/cost_budget.go"
+
+An unmatched from/to pattern is a hard error (no silent no-op), exit 1.
+
+Examples:
+  snipe guard
+  snipe guard .snipe/boundaries.yml
+  snipe guard --format json
+
+Usage:
+  snipe guard [spec] [flags]
+
+Flags:
+  -h, --help   help for guard
+
+Global Flags:
+      --context int        Context lines around match (default 2)
+      --format string      concise (LLM default) | detailed | summary | json (stable, for tooling) | human (TTY) (default "concise")
+      --kg-hints           Include Orca KG hints
+      --limit int          Cap results returned (applied after --select) (default 10)
+      --max-tokens int     Token budget (0 = unlimited)
+      --no-body            Exclude function body
+      --no-siblings        Exclude sibling declarations
+      --offset int         Pagination offset
+      --select string      Pick top candidates by score: all, best, top3, top5 (applied before --limit) (default "all")
+      --signature-only     Return only signature (no body, no context)
+      --suggestions        Include next-step suggestions in Claude output
+      --timeout duration   Timeout for command (e.g., 30s, 5m)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -56,6 +56,7 @@ Graph & Structure:
   deadcode     Report exported symbols with zero non-test references
   deps         Show dependency topology for a package or the full project
   diagram      Render snipe graphs as D2 diagram source
+  guard        Assert architecture boundary rules; exit non-zero on violation
   importers    Find files that import a package
   imports      Show packages imported by a file
   lifecycle    Trace every function creating, mutating, reading, or deleting a type


### PR DESCRIPTION
Adds `snipe guard [spec]` — the gate `snipe boundary` was missing. Reads `.snipe/boundaries.yml` deny rules, reuses `query.FindBoundaryCrossings`, prints violations with file:line, exits non-zero on any.

**Why snipe and not another linter**
- Reference-level (not import-only): `kinds: [func, method]` forbids *calls* while allowing type imports — import linters (go-arch-lint, depguard) can't express this.
- Package-grained (suffix match): rules survive a module→package collapse.
- Reuses the index snipe already builds; no separate source parse.

**Behavior**
- Test files exempt by default (`include_tests` to opt in); `allow` list grandfathers known sites (ratchet).
- Unmatched from/to pattern is a hard error — no silent no-op (depguard glob footgun).
- Fails closed: spec/index errors and violations both exit 1.

Live-validated against trixi: caught 6 real `agent→store` call-level violations that depguard had let lapse to a comment. `make check` green; help golden + unit tests added.

Closes snipe-guard.