### PR TITLE
fix(output): emit meaningful-zero envelope fields instead of dropping via omitempty

### DIFF
--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -33,20 +33,23 @@ var (
 //
 // Total, Completed, Failed, and Stale carry meaning at their zero values
 // ("0 failed", "checked, not stale") — the very signals embed-status reports —
-// so they emit unconditionally (D4). The remaining string/time fields stay
-// omitempty: their zero values are absence, not signal.
+// so they emit unconditionally (D4). The remaining string fields stay
+// omitempty: their zero values are absence, not signal. CreatedAt is a
+// *time.Time so it is genuinely omitted when absent — omitempty is a no-op on
+// a time.Time value, which would otherwise leak "0001-01-01T00:00:00Z" noise
+// (e.g. the no_batch result, which never sets it) into the envelope (D4).
 type EmbedStatusResult struct {
-	BatchID    string    `json:"batch_id,omitempty"`
-	Status     string    `json:"status"`
-	Total      int       `json:"total"`
-	Completed  int       `json:"completed"`
-	Failed     int       `json:"failed"`
-	Model      string    `json:"model,omitempty"`
-	CreatedAt  time.Time `json:"created_at,omitempty"`
-	Age        string    `json:"age,omitempty"`
-	Stale      bool      `json:"stale"`
-	EmbedCount int       `json:"embed_count,omitempty"`
-	Message    string    `json:"message,omitempty"`
+	BatchID    string     `json:"batch_id,omitempty"`
+	Status     string     `json:"status"`
+	Total      int        `json:"total"`
+	Completed  int        `json:"completed"`
+	Failed     int        `json:"failed"`
+	Model      string     `json:"model,omitempty"`
+	CreatedAt  *time.Time `json:"created_at,omitempty"`
+	Age        string     `json:"age,omitempty"`
+	Stale      bool       `json:"stale"`
+	EmbedCount int        `json:"embed_count,omitempty"`
+	Message    string     `json:"message,omitempty"`
 }
 
 func runEmbedStatus() error {
@@ -143,7 +146,7 @@ func runEmbedStatus() error {
 				Completed:  state.Completed,
 				Failed:     state.Failed,
 				Model:      state.Model,
-				CreatedAt:  state.CreatedAt,
+				CreatedAt:  &state.CreatedAt,
 				EmbedCount: embedCount,
 				Message:    fmt.Sprintf("Downloaded and saved %d embeddings", embedCount),
 			}
@@ -168,7 +171,7 @@ func runEmbedStatus() error {
 				Completed: state.Completed,
 				Failed:    state.Failed,
 				Model:     state.Model,
-				CreatedAt: state.CreatedAt,
+				CreatedAt: &state.CreatedAt,
 				Message:   "Batch job failed or was cancelled",
 			}
 			return w.WriteResponse(output.Response[EmbedStatusResult]{
@@ -194,7 +197,7 @@ func runEmbedStatus() error {
 				Completed: state.Completed,
 				Failed:    state.Failed,
 				Model:     state.Model,
-				CreatedAt: state.CreatedAt,
+				CreatedAt: &state.CreatedAt,
 				Age:       age.Round(time.Minute).String(),
 				Stale:     isStale,
 				Message:   msg,

--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -30,16 +30,21 @@ var (
 )
 
 // EmbedStatusResult is the output for embed-status command.
+//
+// Total, Completed, Failed, and Stale carry meaning at their zero values
+// ("0 failed", "checked, not stale") — the very signals embed-status reports —
+// so they emit unconditionally (D4). The remaining string/time fields stay
+// omitempty: their zero values are absence, not signal.
 type EmbedStatusResult struct {
 	BatchID    string    `json:"batch_id,omitempty"`
 	Status     string    `json:"status"`
-	Total      int       `json:"total,omitempty"`
-	Completed  int       `json:"completed,omitempty"`
-	Failed     int       `json:"failed,omitempty"`
+	Total      int       `json:"total"`
+	Completed  int       `json:"completed"`
+	Failed     int       `json:"failed"`
 	Model      string    `json:"model,omitempty"`
 	CreatedAt  time.Time `json:"created_at,omitempty"`
 	Age        string    `json:"age,omitempty"`
-	Stale      bool      `json:"stale,omitempty"`
+	Stale      bool      `json:"stale"`
 	EmbedCount int       `json:"embed_count,omitempty"`
 	Message    string    `json:"message,omitempty"`
 }

--- a/cmd/embed_test.go
+++ b/cmd/embed_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -8,6 +9,31 @@ import (
 	"strings"
 	"testing"
 )
+
+// TestEmbedStatusResultEmitsMeaningfulZeros guards that Total, Completed,
+// Failed, and Stale serialize at their zero values. "0 failed" and
+// "checked, not stale" (stale=false) are the signals embed-status reports;
+// omitempty silently dropped them from the JSON envelope (D4, snipe-0xt).
+func TestEmbedStatusResultEmitsMeaningfulZeros(t *testing.T) {
+	data, err := json.Marshal(EmbedStatusResult{Status: "completed"})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	for _, field := range []string{"total", "completed", "failed", "stale"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("embed-status JSON missing %q at zero value — omitempty dropped a meaningful zero (snipe-0xt)", field)
+		}
+	}
+	if raw["stale"] != false {
+		t.Errorf("stale = %v, want false", raw["stale"])
+	}
+}
 
 // failingSaver fails every SaveEmbedding, simulating a "database is locked"
 // stall on the SQLite WAL — the failure mode that previously got swallowed and

--- a/cmd/embed_test.go
+++ b/cmd/embed_test.go
@@ -33,6 +33,12 @@ func TestEmbedStatusResultEmitsMeaningfulZeros(t *testing.T) {
 	if raw["stale"] != false {
 		t.Errorf("stale = %v, want false", raw["stale"])
 	}
+	// CreatedAt is a *time.Time so an absent timestamp is genuinely omitted —
+	// a time.Time would have leaked "0001-01-01T00:00:00Z" past omitempty,
+	// the D4 noise the no_batch result exhibits (snipe-0xt).
+	if _, ok := raw["created_at"]; ok {
+		t.Errorf("embed-status JSON has created_at at zero value — *time.Time should omit it (snipe-0xt)")
+	}
 }
 
 // failingSaver fails every SaveEmbedding, simulating a "database is locked"

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -47,8 +47,8 @@ type Meta struct {
 	RequestID     string            `json:"request_id,omitempty"`
 	Ms            int64             `json:"ms"`
 	Total         int               `json:"total"`
-	Offset        int               `json:"offset,omitempty"`
-	Limit         int               `json:"limit,omitempty"`
+	Offset        int               `json:"offset"`
+	Limit         int               `json:"limit"`
 	Truncated     bool              `json:"truncated"`
 	TokenEstimate int               `json:"token_estimate"`
 	DecisionPath  []string          `json:"decision_path,omitempty"` // Resolution strategy trace

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -54,6 +54,32 @@ func TestResponseMarshal(t *testing.T) {
 	}
 }
 
+// TestMetaEmitsZeroOffsetLimit guards that Offset and Limit serialize even at
+// their zero values. Page-0 results report Offset:0; dropping it (via omitempty)
+// breaks pagination disambiguation for the orca/Claude toolchain (D4, snipe-0xt).
+func TestMetaEmitsZeroOffsetLimit(t *testing.T) {
+	data, err := json.Marshal(Meta{Command: "def", IndexState: IndexFresh})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	for _, field := range []string{"offset", "limit"} {
+		v, ok := raw[field]
+		if !ok {
+			t.Errorf("meta missing %q at zero value — omitempty dropped a meaningful zero (snipe-0xt)", field)
+			continue
+		}
+		if v.(float64) != 0 {
+			t.Errorf("meta %q = %v, want 0", field, v)
+		}
+	}
+}
+
 func TestErrorMarshal(t *testing.T) {
 	resp := Response[any]{
 		Protocol: ProtocolVersion,

--- a/testdata/golden/ambiguous_output.json
+++ b/testdata/golden/ambiguous_output.json
@@ -7,6 +7,8 @@
     "index_state": "fresh",
     "ms": 8,
     "total": 0,
+    "offset": 0,
+    "limit": 0,
     "truncated": false,
     "token_estimate": 0
   },

--- a/testdata/golden/callers_output.json
+++ b/testdata/golden/callers_output.json
@@ -33,6 +33,7 @@
     "index_state": "fresh",
     "ms": 12,
     "total": 1,
+    "offset": 0,
     "limit": 50,
     "truncated": false,
     "token_estimate": 0

--- a/testdata/golden/def_output.json
+++ b/testdata/golden/def_output.json
@@ -27,6 +27,7 @@
     "index_state": "fresh",
     "ms": 15,
     "total": 1,
+    "offset": 0,
     "limit": 50,
     "truncated": false,
     "token_estimate": 0

--- a/testdata/golden/missing_index_output.json
+++ b/testdata/golden/missing_index_output.json
@@ -7,6 +7,8 @@
     "index_state": "missing",
     "ms": 1,
     "total": 0,
+    "offset": 0,
+    "limit": 0,
     "truncated": false,
     "token_estimate": 0
   },

--- a/testdata/golden/not_found_output.json
+++ b/testdata/golden/not_found_output.json
@@ -7,6 +7,8 @@
     "index_state": "fresh",
     "ms": 5,
     "total": 0,
+    "offset": 0,
+    "limit": 0,
     "truncated": false,
     "token_estimate": 0
   },

--- a/testdata/golden/refs_output.json
+++ b/testdata/golden/refs_output.json
@@ -51,6 +51,7 @@
     "index_state": "fresh",
     "ms": 23,
     "total": 2,
+    "offset": 0,
     "limit": 50,
     "truncated": false,
     "token_estimate": 0

--- a/testdata/golden/search_output.json
+++ b/testdata/golden/search_output.json
@@ -27,6 +27,7 @@
     "index_state": "fresh",
     "ms": 8,
     "total": 1,
+    "offset": 0,
     "limit": 50,
     "truncated": false,
     "token_estimate": 0

--- a/testdata/golden/stale_index_output.json
+++ b/testdata/golden/stale_index_output.json
@@ -30,6 +30,7 @@
     ],
     "ms": 15,
     "total": 1,
+    "offset": 0,
     "limit": 50,
     "truncated": false,
     "token_estimate": 0


### PR DESCRIPTION
Closes: snipe-0xt

Sliced from /team backlog wave 1 (shared branch team/impl-1782589426). Package tests + lint green; see wave report for the orthogonal internal/kg flake.