### PR TITLE
fix: drain go-bug-audit bug backlog (8 fixes)

### DIFF
--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -108,12 +109,24 @@ func runEmbedStatus() error {
 
 		// Handle completion
 		if state.Status == batchStatusCompleted {
-			embedCount, err := downloadAndSaveEmbeddings(GetContext(), client, state, dbPath)
+			// embed-status is a standalone command with no parent store handle,
+			// so opening here is safe (no concurrent writer on the same file).
+			s, openErr := store.Open(dbPath)
+			if openErr != nil {
+				return fmt.Errorf("open store: %w", openErr)
+			}
+			embedCount, err := downloadAndSaveEmbeddings(GetContext(), client, state, s)
+			closeErr := s.Close()
 			if err != nil {
+				// Save failed (locked rows, parse error) — keep batch_state.json
+				// so the paid batch stays recoverable. Do NOT ClearState.
 				return fmt.Errorf("download embeddings: %w", err)
 			}
+			if closeErr != nil {
+				return fmt.Errorf("close store: %w", closeErr)
+			}
 
-			// Clear batch state
+			// Genuine full save — safe to clear batch state.
 			if err := client.ClearState(); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to clear state: %v\n", err)
 			}
@@ -199,9 +212,30 @@ func runEmbedStatus() error {
 	}
 }
 
+// embeddingSaver is the persistence seam downloadAndSaveEmbeddings writes
+// through. *store.Store satisfies it; tests inject a failing implementation.
+// Threading the parent's already-open *store.Store (rather than opening a
+// second handle on the same SQLite file) keeps a SINGLE single-conn pool, so
+// writes serialize correctly instead of contending on busy_timeout and
+// returning "database is locked".
+type embeddingSaver interface {
+	SaveEmbedding(symbolID string, embedding []float32, model string) error
+}
+
+// embeddingStreamParser matches *embed.BatchClient.ParseBatchResults: it reads
+// JSONL from r and invokes fn for each parsed embedding. Factoring it out as a
+// function value lets persistEmbeddings be unit-tested without a real
+// BatchClient or network round-trip.
+type embeddingStreamParser func(r io.Reader, fn func(symbolID string, embedding []float32) error) error
+
 // downloadAndSaveEmbeddings streams batch results directly to the store.
 // Downloads and parses line-by-line to avoid buffering the entire payload in RAM.
-func downloadAndSaveEmbeddings(ctx context.Context, client *embed.BatchClient, state *embed.BatchState, dbPath string) (int, error) {
+//
+// Per-row save failures are accumulated, NOT swallowed: if any row fails to
+// persist, the function returns a non-nil error so the caller keeps
+// batch_state.json and the paid batch stays recoverable. Returns the number of
+// rows actually saved alongside that error.
+func downloadAndSaveEmbeddings(ctx context.Context, client *embed.BatchClient, state *embed.BatchState, saver embeddingSaver) (int, error) {
 	if state.OutputFileID == "" {
 		return 0, fmt.Errorf("no output file available")
 	}
@@ -214,18 +248,28 @@ func downloadAndSaveEmbeddings(ctx context.Context, client *embed.BatchClient, s
 	}
 	defer body.Close()
 
-	// Open store before streaming so we can persist each embedding immediately.
-	s, err := store.Open(dbPath)
-	if err != nil {
-		return 0, fmt.Errorf("open store: %w", err)
-	}
-	defer s.Close()
+	return persistEmbeddings(body, client.ParseBatchResults, saver, state.Model)
+}
 
+// persistEmbeddings streams parsed embeddings into saver, accumulating per-row
+// save failures instead of swallowing them. A "database is locked" on any row
+// means a paid embedding never landed; the resulting non-nil error tells the
+// caller to PRESERVE batch_state.json so the batch stays recoverable rather
+// than clearing it and silently dropping the paid rows (snipe-apz).
+func persistEmbeddings(body io.Reader, parse embeddingStreamParser, saver embeddingSaver, model string) (int, error) {
 	count := 0
-	if err := client.ParseBatchResults(body, func(symbolID string, embedding []float32) error {
-		if err := s.SaveEmbedding(symbolID, embedding, state.Model); err != nil {
+	failed := 0
+	var firstSaveErr error
+	if err := parse(body, func(symbolID string, embedding []float32) error {
+		if err := saver.SaveEmbedding(symbolID, embedding, model); err != nil {
+			// Do NOT swallow: record the failure and keep streaming so we save
+			// what we can, then surface a non-nil error after the stream.
 			fmt.Fprintf(os.Stderr, "Warning: failed to save embedding for %s: %v\n", symbolID, err)
-			return nil // continue on save errors
+			failed++
+			if firstSaveErr == nil {
+				firstSaveErr = err
+			}
+			return nil // keep going; the accumulated error is returned after the stream
 		}
 		count++
 		return nil
@@ -234,6 +278,10 @@ func downloadAndSaveEmbeddings(ctx context.Context, client *embed.BatchClient, s
 	}
 
 	fmt.Fprintf(os.Stderr, "Saved %d embeddings to index\n", count)
+
+	if failed > 0 {
+		return count, fmt.Errorf("failed to save %d of %d embeddings (first error: %w); keeping batch state for recovery", failed, failed+count, firstSaveErr)
+	}
 
 	return count, nil
 }

--- a/cmd/embed_test.go
+++ b/cmd/embed_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// failingSaver fails every SaveEmbedding, simulating a "database is locked"
+// stall on the SQLite WAL — the failure mode that previously got swallowed and
+// caused paid Voyage embeddings to vanish (snipe-apz).
+type failingSaver struct {
+	calls int
+}
+
+func (f *failingSaver) SaveEmbedding(symbolID string, embedding []float32, model string) error {
+	f.calls++
+	return errors.New("database is locked")
+}
+
+// countingSaver records every successful save. Used for the happy path.
+type countingSaver struct {
+	saved int
+}
+
+func (c *countingSaver) SaveEmbedding(symbolID string, embedding []float32, model string) error {
+	c.saved++
+	return nil
+}
+
+// fakeParser returns an embeddingStreamParser that emits the given symbol IDs
+// (with a trivial embedding each), ignoring the reader entirely — so the test
+// needs no network, no real BatchClient, and no credentials.
+func fakeParser(symbolIDs ...string) embeddingStreamParser {
+	return func(_ io.Reader, fn func(symbolID string, embedding []float32) error) error {
+		for _, id := range symbolIDs {
+			if err := fn(id, []float32{0.1, 0.2}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// TestPersistEmbeddings_FailingSaverPropagatesError is the core regression for
+// snipe-apz: when SaveEmbedding fails, the error must NOT be swallowed — it has
+// to propagate so the caller keeps batch_state.json and the paid batch stays
+// recoverable.
+func TestPersistEmbeddings_FailingSaverPropagatesError(t *testing.T) {
+	saver := &failingSaver{}
+
+	count, err := persistEmbeddings(strings.NewReader(""), fakeParser("symA", "symB"), saver, "voyage-test")
+
+	if err == nil {
+		t.Fatal("persistEmbeddings returned nil error despite every SaveEmbedding failing — the lock error was swallowed (snipe-apz regression)")
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (no row persisted when every save fails)", count)
+	}
+	if saver.calls != 2 {
+		t.Errorf("SaveEmbedding called %d times, want 2 (stream should keep going to save what it can)", saver.calls)
+	}
+}
+
+// TestPersistEmbeddings_SuccessReturnsNoError asserts the happy path still
+// returns a nil error (so the caller is free to ClearState only here).
+func TestPersistEmbeddings_SuccessReturnsNoError(t *testing.T) {
+	saver := &countingSaver{}
+
+	count, err := persistEmbeddings(strings.NewReader(""), fakeParser("symA", "symB", "symC"), saver, "voyage-test")
+
+	if err != nil {
+		t.Fatalf("persistEmbeddings returned error on all-success path: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+// TestRecoveryGuard_PreservesBatchStateOnSaveFailure models the caller's
+// ClearState guard end to end: a save failure must leave batch_state.json on
+// disk so the paid batch can be recovered on the next run. Before snipe-apz the
+// recovery branch swallowed the error, "succeeded", and ClearState deleted the
+// only record of the paid batch.
+func TestRecoveryGuard_PreservesBatchStateOnSaveFailure(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "batch_state.json")
+	if err := os.WriteFile(statePath, []byte(`{"batch_id":"b-123","status":"completed"}`), 0o600); err != nil {
+		t.Fatalf("seed batch_state.json: %v", err)
+	}
+
+	saver := &failingSaver{}
+	_, err := persistEmbeddings(strings.NewReader(""), fakeParser("symA"), saver, "voyage-test")
+	if err == nil {
+		t.Fatal("expected non-nil error from failing save")
+	}
+
+	// Caller guard: ClearState runs ONLY when persistEmbeddings returns nil.
+	// Here err != nil, so the (simulated) caller must skip the delete.
+	clearState := func() error { return os.Remove(statePath) }
+	if err == nil {
+		_ = clearState()
+	}
+
+	if _, statErr := os.Stat(statePath); statErr != nil {
+		t.Fatalf("batch_state.json was removed despite a save failure — paid batch became unrecoverable (snipe-apz): %v", statErr)
+	}
+}
+
+// TestRecoveryGuard_ClearsBatchStateOnSuccess is the complement: a genuinely
+// complete save returns nil, so the caller is free to clear the state file.
+func TestRecoveryGuard_ClearsBatchStateOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "batch_state.json")
+	if err := os.WriteFile(statePath, []byte(`{"batch_id":"b-123","status":"completed"}`), 0o600); err != nil {
+		t.Fatalf("seed batch_state.json: %v", err)
+	}
+
+	saver := &countingSaver{}
+	_, err := persistEmbeddings(strings.NewReader(""), fakeParser("symA"), saver, "voyage-test")
+	if err != nil {
+		t.Fatalf("unexpected error on success path: %v", err)
+	}
+
+	clearState := func() error { return os.Remove(statePath) }
+	if err == nil {
+		if cErr := clearState(); cErr != nil {
+			t.Fatalf("clear state: %v", cErr)
+		}
+	}
+
+	if _, statErr := os.Stat(statePath); !os.IsNotExist(statErr) {
+		t.Fatalf("batch_state.json should be cleared on full success, stat err = %v", statErr)
+	}
+}

--- a/cmd/heal.go
+++ b/cmd/heal.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -64,9 +65,28 @@ func maybeSelfHeal(s *store.Store, root string) bool {
 	if err != nil {
 		return false
 	}
-	cmd := exec.Command(exe, "index", "--embed-mode=off", "--enrich=false", root)
+
+	// Honor the command context (--timeout / SIGINT) so a heal can never block a
+	// query past its caller's wall-clock budget. CommandContext also kills the
+	// child when ctx fires; runHealCmd's select adds the 15s backstop.
+	ctx := GetContext()
+	cmd := exec.CommandContext(ctx, exe, "index", "--embed-mode=off", "--enrich=false", root)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
+	if !runHealCmd(ctx, cmd) {
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "healed index: %d changed files reindexed\n", changes.TotalChanged())
+	return true
+}
+
+// runHealCmd starts cmd and waits for it under three exit conditions: clean
+// finish (true), ctx cancellation (kill + drain, false), or the healTimeout
+// backstop (kill + drain, false). It is the testable seam for the ctx-honoring
+// behavior — maybeSelfHeal's store/fingerprint preamble makes it hard to drive
+// end to end, so the subprocess lifecycle lives here on its own.
+func runHealCmd(ctx context.Context, cmd *exec.Cmd) bool {
 	if err := cmd.Start(); err != nil {
 		return false
 	}
@@ -75,17 +95,16 @@ func maybeSelfHeal(s *store.Store, root string) bool {
 	go func() { done <- cmd.Wait() }()
 	select {
 	case err := <-done:
-		if err != nil {
-			return false
-		}
+		return err == nil
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		<-done
+		return false
 	case <-time.After(healTimeout):
 		_ = cmd.Process.Kill()
 		<-done
 		return false
 	}
-
-	fmt.Fprintf(os.Stderr, "healed index: %d changed files reindexed\n", changes.TotalChanged())
-	return true
 }
 
 // shouldHeal is the inline-heal decision: small drift heals, large drift warns.

--- a/cmd/heal_test.go
+++ b/cmd/heal_test.go
@@ -1,6 +1,52 @@
 package cmd
 
-import "testing"
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestRunHealCmdHonorsCtxCancel drives runHealCmd with a slow subprocess and a
+// context that cancels after ~50ms. The heal must return promptly (the killed
+// subprocess), not block ~15s on the healTimeout backstop. Guards snipe-7ba:
+// self-heal must honor cmdCtx so a query's --timeout bounds wall-clock.
+func TestRunHealCmdHonorsCtxCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sleep(1)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// A subprocess that would run far longer than the ctx timeout (and the 15s
+	// backstop). CommandContext + the <-ctx.Done() arm must kill it early.
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+
+	start := time.Now()
+	ok := runHealCmd(ctx, cmd)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Errorf("runHealCmd returned true on ctx cancel; want false")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("runHealCmd blocked %v on ctx cancel; want prompt return (~50ms), not the 15s backstop", elapsed)
+	}
+}
+
+// TestRunHealCmdCleanFinish confirms a fast subprocess that exits 0 yields true.
+func TestRunHealCmdCleanFinish(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses true(1)")
+	}
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, "true")
+	if !runHealCmd(ctx, cmd) {
+		t.Errorf("runHealCmd returned false for a clean exit; want true")
+	}
+}
 
 func TestShouldHeal(t *testing.T) {
 	cases := []struct {

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -670,9 +670,15 @@ func runIncrementalIndex(s *store.Store, result *index.LoadResult, allSymbols []
 	}
 	fmt.Fprintf(os.Stderr, "Found %d imports\n", len(imports))
 
-	// Write incremental update
+	// Extract string literals for changed files only — written atomically
+	// inside WriteIndexIncremental's tx so symbols + literal-refs for a
+	// changed file commit in the same generation (snipe-er5).
+	literals := index.ExtractLiteralsFiltered(result, allSymbols, onlyFiles)
+	fmt.Fprintf(os.Stderr, "Found %d string literals in changed files\n", len(literals))
+
+	// Write incremental update (symbols, refs, edges, imports, literals)
 	fmt.Fprintf(os.Stderr, "Writing incremental index...\n")
-	incResult, err := s.WriteIndexIncremental(changedSymbols, refs, edges, imports, changedFiles, changes.Deleted)
+	incResult, err := s.WriteIndexIncremental(changedSymbols, refs, edges, imports, literals, changedFiles, changes.Deleted)
 	if err != nil {
 		return fmt.Errorf("write incremental index: %w", err)
 	}
@@ -680,13 +686,6 @@ func runIncrementalIndex(s *store.Store, result *index.LoadResult, allSymbols []
 	// Write package docs (full replace — cheap and ensures consistency)
 	if err := s.WritePackageDocs(pkgDocs); err != nil {
 		return fmt.Errorf("write package docs: %w", err)
-	}
-
-	// Extract and write string literals for changed files only
-	literals := index.ExtractLiteralsFiltered(result, allSymbols, onlyFiles)
-	fmt.Fprintf(os.Stderr, "Found %d string literals in changed files\n", len(literals))
-	if err := s.WriteLiteralsForFiles(literals, changedFiles, changes.Deleted, absDir); err != nil {
-		return fmt.Errorf("write literals incremental: %w", err)
 	}
 
 	// Update file hashes for ALL files (cheap stat calls)
@@ -721,16 +720,12 @@ func runDeleteOnlyIndex(s *store.Store, changes *index.ChangeResult, absDir stri
 	nDel := len(changes.Deleted)
 	fmt.Fprintf(os.Stderr, "Delete-only: removing %d files (skipping package load)\n", nDel)
 
-	// Remove symbols, refs, edges, imports, embeddings, purposes, and file entries
-	// for deleted files (all within a single transaction in WriteIndexIncremental)
-	incResult, err := s.WriteIndexIncremental(nil, nil, nil, nil, nil, changes.Deleted)
+	// Remove symbols, refs, edges, imports, string_refs, embeddings, purposes,
+	// and file entries for deleted files — all within a single transaction in
+	// WriteIndexIncremental (nil literals + deleted files prunes string_refs).
+	incResult, err := s.WriteIndexIncremental(nil, nil, nil, nil, nil, nil, changes.Deleted)
 	if err != nil {
 		return fmt.Errorf("delete-only incremental: %w", err)
-	}
-
-	// Remove string_refs for deleted files
-	if err := s.WriteLiteralsForFiles(nil, nil, changes.Deleted, ""); err != nil {
-		return fmt.Errorf("delete literals: %w", err)
 	}
 
 	// Update metadata

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -433,6 +433,46 @@ func resolveEmbedMode(mode string, legacyEmbed bool, s *store.Store) string {
 // batchStaleThreshold is how long a batch can be in validating/in_progress before considered stale.
 const batchStaleThreshold = 12 * time.Hour
 
+// recoverCompletedBatch downloads and saves the results of an already-completed
+// batch, reusing the caller's open store handle so the write goes through ONE
+// connection pool rather than contending on the SQLite WAL lock (snipe-apz).
+//
+// Returns:
+//   - (false, nil): the batch is for a different index generation; state has
+//     been cleared and the caller should start a fresh batch.
+//   - (true, nil):  results were saved and batch state cleared.
+//   - (true, err):  the save failed; batch_state.json is PRESERVED so the paid
+//     batch stays recoverable. The caller must NOT start a new batch (that would
+//     re-bill and orphan the completed one) — surface the error instead.
+func recoverCompletedBatch(ctx context.Context, client *embed.BatchClient, state *embed.BatchState, s *store.Store, fingerprint string) (bool, error) {
+	if !state.MatchesFingerprint(fingerprint) {
+		fmt.Fprintf(os.Stderr, "  Batch was created for a different index version, discarding stale results...\n")
+		if clearErr := client.ClearState(); clearErr != nil {
+			return false, fmt.Errorf("clear stale batch state: %w", clearErr)
+		}
+		return false, nil
+	}
+
+	// Batch completed but results never processed — auto-recover.
+	fmt.Fprintf(os.Stderr, "  Batch completed, recovering results...\n")
+	count, dlErr := downloadAndSaveEmbeddings(ctx, client, state, s)
+	if dlErr != nil {
+		// A save error (locked rows) or a download/parse error (expired output,
+		// API error) leaves batch_state.json in place so the paid batch stays
+		// recoverable next run. Do NOT ClearState, do NOT start a fresh batch.
+		fmt.Fprintf(os.Stderr, "  Recovery failed: %v\n", dlErr)
+		fmt.Fprintf(os.Stderr, "  Keeping batch state for recovery; not starting a new batch.\n")
+		return true, fmt.Errorf("recover batch embeddings (%d saved): %w", count, dlErr)
+	}
+
+	// Genuine full save — safe to clear batch state.
+	fmt.Fprintf(os.Stderr, "  Recovered %d embeddings from completed batch\n", count)
+	if clearErr := client.ClearState(); clearErr != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: failed to clear state: %v\n", clearErr)
+	}
+	return true, nil
+}
+
 // startBatchEmbeddings initiates async batch embedding via Voyage API.
 // fingerprint identifies the index generation that these embeddings belong to.
 // s is the caller's already-open store; the recovery branch reuses it so a
@@ -465,6 +505,25 @@ func startBatchEmbeddings(ctx context.Context, s *store.Store, repoRoot string, 
 		state = nil
 	}
 
+	// A persisted "completed" status means a prior `snipe embed-status` (or index
+	// recovery) fetched a finished batch but failed to download/save its results
+	// and preserved the state for recovery (snipe-apz). Re-attempt the save here
+	// instead of falling through to start a fresh, double-billed batch that would
+	// also orphan the paid completed one. (The validating/in_progress branch below
+	// only discovers a completed batch via the API; a state file already marked
+	// completed would otherwise slip past it unrecovered.)
+	if state != nil && state.Status == batchStatusCompleted {
+		handled, rErr := recoverCompletedBatch(ctx, client, state, s, fingerprint)
+		if rErr != nil {
+			return "", rErr
+		}
+		if handled {
+			return "batch_recovered", nil
+		}
+		// Fingerprint mismatch: state cleared, fall through to start a new batch.
+		state = nil
+	}
+
 	if state != nil && (state.Status == "validating" || state.Status == "in_progress") {
 		// Check if batch is stale (stuck for too long)
 		age := time.Since(state.UpdatedAt)
@@ -493,49 +552,22 @@ func startBatchEmbeddings(ctx context.Context, s *store.Store, repoRoot string, 
 					}
 					// Fall through to start new batch
 				case batchStatusCompleted:
-					// Check if batch was created for a different index generation
-					if !state.MatchesFingerprint(fingerprint) {
-						fmt.Fprintf(os.Stderr, "  Batch was created for a different index version, discarding stale results...\n")
-						if clearErr := client.ClearState(); clearErr != nil {
-							return "", fmt.Errorf("clear stale batch state: %w", clearErr)
-						}
-						// Fall through to start new batch
-					} else {
-						// Batch completed but results never processed — auto-recover
-						fmt.Fprintf(os.Stderr, "  Batch completed, recovering results...\n")
+					// Update state with output file info from API, then recover.
+					state.Status = batchStatusCompleted
+					state.OutputFileID = actualStatus.OutputFileID
+					state.ErrorFileID = actualStatus.ErrorFileID
+					state.Completed = actualStatus.RequestCounts.Completed
+					state.Failed = actualStatus.RequestCounts.Failed
+					state.UpdatedAt = time.Now()
 
-						// Update state with output file info from API
-						state.Status = batchStatusCompleted
-						state.OutputFileID = actualStatus.OutputFileID
-						state.ErrorFileID = actualStatus.ErrorFileID
-						state.Completed = actualStatus.RequestCounts.Completed
-						state.Failed = actualStatus.RequestCounts.Failed
-						state.UpdatedAt = time.Now()
-
-						// Reuse the parent's open store — a second handle on the
-						// same SQLite file would contend on the WAL lock and could
-						// drop paid embeddings under "database is locked" (snipe-apz).
-						count, dlErr := downloadAndSaveEmbeddings(ctx, client, state, s)
-						if dlErr != nil {
-							// A save error (locked rows) leaves batch_state.json in
-							// place: keep it so the paid batch stays recoverable next
-							// run. Do NOT ClearState here, and do NOT start a fresh
-							// batch (which would re-bill). Surface the error instead.
-							//
-							// A pure download/parse error (expired output, API error)
-							// also keeps state — re-running can re-attempt the same
-							// completed batch rather than paying for a new one.
-							fmt.Fprintf(os.Stderr, "  Recovery failed: %v\n", dlErr)
-							fmt.Fprintf(os.Stderr, "  Keeping batch state for recovery; not starting a new batch.\n")
-							return "", fmt.Errorf("recover batch embeddings (%d saved): %w", count, dlErr)
-						}
-						// Genuine full save — safe to clear batch state.
-						fmt.Fprintf(os.Stderr, "  Recovered %d embeddings from completed batch\n", count)
-						if clearErr := client.ClearState(); clearErr != nil {
-							fmt.Fprintf(os.Stderr, "  Warning: failed to clear state: %v\n", clearErr)
-						}
+					handled, rErr := recoverCompletedBatch(ctx, client, state, s, fingerprint)
+					if rErr != nil {
+						return "", rErr
+					}
+					if handled {
 						return "batch_recovered", nil
 					}
+					// Fingerprint mismatch: state cleared, fall through to new batch.
 				default:
 					// Batch is still running according to API, but very old
 					fmt.Fprintf(os.Stderr, "  Batch is still %q according to Voyage AI.\n", actualStatus.Status)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -284,7 +284,7 @@ func runIndex(args []string) error {
 	case embedModeOff:
 		embedStatus = "disabled"
 	case embedModeBatch:
-		status, err := startBatchEmbeddings(GetContext(), absDir, symbols, fp.Combined)
+		status, err := startBatchEmbeddings(GetContext(), s, absDir, symbols, fp.Combined)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: batch embedding failed: %v\n", err)
 			embedStatus = batchStatusFailed
@@ -435,7 +435,10 @@ const batchStaleThreshold = 12 * time.Hour
 
 // startBatchEmbeddings initiates async batch embedding via Voyage API.
 // fingerprint identifies the index generation that these embeddings belong to.
-func startBatchEmbeddings(ctx context.Context, repoRoot string, symbols []index.Symbol, fingerprint string) (string, error) {
+// s is the caller's already-open store; the recovery branch reuses it so a
+// recovered batch writes through ONE connection pool instead of opening a
+// second handle that contends on the SQLite WAL lock (snipe-apz).
+func startBatchEmbeddings(ctx context.Context, s *store.Store, repoRoot string, symbols []index.Symbol, fingerprint string) (string, error) {
 	snipeDir := filepath.Join(repoRoot, ".snipe")
 	client, err := embed.NewBatchClient(snipeDir)
 	if err != nil {
@@ -509,23 +512,29 @@ func startBatchEmbeddings(ctx context.Context, repoRoot string, symbols []index.
 						state.Failed = actualStatus.RequestCounts.Failed
 						state.UpdatedAt = time.Now()
 
-						dbPath := store.DefaultIndexPath(repoRoot)
-						count, dlErr := downloadAndSaveEmbeddings(ctx, client, state, dbPath)
+						// Reuse the parent's open store — a second handle on the
+						// same SQLite file would contend on the WAL lock and could
+						// drop paid embeddings under "database is locked" (snipe-apz).
+						count, dlErr := downloadAndSaveEmbeddings(ctx, client, state, s)
 						if dlErr != nil {
-							// Download failed (expired output, API error) — clear and restart
+							// A save error (locked rows) leaves batch_state.json in
+							// place: keep it so the paid batch stays recoverable next
+							// run. Do NOT ClearState here, and do NOT start a fresh
+							// batch (which would re-bill). Surface the error instead.
+							//
+							// A pure download/parse error (expired output, API error)
+							// also keeps state — re-running can re-attempt the same
+							// completed batch rather than paying for a new one.
 							fmt.Fprintf(os.Stderr, "  Recovery failed: %v\n", dlErr)
-							fmt.Fprintf(os.Stderr, "  Clearing state and starting fresh...\n")
-							if clearErr := client.ClearState(); clearErr != nil {
-								return "", fmt.Errorf("clear failed batch state: %w", clearErr)
-							}
-							// Fall through to start new batch
-						} else {
-							fmt.Fprintf(os.Stderr, "  Recovered %d embeddings from completed batch\n", count)
-							if clearErr := client.ClearState(); clearErr != nil {
-								fmt.Fprintf(os.Stderr, "  Warning: failed to clear state: %v\n", clearErr)
-							}
-							return "batch_recovered", nil
+							fmt.Fprintf(os.Stderr, "  Keeping batch state for recovery; not starting a new batch.\n")
+							return "", fmt.Errorf("recover batch embeddings (%d saved): %w", count, dlErr)
 						}
+						// Genuine full save — safe to clear batch state.
+						fmt.Fprintf(os.Stderr, "  Recovered %d embeddings from completed batch\n", count)
+						if clearErr := client.ClearState(); clearErr != nil {
+							fmt.Fprintf(os.Stderr, "  Warning: failed to clear state: %v\n", clearErr)
+						}
+						return "batch_recovered", nil
 					}
 				default:
 					// Batch is still running according to API, but very old

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -66,7 +66,7 @@ func runSearch(args []string) error {
 	}
 	// Search from the resolved repo root (D3), never arbitrary cwd — keeps rg
 	// from walking outside the repo when invoked from a subdir or above the root.
-	results, err := search.Search(root, pattern, lim, ctx, globs...)
+	results, err := search.Search(GetContext(), root, pattern, lim, ctx, globs...)
 	if err != nil {
 		code := output.ErrInternal
 		if strings.Contains(err.Error(), "not found") {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 )
+
+// watchDrainTimeout bounds the best-effort final reindex performed when the
+// watch loop is cancelled, so shutdown can't hang.
+const watchDrainTimeout = 5 * time.Second
 
 var (
 	watchDebounce int
@@ -52,12 +57,7 @@ func runWatch() error {
 	var pendingFiles []string
 	debounceDuration := time.Duration(watchDebounce) * time.Millisecond
 
-	type reindexResult struct {
-		files   []string
-		elapsed time.Duration
-		err     error
-	}
-	reindexDone := make(chan reindexResult, 1)
+	reindexDone := make(chan reindexResultT, 1)
 	indexing := false
 
 	startReindex := func(files []string) {
@@ -69,8 +69,8 @@ func runWatch() error {
 		})
 		go func() {
 			start := time.Now()
-			err := runReindex(dir)
-			reindexDone <- reindexResult{files: files, elapsed: time.Since(start), err: err}
+			err := runReindex(GetContext(), dir)
+			reindexDone <- reindexResultT{files: files, elapsed: time.Since(start), err: err}
 		}()
 	}
 
@@ -185,6 +185,11 @@ func runWatch() error {
 			})
 
 		case <-GetContext().Done():
+			// Best-effort final drain: a reindex finishing concurrently with
+			// cancel (or files queued during one) would otherwise be dropped,
+			// losing the last edit before Ctrl+C. The parent ctx is already
+			// cancelled, so use a fresh bounded context for the drain.
+			drainOnCancel(dir, indexing, pendingFiles, reindexDone)
 			emitEvent(WatchEvent{
 				Event:     "stopped",
 				Timestamp: time.Now().Format(time.RFC3339),
@@ -192,6 +197,84 @@ func runWatch() error {
 			return GetContext().Err()
 		}
 	}
+}
+
+// drainOnCancel performs a best-effort final reindex when the watch loop is
+// cancelled, so files edited just before shutdown aren't silently dropped.
+//
+// If a reindex is already in flight (indexing), it waits briefly (bounded) for
+// it to finish, folding any files it carried plus newly-pending files into the
+// drain set, rather than starting an overlapping reindex. It then runs ONE last
+// synchronous reindex with a short bounded context if anything remains pending.
+//
+// reindexFn is injectable for testing; nil falls back to the real runReindex.
+func drainOnCancel(dir string, indexing bool, pending []string, reindexDone <-chan reindexResultT) {
+	drainOnCancelWith(dir, indexing, pending, reindexDone, nil)
+}
+
+// reindexResultT carries a reindex goroutine's outcome on reindexDone. It is a
+// package-level type (not loop-local) so the drainOnCancel seam can be
+// unit-tested without reconstructing the watch loop.
+type reindexResultT struct {
+	files   []string
+	elapsed time.Duration
+	err     error
+}
+
+func drainOnCancelWith(
+	dir string,
+	indexing bool,
+	pending []string,
+	reindexDone <-chan reindexResultT,
+	reindexFn func(context.Context, string) error,
+) {
+	if reindexFn == nil {
+		reindexFn = runReindex
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), watchDrainTimeout)
+	defer cancel()
+
+	// An in-flight reindex's subprocess was killed by the cancelled parent ctx,
+	// but its goroutine still sends on reindexDone. Wait (bounded) for it so we
+	// don't start an overlapping reindex; its files are already pending again.
+	if indexing {
+		select {
+		case res := <-reindexDone:
+			// The killed reindex didn't durably cover its files — fold them
+			// back in so the final drain re-runs them.
+			if res.err != nil {
+				pending = append(pending, res.files...)
+			}
+		case <-ctx.Done():
+			// Timed out waiting; fall through and attempt a drain anyway.
+		}
+	}
+
+	if len(pending) == 0 {
+		return
+	}
+
+	emitEvent(WatchEvent{
+		Event:     "reindex_started",
+		Files:     pending,
+		Timestamp: time.Now().Format(time.RFC3339),
+	})
+	if err := reindexFn(ctx, dir); err != nil {
+		if ctx.Err() == nil {
+			emitEvent(WatchEvent{
+				Event:     cmdKindError,
+				Error:     err.Error(),
+				Timestamp: time.Now().Format(time.RFC3339),
+			})
+		}
+		return
+	}
+	emitEvent(WatchEvent{
+		Event:     "reindexed",
+		Files:     pending,
+		Timestamp: time.Now().Format(time.RFC3339),
+	})
 }
 
 // addWatchDirs recursively adds directories to the watcher.
@@ -223,16 +306,16 @@ func addWatchDirs(watcher *fsnotify.Watcher, root string) error {
 	})
 }
 
-// runReindex runs 'snipe index' as a subprocess.
+// runReindex runs 'snipe index' as a subprocess, bound to ctx.
 // V1: Full reindex. V2 will add incremental support.
-func runReindex(dir string) error {
+func runReindex(ctx context.Context, dir string) error {
 	// Find the snipe binary
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("find executable: %w", err)
 	}
 
-	cmd := exec.CommandContext(GetContext(), exe, "index") // #nosec G204 -- exe from os.Executable(), trusted self-invocation
+	cmd := exec.CommandContext(ctx, exe, "index") // #nosec G204 -- exe from os.Executable(), trusted self-invocation
 	cmd.Dir = dir
 	cmd.Stdout = os.Stderr // Redirect index output to stderr
 	cmd.Stderr = os.Stderr

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingReindex is an injectable runReindex that records the files it was
+// asked to index (via a side channel the test sets up before invocation) and
+// the contexts it received.
+type recordingReindex struct {
+	mu    sync.Mutex
+	calls int
+	ctxs  []context.Context
+	err   error
+}
+
+func (r *recordingReindex) fn(ctx context.Context, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	r.ctxs = append(r.ctxs, ctx)
+	return r.err
+}
+
+func (r *recordingReindex) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// TestDrainOnCancelRunsFinalReindex covers the core snipe-l6a fix: when the
+// watch loop is cancelled with files pending (and no reindex in flight), the
+// drain runs one final reindex so the last edit before Ctrl+C isn't dropped.
+func TestDrainOnCancelRunsFinalReindex(t *testing.T) {
+	rec := &recordingReindex{}
+	done := make(chan reindexResultT, 1) // empty: nothing in flight
+
+	drainOnCancelWith("dir", false, []string{"b.go"}, done, rec.fn)
+
+	if got := rec.count(); got != 1 {
+		t.Fatalf("drain ran reindex %d times; want exactly 1 (the final drain)", got)
+	}
+}
+
+// TestDrainOnCancelNoPendingSkips confirms the drain is a no-op when nothing is
+// pending and no reindex is in flight — no wasted final reindex on a clean stop.
+func TestDrainOnCancelNoPendingSkips(t *testing.T) {
+	rec := &recordingReindex{}
+	done := make(chan reindexResultT, 1)
+
+	drainOnCancelWith("dir", false, nil, done, rec.fn)
+
+	if got := rec.count(); got != 0 {
+		t.Fatalf("drain ran reindex %d times on a clean stop; want 0", got)
+	}
+}
+
+// TestDrainOnCancelWaitsForInflightThenDrains models Ctrl+C while a reindex is
+// running: the in-flight subprocess was killed by the cancelled parent ctx, so
+// its goroutine reports an error on reindexDone. The drain must (a) wait for
+// that result rather than starting an overlapping reindex, (b) fold the killed
+// reindex's files back in, and (c) run exactly one final reindex covering both
+// the re-folded files and files queued during the reindex.
+func TestDrainOnCancelWaitsForInflightThenDrains(t *testing.T) {
+	rec := &recordingReindex{}
+	done := make(chan reindexResultT, 1)
+
+	// The killed in-flight reindex reports its files with an error (subprocess
+	// killed by parent ctx cancel — its work didn't land durably).
+	done <- reindexResultT{files: []string{"a.go"}, err: context.Canceled}
+
+	start := time.Now()
+	// indexing=true, plus a file queued during the reindex.
+	drainOnCancelWith("dir", true, []string{"b.go"}, done, rec.fn)
+	elapsed := time.Since(start)
+
+	if got := rec.count(); got != 1 {
+		t.Fatalf("drain ran reindex %d times; want exactly 1 (no overlapping reindex)", got)
+	}
+	// Must not block on the drain timeout — the in-flight result was ready.
+	if elapsed > watchDrainTimeout {
+		t.Fatalf("drain blocked %v; want prompt (in-flight result was ready)", elapsed)
+	}
+}
+
+// TestDrainOnCancelInflightCleanFinishStillDrainsPending confirms that when the
+// in-flight reindex finishes cleanly (no error) but files were queued during
+// it, the drain still runs a final reindex for those queued files. Otherwise the
+// edit made during the last reindex would be silently lost.
+func TestDrainOnCancelInflightCleanFinishStillDrainsPending(t *testing.T) {
+	rec := &recordingReindex{}
+	done := make(chan reindexResultT, 1)
+
+	// In-flight reindex finished cleanly before cancel landed.
+	done <- reindexResultT{files: []string{"a.go"}, err: nil}
+
+	// b.go was queued during that reindex and is still pending.
+	drainOnCancelWith("dir", true, []string{"b.go"}, done, rec.fn)
+
+	if got := rec.count(); got != 1 {
+		t.Fatalf("drain ran reindex %d times; want 1 (pending b.go must still drain)", got)
+	}
+}
+
+// TestDrainOnCancelInflightTimesOut guards the shutdown-can't-hang property: if
+// the in-flight reindex never reports (its goroutine wedged), the drain must
+// still return within roughly the bounded timeout rather than blocking forever.
+func TestDrainOnCancelInflightTimesOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits ~watchDrainTimeout")
+	}
+	rec := &recordingReindex{}
+	done := make(chan reindexResultT) // never sent on, unbuffered
+
+	start := time.Now()
+	// indexing=true but nothing will ever arrive on done.
+	drainOnCancelWith("dir", true, nil, done, rec.fn)
+	elapsed := time.Since(start)
+
+	if elapsed < watchDrainTimeout {
+		t.Fatalf("drain returned in %v; want it to honor the ~%v bounded wait", elapsed, watchDrainTimeout)
+	}
+	// No pending files after the (timed-out) wait, so no final reindex.
+	if got := rec.count(); got != 0 {
+		t.Fatalf("drain ran reindex %d times; want 0 (no pending after timeout)", got)
+	}
+}

--- a/internal/edit/ast.go
+++ b/internal/edit/ast.go
@@ -311,9 +311,17 @@ func ApplyAndWrite(req Request) (*Result, error) {
 		return nil, err
 	}
 
+	// Preserve the source file's original permissions: WriteFileAtomic chmods the
+	// temp file to perm before rename, so a hardcoded mode would silently rewrite a
+	// 0644 checked-in file as that mode. Default to 0644 for a new file.
+	perm := os.FileMode(0644)
+	if info, statErr := os.Stat(req.File); statErr == nil {
+		perm = info.Mode().Perm()
+	}
+
 	// Atomic write: a crash mid-write leaves the original file untouched.
 	// os.WriteFile truncates first, which can corrupt user source on disk-full / SIGKILL.
-	if err := util.WriteFileAtomic(req.File, result.formatted, 0600); err != nil { // #nosec G306 -- preserving original Go source file permissions
+	if err := util.WriteFileAtomic(req.File, result.formatted, perm); err != nil { // #nosec G306 -- perm is the source file's original mode (os.Stat above)
 		return nil, fmt.Errorf("write file: %w", err)
 	}
 

--- a/internal/edit/ast_test.go
+++ b/internal/edit/ast_test.go
@@ -217,6 +217,34 @@ func TestApplyAndWrite_PersistsFormattedChanges_When_RequestIsValid(t *testing.T
 	assert.Contains(t, result.Diff, "return a - b")
 }
 
+func TestApplyAndWrite_PreservesSourceFilePermissions_When_WritingEditedFile(t *testing.T) {
+	t.Parallel()
+
+	// Write a fixture with explicit 0644 perms (Git's default for checked-in source),
+	// then read back the actual mode the OS gave it. umask may strip bits, so the
+	// invariant under test is "mode unchanged after the edit", not a fixed constant.
+	path := filepath.Join(t.TempDir(), "perm.go")
+	require.NoError(t, os.WriteFile(path, []byte(sampleSource), 0o644))
+
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+	wantPerm := before.Mode().Perm()
+
+	result, err := edit.ApplyAndWrite(edit.Request{
+		File:      path,
+		Symbol:    "Add",
+		Operation: edit.OpReplaceBody,
+		NewCode:   "return a - b",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, wantPerm, after.Mode().Perm(),
+		"ApplyAndWrite must preserve the source file's original permissions")
+}
+
 func TestSymbolInfo_HandlesOutOfRangePositions_When_SourceOffsetsAreInvalid(t *testing.T) {
 	t.Parallel()
 

--- a/internal/metrics/capture.go
+++ b/internal/metrics/capture.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -229,13 +230,13 @@ func Capture(cfg CaptureConfig) (*Baseline, error) {
 	// Search metrics
 	start = time.Now()
 	for i := 0; i < runs; i++ {
-		_, _ = search.Search(cfg.Dir, "func", 50, 0)
+		_, _ = search.Search(context.Background(), cfg.Dir, "func", 50, 0)
 	}
 	baseline.Search.SimplePatternMs = float64(time.Since(start).Microseconds()) / float64(runs) / 1000.0
 
 	start = time.Now()
 	for i := 0; i < runs; i++ {
-		_, _ = search.Search(cfg.Dir, "func.*Error", 50, 0)
+		_, _ = search.Search(context.Background(), cfg.Dir, "func.*Error", 50, 0)
 	}
 	baseline.Search.RegexPatternMs = float64(time.Since(start).Microseconds()) / float64(runs) / 1000.0
 

--- a/internal/search/rg.go
+++ b/internal/search/rg.go
@@ -172,6 +172,14 @@ func Search(ctx context.Context, dir, pattern string, limit, contextLines int, g
 	// Exit code -1 means rg was killed by a signal (e.g. SIGPIPE from our
 	// early pipe close) — safe to ignore when we already have results.
 	if err := cmd.Wait(); err != nil {
+		// A context cancellation (timeout or SIGINT) kills rg with a signal,
+		// surfacing as ExitCode() == -1 — the same code as the deliberate
+		// pipe-close we do at the result limit. Disambiguate via ctx: if it
+		// fired, any results are a truncated search, so report cancellation
+		// instead of passing partial results off as a clean early stop.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return results, ctxErr
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			switch code := exitErr.ExitCode(); {

--- a/internal/search/rg.go
+++ b/internal/search/rg.go
@@ -3,6 +3,7 @@ package search
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,7 +44,15 @@ type rgSubmatch struct {
 
 // Search runs ripgrep and returns formatted results.
 // Optional globs are passed as --glob flags to rg (e.g., "*.go", "store.go").
-func Search(dir, pattern string, limit, contextLines int, globs ...string) ([]output.Result, error) {
+//
+// ctx bounds the rg subprocess: cancelling it (timeout or SIGINT) kills rg and
+// makes Search return promptly, instead of blocking until a pathological pattern
+// finishes. A nil ctx is treated as context.Background().
+func Search(ctx context.Context, dir, pattern string, limit, contextLines int, globs ...string) ([]output.Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	if _, err := exec.LookPath("rg"); err != nil {
 		return nil, fmt.Errorf("ripgrep (rg) not found: install from https://github.com/BurntSushi/ripgrep")
 	}
@@ -79,7 +88,7 @@ func Search(dir, pattern string, limit, contextLines int, globs ...string) ([]ou
 
 	args = append(args, pattern, dir)
 
-	cmd := exec.Command("rg", args...) // #nosec G204 -- args constructed internally, rg is trusted CLI tool
+	cmd := exec.CommandContext(ctx, "rg", args...) // #nosec G204 -- args constructed internally, rg is trusted CLI tool
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("create pipe: %w", err)

--- a/internal/search/rg_test.go
+++ b/internal/search/rg_test.go
@@ -1,11 +1,14 @@
 package search
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSearch_BasicMatch(t *testing.T) {
@@ -22,7 +25,7 @@ func Hello() {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
 
-	results, err := Search(dir, "Hello", 10, 0)
+	results, err := Search(context.Background(), dir, "Hello", 10, 0)
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
@@ -46,7 +49,7 @@ func Foo() {
 	}
 
 	// Search for nonexistent pattern returns empty results, not error
-	results, err := Search(dir, "NONEXISTENT_PATTERN_12345", 10, 0)
+	results, err := Search(context.Background(), dir, "NONEXISTENT_PATTERN_12345", 10, 0)
 	if err != nil {
 		t.Errorf("Search with no matches should not return error, got: %v", err)
 	}
@@ -64,7 +67,7 @@ func TestSearch_InvalidRegex(t *testing.T) {
 	}
 
 	// Invalid regex should return an error
-	_, err := Search(dir, "[invalid(regex", 10, 0)
+	_, err := Search(context.Background(), dir, "[invalid(regex", 10, 0)
 	if err == nil {
 		t.Error("Search with invalid regex should return error")
 	}
@@ -82,7 +85,7 @@ func TestSearch_LongLine(t *testing.T) {
 	}
 
 	// This should not panic due to scanner buffer limits
-	results, err := Search(dir, "MARKER", 10, 0)
+	results, err := Search(context.Background(), dir, "MARKER", 10, 0)
 	if err != nil {
 		t.Fatalf("Search with long line should not fail: %v", err)
 	}
@@ -100,7 +103,7 @@ func TestSearch_StderrCapture(t *testing.T) {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
 
-	_, err := Search(dir, "[invalid(regex", 10, 0)
+	_, err := Search(context.Background(), dir, "[invalid(regex", 10, 0)
 	if err == nil {
 		t.Fatal("Expected error for invalid regex")
 	}
@@ -121,13 +124,83 @@ func TestSearch_Limit(t *testing.T) {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
 
-	results, err := Search(dir, "match", 5, 0)
+	results, err := Search(context.Background(), dir, "match", 5, 0)
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
 
 	if len(results) > 5 {
 		t.Errorf("Expected at most 5 results, got %d", len(results))
+	}
+}
+
+// TestSearch_ContextCancelled asserts that a context cancelled before/at the
+// start of the search kills rg and makes Search return promptly instead of
+// running the (potentially pathological) pattern to completion. Regression for
+// snipe-4gz: Search used exec.Command and ignored the context entirely.
+func TestSearch_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	// A tree large enough that an unbounded rg over it would take real time.
+	// With a cancelled context, exec.CommandContext kills rg immediately, so
+	// Search must return well under the deadline below.
+	body := strings.Repeat("aaaaaaaaaaaaaaaaaaaaaaaa\n", 2000)
+	for i := 0; i < 200; i++ {
+		f := filepath.Join(dir, "file"+strconv.Itoa(i)+".txt")
+		if err := os.WriteFile(f, []byte(body), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before Search runs — rg should never run to completion
+
+	done := make(chan struct{})
+	var searchErr error
+	go func() {
+		// Catastrophic-backtrack-shaped pattern; would be slow if rg ran fully.
+		_, searchErr = Search(ctx, dir, "(a+)+$", 50, 0)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Returned promptly. With a cancelled context rg is killed before it
+		// produces output, so we expect an error (process killed / no results),
+		// not a hang. The exact error is platform-dependent; assert non-hang.
+		if searchErr == nil {
+			t.Log("Search returned nil error on cancelled context (rg finished before signal); acceptable as long as it returned promptly")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Search did not return promptly after context cancellation — rg was not killed (snipe-4gz regression)")
+	}
+}
+
+// TestSearch_ContextDeadline asserts that an already-expired deadline bounds the
+// rg subprocess: Search returns promptly rather than blocking on a long scan.
+func TestSearch_ContextDeadline(t *testing.T) {
+	dir := t.TempDir()
+	body := strings.Repeat("aaaaaaaaaaaaaaaaaaaaaaaa\n", 2000)
+	for i := 0; i < 200; i++ {
+		f := filepath.Join(dir, "file"+strconv.Itoa(i)+".txt")
+		if err := os.WriteFile(f, []byte(body), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = Search(ctx, dir, "(a+)+$", 50, 0)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Returned promptly under an expired deadline.
+	case <-time.After(10 * time.Second):
+		t.Fatal("Search did not honor an expired context deadline (snipe-4gz regression)")
 	}
 }
 

--- a/internal/search/rg_test.go
+++ b/internal/search/rg_test.go
@@ -164,11 +164,15 @@ func TestSearch_ContextCancelled(t *testing.T) {
 
 	select {
 	case <-done:
-		// Returned promptly. With a cancelled context rg is killed before it
-		// produces output, so we expect an error (process killed / no results),
-		// not a hang. The exact error is platform-dependent; assert non-hang.
-		if searchErr == nil {
-			t.Log("Search returned nil error on cancelled context (rg finished before signal); acceptable as long as it returned promptly")
+		// Returned promptly. A cancelled context kills rg with a signal
+		// (ExitCode -1) — the same code as our deliberate pipe-close at the
+		// result limit. The error must reflect cancellation, NOT pass partial
+		// results off as a clean early stop. In the rare race where rg finishes
+		// before the signal lands, a nil error is acceptable; but any surfaced
+		// error must be context.Canceled, never a generic "rg failed" (snipe-apz
+		// follow-up: distinguish ctx kills from SIGPIPE).
+		if searchErr != nil && !errors.Is(searchErr, context.Canceled) {
+			t.Fatalf("cancelled context should surface context.Canceled, got: %v", searchErr)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("Search did not return promptly after context cancellation — rg was not killed (snipe-4gz regression)")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -218,9 +218,17 @@ func removeLockIfContentsMatch(lockPath, expect string) bool {
 	return os.Remove(lockPath) == nil
 }
 
-// ReleaseLock removes the lock file
+// ReleaseLock removes the lock file, but only if it still holds THIS process's
+// PID. Release is ownership-checked for the same reason acquire is: after a
+// stale-reap race, the lock we wrote may have been unlinked and re-created by
+// another live writer. An unconditional os.Remove here would delete that
+// foreign live lock, letting a third writer in and violating the single-writer
+// invariant. Reusing removeLockIfContentsMatch keeps release symmetric with the
+// ownership-aware acquire/stale-reap path. A no-op (foreign PID or already-gone
+// lock) returns nil — releasing a lock we don't own is not an error.
 func ReleaseLock(dbPath string) error {
-	return os.Remove(LockPath(dbPath))
+	removeLockIfContentsMatch(LockPath(dbPath), strconv.Itoa(os.Getpid()))
+	return nil
 }
 
 func verifyPragmaString(db *sql.DB, pragma, want string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -405,6 +405,50 @@ func TestRemoveLockIfContentsMatch_RemovesWhenContentsMatch(t *testing.T) {
 	}
 }
 
+// TestReleaseLockLeavesForeignLock is the regression test for snipe-dv3: after a
+// stale-reap race, process A's deferred ReleaseLock must NOT unlink a lock that
+// now holds process B's (foreign) PID. Release is ownership-checked just like
+// acquire — it only removes a lock whose contents are THIS process's PID.
+func TestReleaseLockLeavesForeignLock(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	lockPath := LockPath(dbPath)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0750); err != nil {
+		t.Fatal(err)
+	}
+	// A live foreign holder. Use a PID that is definitely not us; the value
+	// need not be a running process — ReleaseLock keys on contents, not liveness.
+	foreign := os.Getpid() + 1
+	if err := os.WriteFile(lockPath, []byte(fmt.Sprintf("%d\n", foreign)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReleaseLock(dbPath); err != nil {
+		t.Fatalf("ReleaseLock should not error when refusing a foreign lock, got: %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("foreign lock must survive ReleaseLock, stat err: %v", err)
+	}
+}
+
+// TestReleaseLockRemovesOwnLock confirms the happy path: a lock holding THIS
+// process's PID is removed and ReleaseLock reports no error.
+func TestReleaseLockRemovesOwnLock(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	lockPath := LockPath(dbPath)
+
+	if err := AcquireLock(dbPath); err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	if err := ReleaseLock(dbPath); err != nil {
+		t.Fatalf("ReleaseLock failed for own lock: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("own lock should be gone after ReleaseLock, stat err: %v", err)
+	}
+}
+
 func TestOpenSetsPragmas(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "pragmas.db")

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -475,7 +475,14 @@ func (s *Store) WriteIndexIncremental(
 		return nil, fmt.Errorf("disable FK: %w", err)
 	}
 	defer func() {
-		_, _ = conn.ExecContext(context.Background(), "PRAGMA foreign_keys=ON")
+		// Re-enable FK on the pooled connection. SetMaxOpenConns(1) means
+		// conn.Close() returns this physical connection to the idle pool, so a
+		// silently-failed restore would leave FK enforcement off for every
+		// later write/read in the process. Surface the error into the named
+		// return (only when no earlier error already won) so it can't be lost.
+		if _, ferr := conn.ExecContext(context.Background(), "PRAGMA foreign_keys=ON"); ferr != nil && err == nil {
+			err = fmt.Errorf("re-enable FK: %w", ferr)
+		}
 	}()
 
 	tx, err := conn.BeginTx(context.Background(), nil)

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -436,14 +436,21 @@ type IncrementalResult struct {
 }
 
 // WriteIndexIncremental updates the index for changed/deleted files only.
-// Symbols for changed files are replaced; refs, call edges, and imports from
-// changed files are deleted and re-inserted. Unchanged files are left in place.
-// FK constraints are disabled during the write; orphaned refs are counted afterward.
+// Symbols for changed files are replaced; refs, call edges, imports, and
+// string literals from changed files are deleted and re-inserted. Unchanged
+// files are left in place. FK constraints are disabled during the write;
+// orphaned refs are counted afterward.
+//
+// Literal refs (string_refs) are folded into this same transaction so a
+// changed file's symbols and its literal-refs commit atomically — a crash can
+// never leave string_refs describing a prior generation while symbols reflect
+// the new one (snipe-er5).
 func (s *Store) WriteIndexIncremental(
 	changedSymbols []index.Symbol,
 	newRefs []index.Ref,
 	newEdges []index.CallEdge,
 	newImports []index.Import,
+	literals []index.StringRef,
 	changedFiles []string,
 	deletedFiles []string,
 ) (res *IncrementalResult, err error) {
@@ -539,6 +546,19 @@ func (s *Store) WriteIndexIncremental(
 	// Insert new imports
 	if err := writeImports(tx, newImports); err != nil {
 		return nil, fmt.Errorf("write imports: %w", err)
+	}
+
+	// Replace string literals for affected files in the SAME transaction.
+	// Folding this here (vs a separate WriteLiteralsForFiles tx) keeps a
+	// changed file's symbols and its literal-refs in the same generation —
+	// a crash can't leave lits/trace pointing at pre-edit lines (snipe-er5).
+	for _, f := range allAffected {
+		if _, err := tx.Exec(`DELETE FROM string_refs WHERE file_path = ?`, f); err != nil {
+			return nil, fmt.Errorf("delete string_refs for %s: %w", f, err)
+		}
+	}
+	if err := insertLiterals(tx, literals, repoRoot); err != nil {
+		return nil, fmt.Errorf("write string literals: %w", err)
 	}
 
 	// Sweep orphaned refs: refs from unchanged files may still point at

--- a/internal/store/write_test.go
+++ b/internal/store/write_test.go
@@ -353,7 +353,7 @@ func TestWriteIndexIncremental(t *testing.T) {
 		{CallerID: "sym2v2", CalleeID: "sym1", FilePath: "/repo/b.go", Line: 6, Col: 1},
 	}
 
-	result, err := s.WriteIndexIncremental(changedSymbols, newRefs, newEdges, nil,
+	result, err := s.WriteIndexIncremental(changedSymbols, newRefs, newEdges, nil, nil,
 		[]string{"/repo/b.go"}, nil)
 	if err != nil {
 		t.Fatalf("WriteIndexIncremental failed: %v", err)
@@ -376,6 +376,139 @@ func TestWriteIndexIncremental(t *testing.T) {
 	if result.IncrementalCount != 1 {
 		t.Errorf("IncrementalCount = %d, want 1", result.IncrementalCount)
 	}
+}
+
+// TestWriteIndexIncremental_LiteralsAtomic verifies the snipe-er5 fix: a
+// changed file's symbols and its string_refs (literals) commit in the SAME
+// transaction, so a crash can never leave them in mismatched generations.
+//
+// Two halves:
+//   - happy path — after a successful incremental write, the changed file's
+//     symbol and its literal both reflect the NEW generation (gen-2 values),
+//     with the old generation's rows gone.
+//   - forced tx error — when the literal insert fails (string_refs table
+//     dropped mid-flight), the WHOLE tx rolls back: neither the new symbol nor
+//     any literal lands, proving symbols + literals share one atomic commit.
+func TestWriteIndexIncremental_LiteralsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	_ = s.SetMeta("repo_root", "/repo")
+
+	// Initial full index: gen-1 symbol + gen-1 literal, both in /repo/a.go.
+	gen1Syms := []index.Symbol{
+		{ID: "symG1", Name: "Func", Kind: index.KindFunc, FilePath: "/repo/a.go", LineStart: 1, ColStart: 1, LineEnd: 10, ColEnd: 1},
+	}
+	if err := s.WriteIndex(gen1Syms, nil, nil); err != nil {
+		t.Fatalf("WriteIndex failed: %v", err)
+	}
+	gen1Lits := []index.StringRef{
+		{ID: "litG1aaaaaaaaaaaa", Value: "GEN1_KEY", Kind: "env", FilePath: "/repo/a.go", Line: 3, Col: 1},
+	}
+	if err := s.WriteLiterals(gen1Lits, "/repo"); err != nil {
+		t.Fatalf("WriteLiterals failed: %v", err)
+	}
+
+	// --- Happy path: incremental write moves a.go to gen-2. ---
+	gen2Syms := []index.Symbol{
+		{ID: "symG2", Name: "Func", Kind: index.KindFunc, FilePath: "/repo/a.go", LineStart: 5, ColStart: 1, LineEnd: 15, ColEnd: 1},
+	}
+	gen2Lits := []index.StringRef{
+		{ID: "litG2bbbbbbbbbbbb", Value: "GEN2_KEY", Kind: "env", FilePath: "/repo/a.go", Line: 7, Col: 1},
+	}
+	if _, err := s.WriteIndexIncremental(gen2Syms, nil, nil, nil, gen2Lits, []string{"/repo/a.go"}, nil); err != nil {
+		t.Fatalf("WriteIndexIncremental failed: %v", err)
+	}
+
+	// Symbol and literal must BOTH reflect gen-2; gen-1 rows of both must be gone.
+	if got := symValuesForFile(t, s, "/repo/a.go"); !equalStrSet(got, []string{"symG2"}) {
+		t.Errorf("symbols after incremental = %v, want [symG2] (gen-2 only)", got)
+	}
+	if got := litValuesForFile(t, s, "/repo/a.go"); !equalStrSet(got, []string{"GEN2_KEY"}) {
+		t.Errorf("string_refs after incremental = %v, want [GEN2_KEY] (gen-2 only)", got)
+	}
+
+	// --- Forced tx error: literal insert fails, whole tx must roll back. ---
+	// Drop string_refs so the folded literal writes error inside the tx.
+	if _, err := s.DB().Exec(`DROP TABLE string_refs`); err != nil {
+		t.Fatalf("drop string_refs: %v", err)
+	}
+	gen3Syms := []index.Symbol{
+		{ID: "symG3", Name: "Func", Kind: index.KindFunc, FilePath: "/repo/a.go", LineStart: 9, ColStart: 1, LineEnd: 19, ColEnd: 1},
+	}
+	gen3Lits := []index.StringRef{
+		{ID: "litG3cccccccccccc", Value: "GEN3_KEY", Kind: "env", FilePath: "/repo/a.go", Line: 11, Col: 1},
+	}
+	if _, err := s.WriteIndexIncremental(gen3Syms, nil, nil, nil, gen3Lits, []string{"/repo/a.go"}, nil); err == nil {
+		t.Fatal("WriteIndexIncremental: want error from missing string_refs table, got nil")
+	}
+
+	// Symbols must STILL be gen-2 — the failed literal write rolled back the
+	// symbol delete+insert too. Symbols and literals share one atomic commit.
+	if got := symValuesForFile(t, s, "/repo/a.go"); !equalStrSet(got, []string{"symG2"}) {
+		t.Errorf("symbols after rolled-back incremental = %v, want [symG2] (unchanged)", got)
+	}
+}
+
+// symValuesForFile returns symbol IDs recorded for a file path.
+func symValuesForFile(t *testing.T, s *Store, file string) []string {
+	t.Helper()
+	rows, err := s.DB().Query(`SELECT id FROM symbols WHERE file_path = ?`, file)
+	if err != nil {
+		t.Fatalf("query symbols: %v", err)
+	}
+	defer rows.Close()
+	return scanStrings(t, rows)
+}
+
+// litValuesForFile returns string_ref values recorded for a file path.
+func litValuesForFile(t *testing.T, s *Store, file string) []string {
+	t.Helper()
+	rows, err := s.DB().Query(`SELECT value FROM string_refs WHERE file_path = ?`, file)
+	if err != nil {
+		t.Fatalf("query string_refs: %v", err)
+	}
+	defer rows.Close()
+	return scanStrings(t, rows)
+}
+
+func scanStrings(t *testing.T, rows *sql.Rows) []string {
+	t.Helper()
+	var out []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows err: %v", err)
+	}
+	return out
+}
+
+func equalStrSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := make(map[string]int, len(want))
+	for _, w := range want {
+		seen[w]++
+	}
+	for _, g := range got {
+		seen[g]--
+	}
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func TestWriteIndexIncremental_DeletedFiles(t *testing.T) {
@@ -405,7 +538,7 @@ func TestWriteIndexIncremental_DeletedFiles(t *testing.T) {
 	}
 
 	// Delete b.go
-	_, err = s.WriteIndexIncremental(nil, nil, nil, nil, nil, []string{"/repo/b.go"})
+	_, err = s.WriteIndexIncremental(nil, nil, nil, nil, nil, nil, []string{"/repo/b.go"})
 	if err != nil {
 		t.Fatalf("WriteIndexIncremental (delete) failed: %v", err)
 	}
@@ -446,7 +579,7 @@ func TestWriteIndexIncremental_OrphanedRefs(t *testing.T) {
 		{ID: "sym1v2", Name: "Func1", Kind: index.KindFunc, FilePath: "/repo/a.go", LineStart: 5, ColStart: 1, LineEnd: 15, ColEnd: 1},
 	}
 
-	result, err := s.WriteIndexIncremental(changedSymbols, nil, nil, nil,
+	result, err := s.WriteIndexIncremental(changedSymbols, nil, nil, nil, nil,
 		[]string{"/repo/a.go"}, nil)
 	if err != nil {
 		t.Fatalf("WriteIndexIncremental failed: %v", err)

--- a/internal/store/write_test.go
+++ b/internal/store/write_test.go
@@ -378,6 +378,48 @@ func TestWriteIndexIncremental(t *testing.T) {
 	}
 }
 
+// TestWriteIndexIncremental_RestoresForeignKeys verifies the snipe-1vi fix:
+// WriteIndexIncremental flips foreign_keys OFF for the write and must restore
+// it to ON before returning. The store pins a single pooled connection
+// (SetMaxOpenConns(1)), so conn.Close() returns that same physical connection
+// to the idle pool — if the restore were swallowed, every later write/read in
+// the process would run with FK enforcement silently disabled. Asserting
+// PRAGMA foreign_keys == 1 on s.DB() (the same pooled connection) after the
+// call proves the restore happened.
+func TestWriteIndexIncremental_RestoresForeignKeys(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	_ = s.SetMeta("repo_root", "/repo")
+
+	symbols := []index.Symbol{
+		{ID: "sym1", Name: "Func1", Kind: index.KindFunc, FilePath: "/repo/a.go", LineStart: 1, ColStart: 1, LineEnd: 10, ColEnd: 1},
+	}
+	if err := s.WriteIndex(symbols, nil, nil); err != nil {
+		t.Fatalf("WriteIndex failed: %v", err)
+	}
+
+	changedSymbols := []index.Symbol{
+		{ID: "sym1v2", Name: "Func1", Kind: index.KindFunc, FilePath: "/repo/a.go", LineStart: 2, ColStart: 1, LineEnd: 12, ColEnd: 1},
+	}
+	if _, err := s.WriteIndexIncremental(changedSymbols, nil, nil, nil, nil, []string{"/repo/a.go"}, nil); err != nil {
+		t.Fatalf("WriteIndexIncremental failed: %v", err)
+	}
+
+	// FK enforcement must be back ON on the pooled connection after the call.
+	var fk int
+	if err := s.DB().QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatalf("query PRAGMA foreign_keys: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("PRAGMA foreign_keys = %d after WriteIndexIncremental, want 1 (restore was swallowed)", fk)
+	}
+}
+
 // TestWriteIndexIncremental_LiteralsAtomic verifies the snipe-er5 fix: a
 // changed file's symbols and its string_refs (literals) commit in the SAME
 // transaction, so a crash can never leave them in mismatched generations.

--- a/test/bench/bench_test.go
+++ b/test/bench/bench_test.go
@@ -1,6 +1,7 @@
 package bench
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -122,7 +123,7 @@ func BenchmarkSearch(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = search.Search(dir, "func", 50, 0)
+		_, _ = search.Search(context.Background(), dir, "func", 50, 0)
 	}
 }
 
@@ -134,7 +135,7 @@ func BenchmarkSearchRegex(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = search.Search(dir, "func.*Error", 50, 0)
+		_, _ = search.Search(context.Background(), dir, "func.*Error", 50, 0)
 	}
 }
 


### PR DESCRIPTION
## What

Drains the go-bug-audit bug backlog: 8 confirmed/plausible bugs across heal, store-lock, edit, index, search, watch, and embed. One commit per bead. `make audit` green (race + blackbox + govulncheck + eval).

## Beads

Closes: snipe-7ba, snipe-dv3, snipe-aj2, snipe-er5, snipe-4gz, snipe-l6a, snipe-1vi, snipe-apz, snipe-rqo, snipe-8el

## Notes

Each fix ships with a new test for its acceptance criterion (most of these paths had **zero** prior coverage). Reviewed by tier:

**Review carefully (write/recovery-path behavior change):**
- `snipe-er5` fold literal-refs into `WriteIndexIncremental`'s tx — symbols + string_refs for a changed file now commit/rollback atomically. Adds a `literals` param; updates 3 call sites. Folded delete keys on absolute `file_path` (unchanged from old `WriteLiteralsForFiles`).
- `snipe-apz` thread the parent `*store.Store` into `downloadAndSaveEmbeddings` (was opening a 2nd handle on the same SQLite file → lock-stall → swallowed `SaveEmbedding` errors → `ClearState` dropped paid Voyage embeddings). **Behavior change:** a wedged recovery now returns a hard error and preserves `batch_state.json` instead of silently re-batching. Verify acceptable on orca's `snipe index` path.
- `snipe-7ba` self-heal subprocess now `exec.CommandContext(GetContext(), …)` + a `<-ctx.Done()` arm — honors `--timeout`/SIGINT on the hot OpenStore path (was blocking up to 15s).

**Low-risk / contained:**
- `snipe-1vi` capture `PRAGMA foreign_keys=ON` restore error into the named return (was `_, _ =` swallowed on a pooled conn).
- `snipe-dv3` `ReleaseLock` now ownership-checked (reuses `removeLockIfContentsMatch`) — won't unlink a foreign live lock after a stale-reap race.
- `snipe-4gz` `search.Search` takes a `context.Context`; rg runs under `exec.CommandContext`. (Note: the bead's claim that Search already took a ctx was wrong — that arg was `contextLines int`.)
- `snipe-aj2` `ApplyAndWrite` preserves the source file's mode via `os.Stat` (was hardcoding 0600).
- `snipe-l6a` `watch` best-effort bounded final drain on ctx-cancel so the last edit isn't lost.

Built via `/team backlog`: 3 waves packed by disjoint write-sets; subagents did edit+test only, primary did all commits.

## Review fixes (Codex)

- **snipe-rqo** (P1): `snipe index` recovery now handles a persisted `completed` batch state — a failed `embed-status` download left `batch_state.json` at `completed`, which slipped past the validating/in_progress gate and re-billed a fresh batch. Extracted `recoverCompletedBatch`.
- **snipe-8el** (P2): `search.Search` reports ctx cancellation instead of returning partial results as a clean SIGPIPE stop (checks `ctx.Err()` before the exit `-1` path).