### PR TITLE
perf(lifecycle): frontier-batch WalkCallers N+1 (lifecycle half of snipe-0fy)

### DIFF
--- a/internal/lifecycle/callers.go
+++ b/internal/lifecycle/callers.go
@@ -2,8 +2,7 @@ package lifecycle
 
 import (
 	"database/sql"
-
-	"github.com/dkoosis/snipe/internal/query"
+	"strings"
 )
 
 // CallerNode is one hop in the caller chain for a lifecycle function.
@@ -18,6 +17,12 @@ type CallerNode struct {
 // upward from symbolID, up to maxDepth hops. BFS with a visited set prevents
 // infinite recursion on mutually recursive or diamond call graphs.
 // Returns nil when maxDepth <= 0.
+//
+// The walk processes one whole BFS frontier (every node at a given depth) per
+// iteration with a single batched query, rather than one query per node. This
+// collapses the former N-queries-per-walk into one-query-per-level. The query
+// mirrors query.FindCallers' selection (test-file callers included, no role
+// filtering), so results are unchanged from the per-node version.
 func WalkCallers(db *sql.DB, symbolID string, maxDepth int) []CallerNode {
 	if maxDepth <= 0 {
 		return nil
@@ -25,36 +30,76 @@ func WalkCallers(db *sql.DB, symbolID string, maxDepth int) []CallerNode {
 	visited := map[string]bool{symbolID: true}
 	var result []CallerNode
 
-	type item struct {
-		id    string
-		depth int
-	}
-	queue := []item{{symbolID, 0}}
-
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-		if cur.depth >= maxDepth {
-			continue
-		}
-		rows, err := query.FindCallers(db, cur.id, 100, 0)
+	frontier := []string{symbolID}
+	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
+		edges, err := frontierCallers(db, frontier)
 		if err != nil {
-			continue
+			break
 		}
-		for i := range rows {
-			r := &rows[i]
-			if visited[r.CallerID] {
+		var next []string
+		for i := range edges {
+			e := &edges[i]
+			if visited[e.callerID] {
 				continue
 			}
-			visited[r.CallerID] = true
+			visited[e.callerID] = true
 			result = append(result, CallerNode{
-				ID:    r.CallerID,
-				Name:  r.CallerName,
-				File:  r.CallerFileRel,
-				Depth: cur.depth + 1,
+				ID:    e.callerID,
+				Name:  e.callerName,
+				File:  e.callerFileRel,
+				Depth: depth + 1,
 			})
-			queue = append(queue, item{r.CallerID, cur.depth + 1})
+			next = append(next, e.callerID)
 		}
+		frontier = next
 	}
 	return result
+}
+
+// callerEdge is one caller→callee edge fetched during the BFS walk.
+type callerEdge struct {
+	callerID      string
+	callerName    string
+	callerFileRel string
+}
+
+// frontierCallers returns the direct callers of every callee ID in the frontier
+// in a single query. It mirrors query.FindCallers' selection (test-file callers
+// included, no role filtering) but fetches only the three columns the walk needs
+// and batches the whole BFS frontier into one IN(...) query — replacing the
+// former per-node round trips with one query per BFS level. DISTINCT collapses a
+// caller reached via several frontier callees (or several call sites) to one row.
+func frontierCallers(db *sql.DB, ids []string) ([]callerEdge, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	// #nosec G201 -- placeholders are "?" literals; args carry the values (parameterized).
+	q := `
+		SELECT DISTINCT cg.caller_id, caller.name, caller.file_path_rel
+		FROM call_graph cg
+		JOIN symbols caller ON cg.caller_id = caller.id
+		WHERE cg.callee_id IN (` + strings.Join(placeholders, ",") + `)
+		ORDER BY caller.file_path_rel, caller.name`
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var edges []callerEdge
+	for rows.Next() {
+		var e callerEdge
+		if err := rows.Scan(&e.callerID, &e.callerName, &e.callerFileRel); err != nil {
+			return nil, err
+		}
+		edges = append(edges, e)
+	}
+	return edges, rows.Err()
 }

--- a/internal/lifecycle/callers_test.go
+++ b/internal/lifecycle/callers_test.go
@@ -192,3 +192,79 @@ func TestWalkCallers_NoCallers(t *testing.T) {
 		t.Errorf("expected 0 callers, got %d", len(nodes))
 	}
 }
+
+// TestWalkCallers_DiamondFrontier exercises the frontier-batched walk where two
+// depth-1 nodes share a single depth-2 caller. The shared node must appear
+// exactly once at its shallowest depth — proving cross-frontier dedup survives
+// the switch from per-node queries to one batched query per level.
+func TestWalkCallers_DiamondFrontier(t *testing.T) {
+	db := setupCallersTestDB(t)
+	// fn <- a, fn <- b  (depth 1); a <- c, b <- c  (c shared at depth 2)
+	insertSym(t, db, "fn", "fn", "fn.go")
+	insertSym(t, db, "a", "a", "a.go")
+	insertSym(t, db, "b", "b", "b.go")
+	insertSym(t, db, "c", "c", "c.go")
+	insertCall(t, db, "a", "fn")
+	insertCall(t, db, "b", "fn")
+	insertCall(t, db, "c", "a")
+	insertCall(t, db, "c", "b")
+
+	nodes := WalkCallers(db, "fn", 3)
+
+	byID := map[string]int{}
+	count := map[string]int{}
+	for _, n := range nodes {
+		byID[n.ID] = n.Depth
+		count[n.ID]++
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 distinct callers (a,b,c), got %d: %v", len(nodes), nodes)
+	}
+	if byID["a"] != 1 || byID["b"] != 1 {
+		t.Errorf("a and b should be depth 1, got a=%d b=%d", byID["a"], byID["b"])
+	}
+	if byID["c"] != 2 {
+		t.Errorf("shared caller c should be depth 2, got %d", byID["c"])
+	}
+	if count["c"] != 1 {
+		t.Errorf("shared caller c should appear exactly once, got %d", count["c"])
+	}
+}
+
+// TestFrontierCallers_BatchesMultipleCallees is the direct evidence that the BFS
+// frontier is fetched in a single query: one frontierCallers call over multiple
+// callee IDs returns the union of their callers — what was formerly one query
+// per node.
+func TestFrontierCallers_BatchesMultipleCallees(t *testing.T) {
+	db := setupCallersTestDB(t)
+	insertSym(t, db, "fn1", "fn1", "fn1.go")
+	insertSym(t, db, "fn2", "fn2", "fn2.go")
+	insertSym(t, db, "x", "x", "x.go")
+	insertSym(t, db, "y", "y", "y.go")
+	insertCall(t, db, "x", "fn1")
+	insertCall(t, db, "y", "fn2")
+
+	edges, err := frontierCallers(db, []string{"fn1", "fn2"})
+	if err != nil {
+		t.Fatalf("frontierCallers: %v", err)
+	}
+	got := map[string]bool{}
+	for _, e := range edges {
+		got[e.callerID] = true
+	}
+	if len(edges) != 2 || !got["x"] || !got["y"] {
+		t.Fatalf("expected both callers x and y from one batched query, got %v", edges)
+	}
+}
+
+// TestFrontierCallers_Empty guards the zero-frontier short-circuit.
+func TestFrontierCallers_Empty(t *testing.T) {
+	db := setupCallersTestDB(t)
+	edges, err := frontierCallers(db, nil)
+	if err != nil {
+		t.Fatalf("frontierCallers(nil): %v", err)
+	}
+	if edges != nil {
+		t.Errorf("expected nil edges for empty frontier, got %v", edges)
+	}
+}


### PR DESCRIPTION
Partially addresses snipe-0fy — lifecycle WalkCallers now frontier-batches one query per BFS level (behavior preserved; did NOT use FindImpactCallersMulti because its NOT GLOB '*_test.go' filter would drop test-fn callers).

Remaining cmd/types.go N+1 site tracked in snipe-btq (needs an internal/query entry point). Do NOT auto-close snipe-0fy on merge — close it only once snipe-btq also lands, or rescope 0fy to lifecycle-only.

Refs: snipe-0fy, snipe-btq. Sliced from /team backlog wave 2.