### PR TITLE
fix(output): populate Suggestions on ambiguous-symbol errors so Claude gets disambiguation hints

### DIFF
--- a/internal/output/golden_test.go
+++ b/internal/output/golden_test.go
@@ -196,6 +196,11 @@ func TestGoldenAmbiguousOutput(t *testing.T) {
 		{ID: "abc123def45601", Name: "Config", File: "config/config.go", Kind: "type"},
 		{ID: "abc123def45602", Name: "Config", File: "server/config.go", Kind: "type"},
 	}
+	// Mirror the production WriteError path: suggestions flow from the error
+	// itself (err.Suggestions), not a separate re-call of the helper. This makes
+	// the golden assert the real shipped output -- if NewAmbiguousError stopped
+	// populating Suggestions, the hints would vanish and this test would fail.
+	err := NewAmbiguousError("Config", candidates)
 	resp := Response[any]{
 		Protocol: ProtocolVersion,
 		Ok:       false,
@@ -205,8 +210,8 @@ func TestGoldenAmbiguousOutput(t *testing.T) {
 			IndexState: IndexFresh,
 			Ms:         8,
 		},
-		Error:       NewAmbiguousError("Config", candidates),
-		Suggestions: SuggestionsForAmbiguous(candidates),
+		Error:       err,
+		Suggestions: err.Suggestions,
 	}
 
 	testGolden(t, goldenAmbiguousOutput, resp)

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -365,12 +365,15 @@ func joinSuggestions(suggestions []string) string {
 		", or " + suggestions[len(suggestions)-1] + "?"
 }
 
-// NewAmbiguousError creates an AMBIGUOUS_SYMBOL error
+// NewAmbiguousError creates an AMBIGUOUS_SYMBOL error. Suggestions carry the
+// "snipe show <id>" disambiguation hints so the rendered error tells Claude how
+// to pick a candidate (D2), not just that the symbol was ambiguous.
 func NewAmbiguousError(symbol string, candidates []Candidate) *Error {
 	return &Error{
-		Code:       ErrAmbiguousSymbol,
-		Message:    "Multiple definitions found for '" + symbol + "'",
-		Candidates: candidates,
+		Code:        ErrAmbiguousSymbol,
+		Message:     "Multiple definitions found for '" + symbol + "'",
+		Candidates:  candidates,
+		Suggestions: SuggestionsForAmbiguous(candidates),
 	}
 }
 

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -214,6 +214,18 @@ func TestNewAmbiguousError(t *testing.T) {
 	if len(err.Candidates) != 2 {
 		t.Errorf("Candidates count = %d, want 2", len(err.Candidates))
 	}
+	// The error must carry disambiguation hints (snipe show <id>), not just the
+	// candidate list -- production renders err.Suggestions, so an unpopulated
+	// field means Claude gets no way to pick (D2). Guards against regression to
+	// the prior "Candidates only" constructor.
+	if len(err.Suggestions) != 2 {
+		t.Fatalf("Suggestions count = %d, want 2 (one per candidate)", len(err.Suggestions))
+	}
+	for i, s := range err.Suggestions {
+		if !strings.Contains(s.Command, "snipe show ") {
+			t.Errorf("Suggestions[%d].Command = %q, want a 'snipe show <id>' hint", i, s.Command)
+		}
+	}
 }
 
 // TestAmbiguousSymbolJSONFormat verifies the JSON output matches SPEC.md format

--- a/testdata/golden/ambiguous_output.json
+++ b/testdata/golden/ambiguous_output.json
@@ -28,6 +28,18 @@
         "file": "server/config.go",
         "kind": "type"
       }
+    ],
+    "suggestions": [
+      {
+        "command": "snipe show abc123def45601",
+        "description": "Config in config/config.go",
+        "priority": 1
+      },
+      {
+        "command": "snipe show abc123def45602",
+        "description": "Config in server/config.go",
+        "priority": 1
+      }
     ]
   },
   "suggestions": [


### PR DESCRIPTION
Closes: snipe-ami

Sliced from /team backlog wave 3 (shared branch team/impl-1782589426). Package tests + lint green.