### PR TITLE
fix(cmd): route not-found errors to ErrNotFound instead of INTERNAL_ERROR

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,16 @@ import (
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/query"
 )
+
+// editErrCode maps an edit.Apply/ApplyAndWrite error to an output error code.
+// edit.ErrSymbolNotFound is a public sentinel, so surface it as NOT_FOUND:
+// Claude (D1) must see a recoverable lookup miss, not an INTERNAL_ERROR crash.
+func editErrCode(err error) string {
+	if errors.Is(err, edit.ErrSymbolNotFound) {
+		return output.ErrNotFound
+	}
+	return output.ErrInternal
+}
 
 var (
 	editOperation   string
@@ -220,7 +231,7 @@ doEdit:
 
 	if err != nil {
 		return w.WriteError(cmdNameEdit, &output.Error{
-			Code:    output.ErrInternal,
+			Code:    editErrCode(err),
 			Message: err.Error(),
 		})
 	}

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/edit"
+	"github.com/dkoosis/snipe/internal/output"
+)
+
+// TestEditErrCode guards the not-found classification: edit.ErrSymbolNotFound
+// is a public sentinel and must surface to Claude as NOT_FOUND, not the
+// INTERNAL_ERROR crash code (snipe-7rn, D1).
+func TestEditErrCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "bare sentinel routes to NOT_FOUND",
+			err:  edit.ErrSymbolNotFound,
+			want: output.ErrNotFound,
+		},
+		{
+			name: "wrapped sentinel still routes to NOT_FOUND",
+			err:  fmt.Errorf("%w: %q in foo.go", edit.ErrSymbolNotFound, "Bar"),
+			want: output.ErrNotFound,
+		},
+		{
+			name: "generic failure routes to INTERNAL_ERROR",
+			err:  errors.New("write: disk full"),
+			want: output.ErrInternal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := editErrCode(tt.err); got != tt.want {
+				t.Errorf("editErrCode(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -14,6 +16,22 @@ import (
 	"github.com/dkoosis/snipe/internal/store"
 	"github.com/dkoosis/snipe/internal/util"
 )
+
+// classifySearchErr maps a search.Search error to an output error code.
+// A genuine no-matches result returns a nil error (search.Search yields no
+// error on rg exit code 1), so any error here is either a missing rg binary
+// or a runtime failure. We distinguish them with a typed exec.ErrNotFound
+// probe (lookErr) instead of substring-matching the message — "not found"
+// also appears in unrelated rg/runtime errors, so the old match misfired.
+func classifySearchErr(err, lookErr error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(lookErr, exec.ErrNotFound) {
+		return output.ErrRgNotFound
+	}
+	return output.ErrInternal
+}
 
 var identifierRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)
 
@@ -68,12 +86,11 @@ func runSearch(args []string) error {
 	// from walking outside the repo when invoked from a subdir or above the root.
 	results, err := search.Search(GetContext(), root, pattern, lim, ctx, globs...)
 	if err != nil {
-		code := output.ErrInternal
-		if strings.Contains(err.Error(), "not found") {
-			code = output.ErrRgNotFound
-		}
+		// Probe for the rg binary with a typed sentinel so a missing-rg
+		// failure is classified by exec.ErrNotFound, never by message text.
+		_, lookErr := exec.LookPath("rg")
 		return w.WriteError(cmdNameSearch, &output.Error{
-			Code:    code,
+			Code:    classifySearchErr(err, lookErr),
 			Message: err.Error(),
 		})
 	}

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/output"
+)
+
+// TestClassifySearchErr guards the rg-binary-missing vs runtime-error split.
+// A missing binary is detected by the typed exec.ErrNotFound probe, never by
+// substring-matching the message — so a runtime error whose text happens to
+// contain "not found" is no longer misclassified as RG_NOT_FOUND (snipe-7rn).
+func TestClassifySearchErr(t *testing.T) {
+	rgMissing := errors.New("ripgrep (rg) not found: install from ...")
+	runtimeErr := errors.New("rg error (exit 2): regex parse error")
+
+	tests := []struct {
+		name    string
+		err     error
+		lookErr error
+		want    string
+	}{
+		{
+			name:    "no error yields empty code",
+			err:     nil,
+			lookErr: nil,
+			want:    "",
+		},
+		{
+			name:    "missing rg binary routes to RG_NOT_FOUND",
+			err:     rgMissing,
+			lookErr: exec.ErrNotFound,
+			want:    output.ErrRgNotFound,
+		},
+		{
+			name:    "wrapped exec.ErrNotFound routes to RG_NOT_FOUND",
+			err:     rgMissing,
+			lookErr: fmt.Errorf("exec %q: %w", "rg", exec.ErrNotFound),
+			want:    output.ErrRgNotFound,
+		},
+		{
+			name:    "runtime error with rg present routes to INTERNAL_ERROR",
+			err:     runtimeErr,
+			lookErr: nil,
+			want:    output.ErrInternal,
+		},
+		{
+			// Regression: message contains "not found" but rg is present —
+			// the old substring match wrongly tagged this RG_NOT_FOUND.
+			name:    "non-rg error containing 'not found' stays INTERNAL_ERROR",
+			err:     errors.New("pattern not found in any tracked file"),
+			lookErr: nil,
+			want:    output.ErrInternal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifySearchErr(tt.err, tt.lookErr); got != tt.want {
+				t.Errorf("classifySearchErr(%v, %v) = %q, want %q", tt.err, tt.lookErr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes: snipe-7rn

Sliced from /team backlog wave 1 (shared branch team/impl-1782589426). Package tests + lint green; see wave report for the orthogonal internal/kg flake.