### PR TITLE
fix(store): surface corrupt-embedding BLOB as an error instead of silent nil

### DIFF
--- a/internal/store/embed.go
+++ b/internal/store/embed.go
@@ -1,11 +1,18 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/dkoosis/snipe/internal/vector"
 )
+
+// ErrCorruptEmbedding signals that a stored embedding BLOB could not be
+// deserialized — its length is not a multiple of 4 bytes. Callers must treat
+// this distinctly from an absent embedding (sql.ErrNoRows) or a valid result,
+// rather than silently scoring a corrupt vector as 0.
+var ErrCorruptEmbedding = errors.New("corrupt embedding blob")
 
 // SaveEmbedding stores an embedding for a symbol.
 func (s *Store) SaveEmbedding(symbolID string, embedding []float32, model string) error {
@@ -31,7 +38,14 @@ func (s *Store) GetEmbedding(symbolID string) ([]float32, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("get embedding for symbol %s: %w", symbolID, err)
 	}
-	return vector.DeserializeEmbedding(data), model, nil
+	emb := vector.DeserializeEmbedding(data)
+	if emb == nil && len(data) > 0 {
+		// Non-empty BLOB that failed to deserialize (odd/malformed length):
+		// surface corruption instead of returning (nil, model, nil), which a
+		// caller would otherwise mistake for a valid empty vector.
+		return nil, "", fmt.Errorf("get embedding for symbol %s: %w", symbolID, ErrCorruptEmbedding)
+	}
+	return emb, model, nil
 }
 
 // EmbeddingRow represents a row from the embeddings table with symbol info.

--- a/internal/store/embed_test.go
+++ b/internal/store/embed_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/index"
+)
+
+// TestGetEmbeddingCorruptBlob verifies that a non-empty embedding BLOB that
+// cannot be deserialized (length not a multiple of 4 bytes) surfaces
+// ErrCorruptEmbedding instead of the silent (nil, model, nil) that lets a
+// corrupt vector score 0 and never match.
+func TestGetEmbeddingCorruptBlob(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	// The embeddings table has a FK on symbol_id, so a symbol must exist first.
+	sym := index.Symbol{
+		ID: "corrupt-sym", Name: "Func1", Kind: index.KindFunc,
+		FilePath: "/a.go", LineStart: 1, ColStart: 1, LineEnd: 10, ColEnd: 1,
+	}
+	if err := s.WriteIndex([]index.Symbol{sym}, nil, nil); err != nil {
+		t.Fatalf("WriteIndex failed: %v", err)
+	}
+
+	// Store an odd-length BLOB directly. DeserializeEmbedding returns nil for
+	// any length that is not a multiple of 4 bytes — the corruption case.
+	corrupt := []byte{0x01, 0x02, 0x03}
+	if _, err := s.db.Exec(
+		`INSERT OR REPLACE INTO embeddings (symbol_id, embedding, model, created_at) VALUES (?, ?, ?, ?)`,
+		sym.ID, corrupt, "test-model", "2026-06-27T00:00:00Z",
+	); err != nil {
+		t.Fatalf("insert corrupt embedding: %v", err)
+	}
+
+	emb, model, err := s.GetEmbedding(sym.ID)
+	if err == nil {
+		t.Fatalf("expected corruption error for odd-length blob, got nil (emb=%v model=%q)", emb, model)
+	}
+	if !errors.Is(err, ErrCorruptEmbedding) {
+		t.Errorf("expected ErrCorruptEmbedding, got %v", err)
+	}
+	if emb != nil {
+		t.Errorf("expected nil embedding on corruption, got %v", emb)
+	}
+}
+
+// TestGetEmbeddingValidRoundTrip guards the happy path: a valid stored
+// embedding still round-trips without tripping the corruption check.
+func TestGetEmbeddingValidRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	sym := index.Symbol{
+		ID: "good-sym", Name: "Func1", Kind: index.KindFunc,
+		FilePath: "/a.go", LineStart: 1, ColStart: 1, LineEnd: 10, ColEnd: 1,
+	}
+	if err := s.WriteIndex([]index.Symbol{sym}, nil, nil); err != nil {
+		t.Fatalf("WriteIndex failed: %v", err)
+	}
+
+	want := []float32{0.1, 0.2, 0.3}
+	if err := s.SaveEmbedding(sym.ID, want, "test-model"); err != nil {
+		t.Fatalf("SaveEmbedding failed: %v", err)
+	}
+
+	emb, model, err := s.GetEmbedding(sym.ID)
+	if err != nil {
+		t.Fatalf("GetEmbedding failed: %v", err)
+	}
+	if model != "test-model" {
+		t.Errorf("model = %q, want test-model", model)
+	}
+	if len(emb) != len(want) {
+		t.Fatalf("embedding len = %d, want %d", len(emb), len(want))
+	}
+	for i := range want {
+		if emb[i] != want[i] {
+			t.Errorf("embedding[%d] = %v, want %v", i, emb[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Closes: snipe-vv3

Sliced from /team backlog wave 3 (shared branch team/impl-1782589426). Package tests + lint green.