### PR TITLE
test: regenerate blackbox goldens for #170 zero-emit (unbreak make audit on main)

### DIFF
--- a/test/blackbox/testdata/golden/TestDef_ByPosition_ReturnsDefinition_When_IndexPresent.json
+++ b/test/blackbox/testdata/golden/TestDef_ByPosition_ReturnsDefinition_When_IndexPresent.json
@@ -5,6 +5,8 @@
     "decision_path": [
       "lookup:position"
     ],
+    "limit": 0,
+    "offset": 0,
     "query": {
       "at": "\u003crepo\u003e/main.go:25:11"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Callees.json
+++ b/test/blackbox/testdata/golden/TestGolden_Callees.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "callees",
     "limit": 50,
+    "offset": 0,
     "query": {
       "symbol": "CallMany"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Callers.json
+++ b/test/blackbox/testdata/golden/TestGolden_Callers.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "callers",
     "limit": 50,
+    "offset": 0,
     "query": {
       "symbol": "Callee"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Def_Function.json
+++ b/test/blackbox/testdata/golden/TestGolden_Def_Function.json
@@ -5,6 +5,8 @@
     "decision_path": [
       "lookup:name"
     ],
+    "limit": 0,
+    "offset": 0,
     "query": {
       "symbol": "Callee"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Def_Interface.json
+++ b/test/blackbox/testdata/golden/TestGolden_Def_Interface.json
@@ -5,6 +5,8 @@
     "decision_path": [
       "lookup:name"
     ],
+    "limit": 0,
+    "offset": 0,
     "query": {
       "symbol": "Greeter"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Def_Struct.json
+++ b/test/blackbox/testdata/golden/TestGolden_Def_Struct.json
@@ -5,6 +5,8 @@
     "decision_path": [
       "lookup:name"
     ],
+    "limit": 0,
+    "offset": 0,
     "query": {
       "symbol": "Widget"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Deps.json
+++ b/test/blackbox/testdata/golden/TestGolden_Deps.json
@@ -2,6 +2,8 @@
   "error": null,
   "meta": {
     "command": "deps",
+    "limit": 0,
+    "offset": 0,
     "query": {
       "package": "example.com/fixture"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Impact.json
+++ b/test/blackbox/testdata/golden/TestGolden_Impact.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "impact",
     "limit": 50,
+    "offset": 0,
     "query": {
       "symbol": "Callee"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Impl.json
+++ b/test/blackbox/testdata/golden/TestGolden_Impl.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "impl",
     "limit": 50,
+    "offset": 0,
     "query": {
       "interface": "Greeter"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Lifecycle_AllRoles.json
+++ b/test/blackbox/testdata/golden/TestGolden_Lifecycle_AllRoles.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "lifecycle",
     "limit": 50,
+    "offset": 0,
     "query": {
       "type": "Widget"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Lifecycle_IncludeTests.json
+++ b/test/blackbox/testdata/golden/TestGolden_Lifecycle_IncludeTests.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "lifecycle",
     "limit": 50,
+    "offset": 0,
     "query": {
       "type": "Widget"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Pack_Struct.json
+++ b/test/blackbox/testdata/golden/TestGolden_Pack_Struct.json
@@ -2,6 +2,8 @@
   "error": null,
   "meta": {
     "command": "pack",
+    "limit": 0,
+    "offset": 0,
     "query": {
       "symbol": "Widget"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Pkg.json
+++ b/test/blackbox/testdata/golden/TestGolden_Pkg.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "pkg",
     "limit": 200,
+    "offset": 0,
     "query": {
       "package": "example.com/fixture"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Refs.json
+++ b/test/blackbox/testdata/golden/TestGolden_Refs.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "refs",
     "limit": 50,
+    "offset": 0,
     "query": {
       "symbol": "Callee"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Tests.json
+++ b/test/blackbox/testdata/golden/TestGolden_Tests.json
@@ -3,6 +3,7 @@
   "meta": {
     "command": "tests",
     "limit": 50,
+    "offset": 0,
     "query": {
       "symbol": "Callee"
     },

--- a/test/blackbox/testdata/golden/TestGolden_Types.json
+++ b/test/blackbox/testdata/golden/TestGolden_Types.json
@@ -2,6 +2,8 @@
   "error": null,
   "meta": {
     "command": "types",
+    "limit": 0,
+    "offset": 0,
     "query": {
       "symbol": "Widget"
     },

--- a/test/blackbox/testdata/golden/TestShow_ByID_ReturnsExpandedContext_When_UsingPriorResultID.json
+++ b/test/blackbox/testdata/golden/TestShow_ByID_ReturnsExpandedContext_When_UsingPriorResultID.json
@@ -2,6 +2,8 @@
   "error": null,
   "meta": {
     "command": "show",
+    "limit": 0,
+    "offset": 0,
     "query": {},
     "repo_root": "\u003crepo\u003e",
     "total": 1,


### PR DESCRIPTION
Closes: snipe-aox

#170 (snipe-0xt) dropped omitempty from meaningful-zero Meta fields but did not regen test/blackbox/testdata, so TestGolden_* fail under make audit/CI on main (make check skips blackbox → slipped through). Regen adds only offset/limit zero fields across 15 goldens. NOT draft — unbreaks main, merge-ready.