### PR TITLE
ci: Codex review → comment-model + port CI-on-demand rules

### DIFF
--- a/.claude/rules/ci-on-demand.md
+++ b/.claude/rules/ci-on-demand.md
@@ -1,0 +1,20 @@
+# CI On-Demand — opt expensive CI in at PR time
+
+*Codex review (OpenAI spend) no longer runs on every PR. Claude opts a PR in via a comment when the diff warrants it. Default OFF; unsure → don't opt in.*
+
+## Codex review — comment `@codex review`
+
+Advisory; does **not** gate merge (`make audit` / `check` is the gate).
+
+```bash
+gh pr comment <PR#> --body "@codex review"
+```
+
+| Request when diff has | Skip for |
+|---|---|
+| new/changed logic w/ branching or edge cases | docs / config / test-only |
+| concurrency / lifecycle / goroutine code | mechanical renames/moves, `s/this/that/g` sweeps |
+| persistence / write paths | dependency bumps |
+| scoring / retrieval / output-format changes | one-liners |
+| security-adjacent (auth, SSRF, input handling) | generated code |
+| large / sprawling change | reverts / cherry-picks of already-reviewed work |

--- a/.claude/rules/session-protocol.md
+++ b/.claude/rules/session-protocol.md
@@ -16,6 +16,7 @@ How to work on snipe. Stable — only update when the workflow itself changes.
 - One task per session. Finish it or document why it's blocked.
 - Commit after each logical unit that passes `make`.
 - For removals: batch by file/package, `make audit` after each batch.
+- ‡ **Batch small fixes → one PR.** Several small/independent fixes in flight → ONE branch, ONE PR, one commit per fix. `make audit`/CI fires once at the PR (+ once on merge to main), NOT once per fix — a PR-per-one-liner serializes the queue behind build time. Each fix stays its own commit (traceable); PR body lists them. Bundle by session/theme; ✗ mix a risky change in with trivial ones (it drags the whole PR's review bar up). **Default: auto-batch** — ≥2 small fixes queued → roll them onto one PR without asking.
 
 ### Verification evidence
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,47 +1,63 @@
 name: codex-review
 
-# Codex reviews PRs and posts findings as a single PR comment.
+# Codex reviews a PR ONLY when someone comments `@codex review` on it — normally
+# Claude opting the PR in at creation time when the diff has room for improvement
+# (see .claude/rules/ci-on-demand.md). On-demand, not every PR: keeps the OpenAI
+# spend and runner minutes off trivial/mechanical changes.
 # Linux-only (no macOS 10x billing). Requires repo secret OPENAI_API_KEY.
 # Review prompt: .github/codex/prompts/review.md
 #
-# Advisory only — does NOT gate merge (not a required status check).
-#
-# Gate (see the `if:` on the codex job): review runs only when the PR is NOT a
-# draft, targets `main`, AND is "meaty" — either carries the `codex-review`
-# label or changes >= 50 lines. Tune the threshold inline below.
+# This is advisory — it does NOT gate merge (not a required status check).
+# The merge gate remains `make audit` / the `check` workflow.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  issue_comment:
+    types: [created]
 
+# Top-level: least privilege. Per-job permissions widen only where needed.
 permissions:
   contents: read
 
 jobs:
   codex:
+    # Fire only on a PR comment carrying the trigger phrase. github.event.issue
+    # is a PR iff .pull_request is set. Private repo → commenters are already
+    # collaborators, so no extra author gating is needed.
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@codex review') }}
     runs-on: ubuntu-latest
-    if: >-
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.base.ref == 'main' &&
-      (
-        contains(github.event.pull_request.labels.*.name, 'codex-review') ||
-        (github.event.pull_request.additions + github.event.pull_request.deletions) >= 50
-      )
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
     steps:
+      # issue_comment carries no PR head/base context — resolve the base ref from
+      # the PR number before checkout/fetch can reference it.
+      - name: Resolve PR base ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          base_ref="$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.base.ref')"
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v5
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: refs/pull/${{ github.event.issue.number }}/merge
           persist-credentials: false
 
       - name: Pre-fetch base and head refs
+        # checkout above runs with persist-credentials: false, so it leaves no
+        # credential in .git/config. Authenticate this fetch with the run-scoped
+        # GITHUB_TOKEN — basic auth (base64 of x-access-token:<token>), the same
+        # scheme actions/checkout uses; GitHub's git endpoint rejects a bearer
+        # header here. The header is passed per-command via -c, so nothing is
+        # persisted to disk for the downstream Codex step to read.
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
           git -c http.extraheader="$AUTH_HEADER" \
@@ -73,7 +89,7 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: context.issue.number,
               body: process.env.CODEX_FINAL_MESSAGE,
             });
         env:


### PR DESCRIPTION
Ports trixi's CI-economy convention to snipe (Codex only — snipe has no macOS leg).

## Changes
- **`codex-review.yml` → comment model.** Trigger flips from `on: pull_request` (auto-fired on ≥50-line or `codex-review`-labeled PRs) to `on: issue_comment`, gated on `if: github.event.issue.pull_request && contains(comment.body, '@codex review')`. Adds issue_comment plumbing carried over from trixi's version: **Resolve PR base ref** via `gh api`, checkout `refs/pull/<n>/merge` with `persist-credentials: false`, **Pre-fetch base+head** with a basic-auth `http.extraheader`. `post_feedback` now keys on `context.issue.number`. Run Codex + prompt-file path unchanged.
- **`.claude/rules/ci-on-demand.md`** — new rule doc, Codex section only (no macOS section).
- **`session-protocol.md`** — ports the "Batch small fixes → one PR / auto-batch default" convention into the `### Workflow` section (snipe's dev-workflow home; guard-rails.md has no workflow section).

Advisory only — does NOT gate merge. `make audit` / `check` stays the gate.

## Deviations from the brief
- Brief said port the batching rule into `guard-rails.md` "under its Dev-Workflow-equivalent section". snipe's guard-rails.md has no workflow section (it's a different file from trixi's); the genuine dev-workflow home is `session-protocol.md` `### Workflow`. Placed it there per the boundary rule (workflow content → workflow file).
- snipe's codex-review.yml had no `setup-go` step, so none was kept/added (trixi's exists for its `make doctor` preflight; snipe's Codex prompt doesn't need it).