### PR TITLE
refactor(index): dedup ExtractLiterals, simplify isTestFile

### DIFF
--- a/internal/index/cyclo.go
+++ b/internal/index/cyclo.go
@@ -1,6 +1,9 @@
 package index
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // CycloRollup is the per-package cyclomatic complexity summary.
 // Sum/Max are integers; P95 may fall between samples (linear interpolation).
@@ -64,9 +67,5 @@ func percentile(sorted []int, p float64) float64 {
 }
 
 func isTestFile(path string) bool {
-	const suf = "_test.go"
-	if len(path) < len(suf) {
-		return false
-	}
-	return path[len(path)-len(suf):] == suf
+	return strings.HasSuffix(path, "_test.go")
 }

--- a/internal/index/literals.go
+++ b/internal/index/literals.go
@@ -26,27 +26,7 @@ type StringRef struct {
 
 // ExtractLiterals extracts string literals from all packages in the result.
 func ExtractLiterals(result *LoadResult, symbols []Symbol) []StringRef {
-	encMap := buildGlobalEnclosingMap(result, symbols)
-	var out []StringRef
-	for _, pkg := range result.Packages {
-		for i, file := range pkg.Syntax {
-			if i >= len(pkg.GoFiles) {
-				continue
-			}
-			filePath := pkg.GoFiles[i]
-			lines, err := util.LoadFileLines(filePath)
-			refs := extractFileLiterals(file, filePath, result.Fset)
-			for j := range refs {
-				refs[j].ID = literalID(refs[j])
-				if err == nil && refs[j].Line > 0 && refs[j].Line <= len(lines) {
-					refs[j].Snippet = lines[refs[j].Line-1]
-				}
-				refs[j].EnclosingID = encMap[filePath][refs[j].Line]
-			}
-			out = append(out, refs...)
-		}
-	}
-	return out
+	return ExtractLiteralsFiltered(result, symbols, nil)
 }
 
 // ExtractLiteralsFiltered extracts only from files in the onlyFiles set.
@@ -168,7 +148,7 @@ func extractConstLiterals(decl *ast.GenDecl, filePath string, fset *token.FileSe
 
 // literalID generates a stable 16-char hex ID for a string ref.
 func literalID(r StringRef) string {
-	h := sha256.Sum256([]byte(fmt.Sprintf("%s:%d:%d:%s", r.FilePath, r.Line, r.Col, r.Value)))
+	h := sha256.Sum256(fmt.Appendf(nil, "%s:%d:%d:%s", r.FilePath, r.Line, r.Col, r.Value))
 	return hex.EncodeToString(h[:])[:16]
 }
 

--- a/internal/index/literals.go
+++ b/internal/index/literals.go
@@ -149,7 +149,7 @@ func extractConstLiterals(decl *ast.GenDecl, filePath string, fset *token.FileSe
 // literalID generates a stable 16-char hex ID for a string ref.
 func literalID(r StringRef) string {
 	h := sha256.Sum256(fmt.Appendf(nil, "%s:%d:%d:%s", r.FilePath, r.Line, r.Col, r.Value))
-	return hex.EncodeToString(h[:])[:16]
+	return hex.EncodeToString(h[:8])
 }
 
 // buildGlobalEnclosingMap returns map[filePath][line] -> enclosing symbol ID.


### PR DESCRIPTION
From `/simplify internal/index`. Quality-only cleanups, behavior-preserving, `go test ./internal/index` green.

- `ExtractLiterals` now delegates to `ExtractLiteralsFiltered(.., nil)`, dropping a copy-pasted loop that double-computed the enclosing map (−22 lines), matching the callgraph/imports pattern.
- `isTestFile` uses `strings.HasSuffix`.
- `literalID` uses `fmt.Appendf` (modernize lint).

Closes: none