### PR TITLE
refactor: typed child-table enum, EmbeddingHandler alias, drop dead NewWriter compact param

### DIFF
--- a/cmd/baseline.go
+++ b/cmd/baseline.go
@@ -14,8 +14,7 @@ var (
 )
 
 func runBaseline() error {
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/cmd/boundary.go
+++ b/cmd/boundary.go
@@ -25,8 +25,7 @@ var (
 func runBoundary(args []string) error {
 	start := time.Now()
 
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	s, dir, err := OpenStore(w, "boundary")
 	if err != nil {
@@ -184,7 +183,7 @@ type layerCrossingRow struct {
 }
 
 func runBoundaryLayers(s *store.Store, dir string, start time.Time) error {
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	data, err := os.ReadFile(boundaryLayers)
 	if err != nil {

--- a/cmd/callees.go
+++ b/cmd/callees.go
@@ -14,14 +14,14 @@ var calleesID string
 func runCallees(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 
 	// Apply format overrides
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && calleesID == "" {
 		return w.WriteError(cmdNameCallees, &output.Error{

--- a/cmd/callers.go
+++ b/cmd/callers.go
@@ -14,14 +14,14 @@ var callersID string
 func runCallers(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 
 	// Apply format overrides
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && callersID == "" {
 		return w.WriteError(cmdNameCallers, &output.Error{

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -15,8 +15,7 @@ var (
 )
 
 func runCheck() error {
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/cmd/deadcode.go
+++ b/cmd/deadcode.go
@@ -33,7 +33,7 @@ type deadcodeRow struct {
 
 func runDeadcode() error {
 	start := time.Now()
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	s, dir, err := OpenStore(w, "deadcode")
 	if err != nil {

--- a/cmd/def.go
+++ b/cmd/def.go
@@ -23,13 +23,13 @@ var (
 func runDef(args []string) error {
 	start := time.Now()
 
-	compact, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
+	_, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
 	format := GetResponseFormat()
 
 	// Apply format overrides; def always shows body unless --no-body is explicit.
 	_, withSiblings, contextLines = ApplyFormatOverrides(format, withBody, withSiblings, contextLines)
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Handle --file and --pkg scoped queries.
 	// --pkg + symbol name: look up the named symbol within the package.

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -15,8 +15,7 @@ var depsTreeFlag bool
 func runDeps(args []string) error {
 	start := time.Now()
 
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	s, dir, err := OpenStore(w, "deps")
 	if err != nil {

--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -71,7 +71,7 @@ func renderSVG(d2src string) error {
 // ---------- arch ----------------------------------------------------------
 
 func runDiagramArch() error {
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 	s, _, err := OpenStore(w, "diagram arch")
 	if err != nil {
 		return err
@@ -258,7 +258,7 @@ func runDiagramFlow(args []string) error {
 		diagramFlowDepth = 10
 	}
 
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 	s, _, err := OpenStore(w, "diagram flow")
 	if err != nil {
 		return err
@@ -549,7 +549,7 @@ func walk(roots []string, edges [][2]string, depth, maxDepth int, syMap map[stri
 // ---------- lifecycle ----------------------------------------------------
 
 func runDiagramLifecycle(args []string) error {
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 	s, _, err := OpenStore(w, "diagram lifecycle")
 	if err != nil {
 		return err

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -40,8 +40,7 @@ const (
 const remediationReindex = "snipe index"
 
 func runDoctor() error {
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	allOK := true
 	var checks []DoctorCheck

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -59,8 +59,7 @@ type BatchEditRequest struct {
 func runEdit(args []string) error {
 	start := time.Now()
 
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Handle batch mode
 	if editBatch {

--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -64,8 +64,7 @@ func runEmbedStatus() error {
 	dbPath := store.DefaultIndexPath(absDir)
 
 	// Setup output writer
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Load batch client
 	client, err := embed.NewBatchClient(snipeDir)
@@ -234,7 +233,7 @@ type embeddingSaver interface {
 // JSONL from r and invokes fn for each parsed embedding. Factoring it out as a
 // function value lets persistEmbeddings be unit-tested without a real
 // BatchClient or network round-trip.
-type embeddingStreamParser func(r io.Reader, fn func(symbolID string, embedding []float32) error) error
+type embeddingStreamParser func(r io.Reader, fn embed.EmbeddingHandler) error
 
 // downloadAndSaveEmbeddings streams batch results directly to the store.
 // Downloads and parses line-by-line to avoid buffering the entire payload in RAM.

--- a/cmd/embed_test.go
+++ b/cmd/embed_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dkoosis/snipe/internal/embed"
 )
 
 // TestEmbedStatusResultEmitsMeaningfulZeros guards that Total, Completed,
@@ -67,7 +69,7 @@ func (c *countingSaver) SaveEmbedding(symbolID string, embedding []float32, mode
 // (with a trivial embedding each), ignoring the reader entirely — so the test
 // needs no network, no real BatchClient, and no credentials.
 func fakeParser(symbolIDs ...string) embeddingStreamParser {
-	return func(_ io.Reader, fn func(symbolID string, embedding []float32) error) error {
+	return func(_ io.Reader, fn embed.EmbeddingHandler) error {
 		for _, id := range symbolIDs {
 			if err := fn(id, []float32{0.1, 0.2}); err != nil {
 				return err

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -20,8 +20,7 @@ var (
 func runExplain(args []string) error {
 	start := time.Now()
 
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Need either a symbol name or --at position
 	if len(args) == 0 && explainAt == "" {

--- a/cmd/guard.go
+++ b/cmd/guard.go
@@ -64,7 +64,7 @@ type guardViolation struct {
 
 func runGuard(args []string) error {
 	start := time.Now()
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	specPath := defaultGuardSpec
 	if len(args) == 1 {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -14,8 +14,7 @@ var (
 )
 
 func runHistory() error {
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/cmd/impact.go
+++ b/cmd/impact.go
@@ -20,12 +20,12 @@ var (
 func runImpact(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && impactAt == "" && impactID == "" {
 		return w.WriteError(cmdNameImpact, &output.Error{

--- a/cmd/impl.go
+++ b/cmd/impl.go
@@ -14,11 +14,11 @@ var implID string
 func runImpl(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && implID == "" {
 		return w.WriteError(cmdNameImpl, &output.Error{

--- a/cmd/importers.go
+++ b/cmd/importers.go
@@ -13,8 +13,8 @@ import (
 func runImporters(args []string) error {
 	start := time.Now()
 
-	compact, lim, offset, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, lim, offset, _, _, _ := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	pkgPath := args[0]
 

--- a/cmd/imports.go
+++ b/cmd/imports.go
@@ -12,8 +12,8 @@ import (
 func runImports(args []string) error {
 	start := time.Now()
 
-	compact, lim, offset, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, lim, offset, _, _, _ := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	filePath := args[0]
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -53,8 +53,7 @@ func runIndex(args []string) error {
 	}
 
 	// Setup output writer
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Acquire lock to signal indexing in progress
 	dbPath := store.DefaultIndexPath(absDir)

--- a/cmd/lifecycle.go
+++ b/cmd/lifecycle.go
@@ -23,7 +23,7 @@ func runLifecycle(args []string) error {
 
 	_, lim, off, _, _, _ := GetOutputConfig()
 
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && lifecycleAt == "" {
 		return w.WriteError("lifecycle", &output.Error{

--- a/cmd/lits.go
+++ b/cmd/lits.go
@@ -13,8 +13,8 @@ func runLits(args []string) error {
 	start := time.Now()
 	value := args[0]
 
-	compact, lim, off, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, lim, off, _, _, _ := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	s, dir, err := OpenStore(w, "lits")
 	if err != nil {

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -25,8 +25,7 @@ var (
 func runMetrics() error {
 	start := time.Now()
 
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Multi-kind: comma-separated list collapses N sequential calls into one
 	// merged table keyed by node (snipe-0zg). Composite kinds (topo, cycles,
@@ -529,7 +528,7 @@ type multiKindRow struct {
 // row-set, merge by NodeID into a single wide table, optionally filter by
 // --pkg, sort by the first kind value desc, then truncate to --top.
 func runMultiKindMetrics(s *store.Store, dir string, startedAt time.Time) error {
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	kinds := splitAndTrim(metricsKind)
 	if len(kinds) == 0 {

--- a/cmd/orient.go
+++ b/cmd/orient.go
@@ -43,7 +43,7 @@ type orientManifest struct {
 
 func runOrient() error {
 	start := time.Now()
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if orientOut == "" {
 		return w.WriteError("orient", &output.Error{

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -25,8 +25,8 @@ var (
 func runPack(args []string) error {
 	start := time.Now()
 
-	compact, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && packAt == "" {
 		return w.WriteError(cmdNamePack, &output.Error{

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -17,7 +17,7 @@ var pkgDigest bool
 func runPkg(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 
 	// pkg is an orientation command — show full surface by default
@@ -26,7 +26,7 @@ func runPkg(args []string) error {
 	}
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	pkgPattern := args[0]
 
@@ -201,7 +201,7 @@ type pkgDigestRow struct {
 }
 
 func runPkgDigest(s *store.Store, dir, pkgPattern string, startedAt time.Time) error {
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	fullPkg := query.FindFullPkgPath(s.DB(), pkgPattern)
 	if fullPkg == "" {

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -24,14 +24,14 @@ var (
 func runRefs(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 
 	// Apply format overrides
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if refsBatch {
 		return runRefsBatch(w, start)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -41,14 +41,14 @@ func runSearch(args []string) error {
 	start := time.Now()
 	pattern := args[0]
 
-	compact, lim, _, ctx, _, _ := GetOutputConfig()
+	_, lim, _, ctx, _, _ := GetOutputConfig()
 	format := GetResponseFormat()
 
 	// Apply format overrides
 	_, _, ctx = ApplyFormatOverrides(format, false, false, ctx)
 	summary := format == FormatSummary
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Get current directory
 	dir, err := os.Getwd()

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -13,8 +13,8 @@ import (
 func runShow(args []string) error {
 	start := time.Now()
 
-	compact, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	symbolID := args[0]
 

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -24,8 +24,8 @@ var (
 func runSim(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if simPairs {
 		s, dir, err := OpenStore(w, cmdNameSim)
@@ -42,15 +42,15 @@ func runSim(args []string) error {
 			Message: "sim requires a query argument unless --pairs is set",
 		})
 	}
-	return runSimQuery(args, start, compact, lim, off, contextLines, withBody)
+	return runSimQuery(args, start, lim, off, contextLines, withBody)
 }
 
-func runSimQuery(args []string, start time.Time, compact bool, lim, off, contextLines int, withBody bool) error {
+func runSimQuery(args []string, start time.Time, lim, off, contextLines int, withBody bool) error {
 	queryText := args[0]
 	format := GetResponseFormat()
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	s, dir, err := OpenStore(w, cmdNameSim)
 	if err != nil {
@@ -186,7 +186,7 @@ type simPairRow struct {
 }
 
 func runSimPairs(s *store.Store, dir string, startedAt time.Time) error {
-	w := output.NewWriter(os.Stdout, false, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 	if !simWithinPkg {
 		return w.WriteError(cmdNameSim, &output.Error{
 			Code:    output.ErrInternal,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,8 +21,7 @@ type StatusResponse struct {
 }
 
 func runStatus() error {
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Find repo root
 	cwd, err := os.Getwd()

--- a/cmd/sym.go
+++ b/cmd/sym.go
@@ -23,8 +23,8 @@ var (
 func runSym(args []string) error {
 	start := time.Now()
 
-	compact, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	_, _, _, contextLines, withBody, withSiblings := GetOutputConfig()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	// Need either a symbol name or --at position
 	if len(args) == 0 && symAt == "" {

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -20,12 +20,12 @@ var (
 func runTests(args []string) error {
 	start := time.Now()
 
-	compact, lim, off, contextLines, withBody, _ := GetOutputConfig()
+	_, lim, off, contextLines, withBody, _ := GetOutputConfig()
 	format := GetResponseFormat()
 	withBody, _, contextLines = ApplyFormatOverrides(format, withBody, false, contextLines)
 	summary := format == FormatSummary
 
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && testsAt == "" && testsID == "" {
 		return w.WriteError(cmdNameTests, &output.Error{

--- a/cmd/trace.go
+++ b/cmd/trace.go
@@ -13,8 +13,7 @@ func runTrace(args []string) error {
 	value := args[0]
 
 	_, lim, off, _, _, _ := GetOutputConfig()
-	compact := false
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	s, dir, err := OpenStore(w, "trace")
 	if err != nil {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -19,8 +19,7 @@ var (
 func runTypes(args []string) error {
 	start := time.Now()
 
-	compact, _, _, _, _, _ := GetOutputConfig()
-	w := output.NewWriter(os.Stdout, compact, GetOutputFormat())
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	if len(args) == 0 && typesAt == "" {
 		return w.WriteError(cmdNameTypes, &output.Error{

--- a/internal/embed/batch.go
+++ b/internal/embed/batch.go
@@ -313,9 +313,14 @@ func (c *BatchClient) DownloadFile(ctx context.Context, fileID string) (io.ReadC
 	return resp.Body, nil
 }
 
+// EmbeddingHandler receives one parsed embedding (symbol ID + vector) from a
+// batch-results stream. It is the single named spelling of the per-row callback
+// shared by ParseBatchResults and the cmd-side parser/persist seam.
+type EmbeddingHandler func(symbolID string, embedding []float32) error
+
 // ParseBatchResults streams JSONL from r, calling fn for each successfully parsed embedding.
 // Stops early and returns the error if fn returns an error.
-func (c *BatchClient) ParseBatchResults(r io.Reader, fn func(symbolID string, embedding []float32) error) error {
+func (c *BatchClient) ParseBatchResults(r io.Reader, fn EmbeddingHandler) error {
 	scanner := bufio.NewScanner(r)
 
 	// Handle potentially large lines

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -40,7 +40,7 @@ func humanResp() Response[Result] {
 func TestHumanFormat_NonTTY_NoAnsi(t *testing.T) {
 	withTTY(t, false)
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputHuman)
+	w := NewWriter(&buf, OutputHuman)
 	if err := w.WriteResponse(humanResp()); err != nil {
 		t.Fatalf("WriteResponse: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestHumanFormat_NonTTY_NoAnsi(t *testing.T) {
 func TestHumanFormat_TTY_HasAnsi(t *testing.T) {
 	withTTY(t, true)
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputHuman)
+	w := NewWriter(&buf, OutputHuman)
 	if err := w.WriteResponse(humanResp()); err != nil {
 		t.Fatalf("WriteResponse: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestHumanFormat_TTY_HasAnsi(t *testing.T) {
 func TestHumanFormat_EmptyResults(t *testing.T) {
 	withTTY(t, false)
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputHuman)
+	w := NewWriter(&buf, OutputHuman)
 	resp := Response[Result]{
 		Protocol: ProtocolVersion,
 		Ok:       true,
@@ -101,7 +101,7 @@ func TestHumanFormat_EmptyResults(t *testing.T) {
 func TestHumanFormat_ErrorRendering(t *testing.T) {
 	withTTY(t, false)
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputHuman)
+	w := NewWriter(&buf, OutputHuman)
 	err := &Error{
 		Code:    ErrNotFound,
 		Message: "Symbol not found: Foo",
@@ -129,7 +129,7 @@ func TestHumanFormat_ErrorRendering(t *testing.T) {
 func TestHumanFormat_CompositeFallback(t *testing.T) {
 	withTTY(t, false)
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputHuman)
+	w := NewWriter(&buf, OutputHuman)
 	resp := Response[PackResult]{
 		Protocol: ProtocolVersion,
 		Ok:       true,

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -37,10 +37,9 @@ func SetShowSuggestions(v bool) { showSuggestionsEnabled = v }
 
 // Writer handles output formatting for LLM consumers.
 type Writer struct {
-	out     io.Writer
-	compact bool
-	format  OutputFormat
-	start   time.Time
+	out    io.Writer
+	format OutputFormat
+	start  time.Time
 	// embedMissing, when set, appends `! noembed` to the meta line of Claude
 	// output — an index-global self-assessment marker stamped once at store
 	// open (see OpenStore) so every query command emits it uniformly.
@@ -53,12 +52,11 @@ func (w *Writer) SetEmbedMissing(missing bool) { w.embedMissing = missing }
 
 // NewWriter creates a new output writer.
 // format controls rendering: "" (default) = Claude-optimized text, "json" = full JSON envelope.
-func NewWriter(out io.Writer, compact bool, format OutputFormat) *Writer {
+func NewWriter(out io.Writer, format OutputFormat) *Writer {
 	return &Writer{
-		out:     out,
-		compact: compact,
-		format:  format,
-		start:   time.Now(),
+		out:    out,
+		format: format,
+		start:  time.Now(),
 	}
 }
 
@@ -78,13 +76,10 @@ func (w *Writer) WriteResponse(resp any) error {
 	return w.writeClaude(resp)
 }
 
-// writeJSON writes the full JSON envelope (legacy/orca format).
+// writeJSON writes the full JSON envelope (legacy/orca format) as compact,
+// single-line JSON — the shape orca's go_symbol subprocess already consumes.
 func (w *Writer) writeJSON(resp any) error {
-	enc := json.NewEncoder(w.out)
-	if !w.compact {
-		enc.SetIndent("", "  ")
-	}
-	return enc.Encode(resp)
+	return json.NewEncoder(w.out).Encode(resp)
 }
 
 // writeClaude renders a response as terse structured text optimized for Claude.

--- a/internal/output/lifecycle_test.go
+++ b/internal/output/lifecycle_test.go
@@ -46,7 +46,7 @@ func TestLifecycleCallerChain(t *testing.T) {
 }
 
 func TestWriteClaudeLifecycle_CallersRendered(t *testing.T) {
-	w := NewWriter(&strings.Builder{}, false, OutputClaude)
+	w := NewWriter(&strings.Builder{}, OutputClaude)
 	var b strings.Builder
 	results := []LifecycleResult{
 		{
@@ -106,7 +106,7 @@ func TestWriteClaudeLifecycle_CallersRendered(t *testing.T) {
 }
 
 func TestWriteClaudeLifecycle_SummaryFormat(t *testing.T) {
-	w := NewWriter(&strings.Builder{}, false, OutputClaude)
+	w := NewWriter(&strings.Builder{}, OutputClaude)
 	var b strings.Builder
 	funcs := make([]LifecycleFunction, 0, 15)
 	for i := 0; i < 15; i++ {
@@ -240,7 +240,7 @@ func TestTruncateLifecycleToTokenBudget(t *testing.T) {
 
 func TestWriteClaudeLifecycle_JSONEnvelope(t *testing.T) {
 	var buf strings.Builder
-	w := NewWriter(&buf, false, OutputJSON)
+	w := NewWriter(&buf, OutputJSON)
 	results := []LifecycleResult{
 		{
 			Type:         "Store",

--- a/internal/output/matchtier_test.go
+++ b/internal/output/matchtier_test.go
@@ -12,7 +12,7 @@ import (
 func TestClaudeMatchTierMarker(t *testing.T) {
 	render := func(degraded ...string) string {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, false, OutputClaude)
+		w := NewWriter(&buf, OutputClaude)
 		resp := Response[Result]{
 			Protocol: ProtocolVersion,
 			Ok:       true,
@@ -42,7 +42,7 @@ func TestClaudeMatchTierMarker(t *testing.T) {
 // is the only place that magnitude survives.
 func TestClaudeSemanticMarker(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputClaude)
+	w := NewWriter(&buf, OutputClaude)
 	resp := Response[Result]{
 		Protocol: ProtocolVersion,
 		Ok:       true,

--- a/internal/output/noembed_test.go
+++ b/internal/output/noembed_test.go
@@ -28,7 +28,7 @@ func noEmbedResp() Response[Result] {
 func renderClaude(t *testing.T, embedMissing bool) string {
 	t.Helper()
 	var buf bytes.Buffer
-	w := NewWriter(&buf, false, OutputClaude)
+	w := NewWriter(&buf, OutputClaude)
 	w.SetEmbedMissing(embedMissing)
 	if err := w.WriteResponse(noEmbedResp()); err != nil {
 		t.Fatalf("WriteResponse: %v", err)

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -498,12 +498,12 @@ func (s *Store) WriteIndexIncremental(
 
 	if len(allAffected) > 0 {
 		// Delete embeddings + purposes for symbols in affected files
-		if err := deleteByFilePaths(tx, "SELECT id FROM symbols", "DELETE FROM embeddings WHERE symbol_id IN", allAffected, repoRoot); err != nil {
+		if err := deleteByFilePaths(tx, childEmbeddings, allAffected, repoRoot); err != nil {
 			if !isNoSuchTableErr(err, "embeddings") {
 				return nil, fmt.Errorf("delete embeddings: %w", err)
 			}
 		}
-		if err := deleteByFilePaths(tx, "SELECT id FROM symbols", "DELETE FROM symbol_purposes WHERE symbol_id IN", allAffected, repoRoot); err != nil {
+		if err := deleteByFilePaths(tx, childSymbolPurposes, allAffected, repoRoot); err != nil {
 			if !isNoSuchTableErr(err, "symbol_purposes") {
 				return nil, fmt.Errorf("delete symbol_purposes: %w", err)
 			}
@@ -621,14 +621,29 @@ func deleteFromFileSet(tx *sql.Tx, table string, files []string) error {
 	return err
 }
 
-// deleteByFilePaths finds symbol IDs in affected files, then deletes from a target table.
-func deleteByFilePaths(tx *sql.Tx, selectQuery, deleteQuery string, files []string, repoRoot string) error {
+// childTable names a symbol-owned child table whose rows are purged when the
+// owning symbols are re-indexed. Constraining the table to this enum lets
+// deleteByFilePaths bake the (invariant) symbol-ID SELECT and build the DELETE
+// itself, so call sites name a table identity instead of passing raw SQL.
+type childTable string
+
+const (
+	childEmbeddings     childTable = "embeddings"
+	childSymbolPurposes childTable = "symbol_purposes"
+)
+
+// deleteByFilePaths finds symbol IDs in the affected files, then deletes their
+// rows from a symbol-owned child table. The symbol-ID SELECT is invariant; only
+// the child table varies, so it is named by the constrained childTable enum.
+func deleteByFilePaths(tx *sql.Tx, table childTable, files []string, repoRoot string) error {
 	if len(files) == 0 {
 		return nil
 	}
+	const selectQuery = "SELECT id FROM symbols"
+	deleteQuery := "DELETE FROM " + string(table) + " WHERE symbol_id IN" // table is a constrained enum constant, never user input
 	// Find symbol IDs in affected files (by absolute path)
 	placeholders, args := toPlaceholders(files)
-	query := fmt.Sprintf("%s WHERE file_path IN (%s)", selectQuery, strings.Join(placeholders, ",")) // #nosec G201 -- query parts are hardcoded
+	query := fmt.Sprintf("%s WHERE file_path IN (%s)", selectQuery, strings.Join(placeholders, ",")) // #nosec G201 -- selectQuery is a const; placeholders are '?'
 	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return err
@@ -653,7 +668,7 @@ func deleteByFilePaths(tx *sql.Tx, selectQuery, deleteQuery string, files []stri
 		for i, f := range files {
 			relArgs[i] = toRelPath(f, repoRoot)
 		}
-		query = fmt.Sprintf("%s WHERE file_path_rel IN (%s)", selectQuery, strings.Join(placeholders, ",")) // #nosec G201 -- query parts are hardcoded
+		query = fmt.Sprintf("%s WHERE file_path_rel IN (%s)", selectQuery, strings.Join(placeholders, ",")) // #nosec G201 -- selectQuery is a const; placeholders are '?'
 		rows2, err := tx.Query(query, relArgs...)
 		if err != nil {
 			return err
@@ -677,7 +692,7 @@ func deleteByFilePaths(tx *sql.Tx, selectQuery, deleteQuery string, files []stri
 
 	// Delete from target table
 	idPlaceholders, idArgs := toPlaceholders(ids)
-	delQuery := fmt.Sprintf("%s (%s)", deleteQuery, strings.Join(idPlaceholders, ",")) // #nosec G201 -- query parts are hardcoded
+	delQuery := fmt.Sprintf("%s (%s)", deleteQuery, strings.Join(idPlaceholders, ",")) // #nosec G201 -- deleteQuery is enum-built; placeholders are '?'
 	_, err = tx.Exec(delQuery, idArgs...)
 	return err
 }


### PR DESCRIPTION
Closes: snipe-x95

Sliced from /team backlog wave 4 (shared branch team/impl-1782589426). make check green (vet+lint+test).