### PR TITLE
chore: add PR template + PR↔beads Closes-trailer rule

### DIFF
--- a/.claude/rules/session-protocol.md
+++ b/.claude/rules/session-protocol.md
@@ -16,7 +16,8 @@ How to work on snipe. Stable — only update when the workflow itself changes.
 - One task per session. Finish it or document why it's blocked.
 - Commit after each logical unit that passes `make`.
 - For removals: batch by file/package, `make audit` after each batch.
-- ‡ **Batch small fixes → one PR.** Several small/independent fixes in flight → ONE branch, ONE PR, one commit per fix. `make audit`/CI fires once at the PR (+ once on merge to main), NOT once per fix — a PR-per-one-liner serializes the queue behind build time. Each fix stays its own commit (traceable); PR body lists them. Bundle by session/theme; ✗ mix a risky change in with trivial ones (it drags the whole PR's review bar up). **Default: auto-batch** — ≥2 small fixes queued → roll them onto one PR without asking.
+- ‡ **Batch small fixes → one PR.** Several small/independent fixes in flight → ONE branch, ONE PR, one commit per bead. `make audit`/CI fires once at the PR (+ once on merge to main), NOT once per fix — a PR-per-one-liner serializes the queue behind build time. Each fix stays its own commit (traceable); PR body lists them. Bundle by session/theme; ✗ mix a risky change in with trivial ones (it drags the whole PR's review bar up). **Default: auto-batch** — ≥2 small fixes queued → roll them onto one PR without asking.
+- ‡ **PR ↔ beads.** Every PR body carries a `Closes:` trailer naming the beads it lands (`Closes: snipe-abc, snipe-def`; no bead → `Closes: none`); squash-merge keeps it in main's commit. On merge, close them with the ref: `bd close <ids> --reason "merged #<PR> (<sha>)"`. ✗ merge-then-forget — a landed-but-open bead is a leak.
 
 ### Verification evidence
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Keep it terse. Most PRs are small batches; one commit per bead. -->
+
+## What
+
+<!-- one-line summary of the change -->
+
+## Beads
+
+Closes: <bead-ids, comma-separated — or "none">
+
+<!-- On merge, close them with the landing ref: bd close <ids> --reason "merged #<PR> (<sha>)".
+     See .claude/rules/session-protocol.md (During → Workflow). -->
+
+## Notes
+
+<!-- review pointers, risk, test/eval evidence -->


### PR DESCRIPTION
Addendum to #163 — adds the PR↔beads half of the CI-economy port.

## What
- **`.github/pull_request_template.md`** (new) — What / Beads (`Closes: <ids|none>`) / Notes. Adapted from trixi's; dropped the trixi-only `scripts/wt-land` mention (snipe has no wt-land); comment points at `session-protocol.md`.
- **`session-protocol.md`** — added a terse **PR ↔ beads** rule next to the batching convention: every PR body carries a `Closes:` trailer; on merge close beads with `bd close <ids> --reason "merged #<PR> (<sha>)"`; ✗ merge-then-forget. Also aligned the batching line to "one commit per bead" (snipe uses beads — `.beads/` present).

## Notes
- **Placement:** the batching + Closes rules live in `session-protocol.md` `### Workflow`, not `guard-rails.md`. Verified on main: the batching rule is in session-protocol.md **only** (not duplicated, not in CLAUDE.md). snipe's `guard-rails.md` is architectural principles (D1/D2/D4) + "Do Not Build" with no workflow section; session-protocol.md is the genuine dev-workflow home ("One task per session", commit cadence, removal-batching). Kept the workflow rules together there per single-concern-per-file. Easy to relocate if you'd rather it be in guard-rails.md.
- Docs/config only; no code paths touched.

Closes: none