### PR TITLE
Git-aware code-risk metrics (crime-scene model)

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -42,6 +42,7 @@ type CLI struct {
 	Types     TypesCmd     `cmd:"" group:"Graph & Structure:" help:"Show type relationships"`
 	Boundary  BoundaryCmd  `cmd:"" group:"Graph & Structure:" help:"Show symbols whose refs cross between two package sets"`
 	Metrics   MetricsCmd   `cmd:"" group:"Graph & Structure:" help:"Show graph metrics (PageRank, coupling, HITS, etc.) over the import or call graph"`
+	Hotspots  HotspotsCmd  `cmd:"" group:"Graph & Structure:" help:"Rank files by complexity × git change-frequency (Tornhill hotspot model)"`
 	Diagram   DiagramCmd   `cmd:"" group:"Graph & Structure:" help:"Render snipe graphs as D2 diagram source"`
 	Lifecycle LifecycleCmd `cmd:"" group:"Graph & Structure:" help:"Trace every function creating, mutating, reading, or deleting a type"`
 	Deadcode  DeadcodeCmd  `cmd:"" group:"Graph & Structure:" help:"Report exported symbols with zero non-test references"`

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -43,6 +43,7 @@ type CLI struct {
 	Boundary  BoundaryCmd  `cmd:"" group:"Graph & Structure:" help:"Show symbols whose refs cross between two package sets"`
 	Metrics   MetricsCmd   `cmd:"" group:"Graph & Structure:" help:"Show graph metrics (PageRank, coupling, HITS, etc.) over the import or call graph"`
 	Hotspots  HotspotsCmd  `cmd:"" group:"Graph & Structure:" help:"Rank files by complexity × git change-frequency (Tornhill hotspot model)"`
+	Sensitive SensitiveCmd `cmd:"" group:"Graph & Structure:" help:"List files in security-sensitive zones (auth/crypto/migration/secret/payment)"`
 	Diagram   DiagramCmd   `cmd:"" group:"Graph & Structure:" help:"Render snipe graphs as D2 diagram source"`
 	Lifecycle LifecycleCmd `cmd:"" group:"Graph & Structure:" help:"Trace every function creating, mutating, reading, or deleting a type"`
 	Deadcode  DeadcodeCmd  `cmd:"" group:"Graph & Structure:" help:"Report exported symbols with zero non-test references"`

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -327,6 +327,16 @@ func (c *MetricsCmd) Run() error {
 	return runMetrics()
 }
 
+type HotspotsCmd struct {
+	Top  int    `default:"20" help:"Top-N files to print"`
+	Pkg  string `help:"Filter to paths containing this substring (e.g. internal/store)"`
+	File string `help:"Filter to paths containing this substring"`
+}
+
+func (c *HotspotsCmd) Run() error {
+	return runHotspots(c.Top, c.Pkg, c.File)
+}
+
 type DiagramCmd struct {
 	// diagram reuses the global --format flag (d2 default, or svg). It cannot
 	// redeclare --format because the global flag is embedded on every command.

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -314,7 +314,7 @@ func (c *BoundaryCmd) Run() error {
 
 type MetricsCmd struct {
 	Top   int    `default:"20" help:"Top-N rows to print"`
-	Kind  string `default:"pagerank" help:"Metric kind (or comma-separated list for a merged table): pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|usage"`
+	Kind  string `default:"pagerank" help:"Metric kind (or comma-separated list for a merged table): pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|churn|usage"`
 	Graph string `default:"imports" help:"Graph kind ('imports' or 'calls')"`
 	Pkg   string `help:"Filter to a single package (suffix-matches package import path)"`
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -337,6 +337,12 @@ func (c *HotspotsCmd) Run() error {
 	return runHotspots(c.Top, c.Pkg, c.File)
 }
 
+type SensitiveCmd struct{}
+
+func (c *SensitiveCmd) Run() error {
+	return runSensitive()
+}
+
 type DiagramCmd struct {
 	// diagram reuses the global --format flag (d2 default, or svg). It cannot
 	// redeclare --format because the global flag is embedded on every command.

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -314,7 +314,7 @@ func (c *BoundaryCmd) Run() error {
 
 type MetricsCmd struct {
 	Top   int    `default:"20" help:"Top-N rows to print"`
-	Kind  string `default:"pagerank" help:"Metric kind (or comma-separated list for a merged table): pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|churn|usage"`
+	Kind  string `default:"pagerank" help:"Metric kind (or comma-separated list for a merged table): pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|cognitive|churn|usage"`
 	Graph string `default:"imports" help:"Graph kind ('imports' or 'calls')"`
 	Pkg   string `help:"Filter to a single package (suffix-matches package import path)"`
 }

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -53,6 +53,7 @@ const (
 	cmdKindError     = "error"
 	cmdKindGraph     = "graph"
 	cmdKindCyclo     = "cyclo"
+	cmdKindCognitive = "cognitive"
 	cmdKindCycles    = "cycles"
 	cmdKindCoupling  = "coupling"
 	cmdKindInterface = "interface"

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -14,6 +14,7 @@ const (
 	cmdNameDoctor      = "doctor"
 	cmdNameSim         = "sim"
 	cmdNameMetrics     = "metrics"
+	cmdNameHotspots    = "hotspots"
 	cmdNameSym         = "sym"
 	cmdNameSearch      = "search"
 	cmdNameShow        = "show"

--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+// hotspotRow is one file ranked by the Tornhill hotspot model.
+type hotspotRow struct {
+	Path        string  `json:"path"`
+	Score       float64 `json:"score"`        // 0..1, complexity × change-frequency
+	Cyclo       int     `json:"cyclo"`        // summed McCabe complexity of the file's funcs
+	CycloMax    int     `json:"cyclo_max"`    // hottest single function
+	Commits     int     `json:"commits"`      // revisions touching the file
+	Authors     int     `json:"authors"`      // distinct committers (bus factor)
+	LastChanged string  `json:"last_changed"` // empty when churn unavailable
+}
+
+// runHotspots ranks files by complexity × change-frequency — Tornhill's
+// single most practical risk heuristic (Your Code as a Crime Scene, 2015;
+// CodeScene). Complex code that never changes is stable and churning simple
+// code is cheap; risk concentrates in the overlap. It joins per-file McCabe
+// complexity (computeFileCyclo) with git churn (file_churn). Outside a git
+// repo it degrades to a complexity-only ranking with a printed note.
+func runHotspots(top int, pkg, file string) error {
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+	s, dir, err := OpenStore(w, cmdNameHotspots)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	start := time.Now()
+
+	cycloSum, err := s.ReadTopN("files", "cyclo_sum", 0)
+	if err != nil {
+		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	if len(cycloSum) == 0 {
+		_, werr := os.Stdout.WriteString("hotspots · (no complexity data — run `snipe index` to populate)\n")
+		return werr
+	}
+	cycloMax, err := s.ReadTopN("files", "cyclo_max", 0)
+	if err != nil {
+		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	churn, err := s.ReadFileChurnTopN(0)
+	if err != nil {
+		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+
+	maxByPath := make(map[string]int, len(cycloMax))
+	for _, r := range cycloMax {
+		maxByPath[r.NodeID] = int(r.Value)
+	}
+	churnByPath := make(map[string]store.FileChurn, len(churn))
+	for _, c := range churn {
+		churnByPath[c.Path] = c
+	}
+	haveChurn := len(churn) > 0
+
+	rows := buildHotspots(cycloSum, maxByPath, churnByPath, haveChurn)
+	rows = filterHotspots(rows, pkg, file)
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Score != rows[j].Score {
+			return rows[i].Score > rows[j].Score
+		}
+		return rows[i].Path < rows[j].Path
+	})
+	if top > 0 && len(rows) > top {
+		rows = rows[:top]
+	}
+
+	if GetOutputFormat() == output.OutputJSON {
+		return writeHotspotsJSON(rows, dir, start)
+	}
+	return writeHotspotsText(rows, haveChurn)
+}
+
+// buildHotspots joins complexity with churn and assigns a normalized score.
+// Complexity is normalized linearly; churn is log-scaled first because commit
+// counts are heavy-tailed (a few files dominate). With churn present, only
+// files that have history are scored (inner join); without it, every file is
+// scored on complexity alone so the command still ranks something useful.
+func buildHotspots(cycloSum []store.MetricRow, maxByPath map[string]int, churnByPath map[string]store.FileChurn, haveChurn bool) []hotspotRow {
+	var maxCyclo, maxLogChurn float64
+	for _, r := range cycloSum {
+		if r.Value > maxCyclo {
+			maxCyclo = r.Value
+		}
+	}
+	if haveChurn {
+		for _, c := range churnByPath {
+			if l := math.Log1p(float64(c.Commits)); l > maxLogChurn {
+				maxLogChurn = l
+			}
+		}
+	}
+
+	rows := make([]hotspotRow, 0, len(cycloSum))
+	for _, r := range cycloSum {
+		c, ok := churnByPath[r.NodeID]
+		if haveChurn && !ok {
+			continue // no history → not a hotspot in the crime-scene sense
+		}
+		cycloNorm := 0.0
+		if maxCyclo > 0 {
+			cycloNorm = r.Value / maxCyclo
+		}
+		score := cycloNorm
+		if haveChurn && maxLogChurn > 0 {
+			score = cycloNorm * (math.Log1p(float64(c.Commits)) / maxLogChurn)
+		}
+		rows = append(rows, hotspotRow{
+			Path:        r.NodeID,
+			Score:       score,
+			Cyclo:       int(r.Value),
+			CycloMax:    maxByPath[r.NodeID],
+			Commits:     c.Commits,
+			Authors:     c.Authors,
+			LastChanged: c.LastChanged,
+		})
+	}
+	return rows
+}
+
+func filterHotspots(rows []hotspotRow, pkg, file string) []hotspotRow {
+	if pkg == "" && file == "" {
+		return rows
+	}
+	out := rows[:0]
+	for _, r := range rows {
+		if pkg != "" && !strings.Contains(r.Path, pkg) {
+			continue
+		}
+		if file != "" && !strings.Contains(r.Path, file) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func writeHotspotsJSON(rows []hotspotRow, dir string, start time.Time) error {
+	resp := output.Response[hotspotRow]{
+		Protocol: output.ProtocolVersion,
+		Ok:       true,
+		Results:  rows,
+		Meta: output.Meta{
+			Command:  cmdNameHotspots,
+			RepoRoot: dir,
+			Ms:       time.Since(start).Milliseconds(),
+			Total:    len(rows),
+		},
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
+	var b strings.Builder
+	b.WriteString("hotspots · complexity × change-frequency (Tornhill crime-scene: risk peaks where complex code changes often)\n")
+	if !haveChurn {
+		b.WriteString("  ⚠ no git churn available (not a git repo) — ranking by complexity only\n")
+	}
+	if len(rows) == 0 {
+		b.WriteString("  (no rows)\n")
+		_, err := os.Stdout.WriteString(b.String())
+		return err
+	}
+	if haveChurn {
+		fmt.Fprintf(&b, "  %5s %6s %5s %8s %8s  %-12s  %s\n", "score", "cyclo", "cmax", "commits", "authors", "last-changed", "path")
+		for _, r := range rows {
+			fmt.Fprintf(&b, "  %5.2f %6d %5d %8d %8d  %-12s  %s\n",
+				r.Score, r.Cyclo, r.CycloMax, r.Commits, r.Authors, r.LastChanged, r.Path)
+		}
+	} else {
+		fmt.Fprintf(&b, "  %5s %6s %5s  %s\n", "score", "cyclo", "cmax", "path")
+		for _, r := range rows {
+			fmt.Fprintf(&b, "  %5.2f %6d %5d  %s\n", r.Score, r.Cyclo, r.CycloMax, r.Path)
+		}
+	}
+	_, err := os.Stdout.WriteString(b.String())
+	return err
+}

--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -10,18 +10,20 @@ import (
 	"time"
 
 	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/sensitive"
 	"github.com/dkoosis/snipe/internal/store"
 )
 
 // hotspotRow is one file ranked by the Tornhill hotspot model.
 type hotspotRow struct {
-	Path        string  `json:"path"`
-	Score       float64 `json:"score"`        // 0..1, complexity × change-frequency
-	Cyclo       int     `json:"cyclo"`        // summed McCabe complexity of the file's funcs
-	CycloMax    int     `json:"cyclo_max"`    // hottest single function
-	Commits     int     `json:"commits"`      // revisions touching the file
-	Authors     int     `json:"authors"`      // distinct committers (bus factor)
-	LastChanged string  `json:"last_changed"` // empty when churn unavailable
+	Path        string           `json:"path"`
+	Score       float64          `json:"score"`               // 0..1, complexity × change-frequency
+	Cyclo       int              `json:"cyclo"`               // summed McCabe complexity of the file's funcs
+	CycloMax    int              `json:"cyclo_max"`           // hottest single function
+	Commits     int              `json:"commits"`             // revisions touching the file
+	Authors     int              `json:"authors"`             // distinct committers (bus factor)
+	LastChanged string           `json:"last_changed"`        // empty when churn unavailable
+	Sensitive   []sensitive.Zone `json:"sensitive,omitempty"` // auth/crypto/migration/... if any
 }
 
 // runHotspots ranks files by complexity × change-frequency — Tornhill's
@@ -68,6 +70,12 @@ func runHotspots(top int, pkg, file string) error {
 
 	rows := buildHotspots(cycloSum, maxByPath, churnByPath, haveChurn)
 	rows = filterHotspots(rows, pkg, file)
+	// Annotate with sensitive zones so a small-but-critical file (auth, crypto,
+	// migration) is visible even when its complexity × churn score is modest.
+	cls := sensitive.Load(dir)
+	for i := range rows {
+		rows[i].Sensitive = cls.Zones(rows[i].Path)
+	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].Score != rows[j].Score {
 			return rows[i].Score > rows[j].Score
@@ -165,6 +173,15 @@ func writeHotspotsJSON(rows []hotspotRow, dir string, start time.Time) error {
 	return enc.Encode(resp)
 }
 
+// zoneSuffix renders a sensitive-zone marker appended to a hotspot's path,
+// e.g. " ⚑[auth,crypto]", or "" when the file is in no sensitive zone.
+func zoneSuffix(zones []sensitive.Zone) string {
+	if len(zones) == 0 {
+		return ""
+	}
+	return "  ⚑" + zonesString(zones)
+}
+
 func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
 	var b strings.Builder
 	b.WriteString("hotspots · complexity × change-frequency (Tornhill crime-scene: risk peaks where complex code changes often)\n")
@@ -179,13 +196,13 @@ func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
 	if haveChurn {
 		fmt.Fprintf(&b, "  %5s %6s %5s %8s %8s  %-12s  %s\n", "score", "cyclo", "cmax", "commits", "authors", "last-changed", "path")
 		for _, r := range rows {
-			fmt.Fprintf(&b, "  %5.2f %6d %5d %8d %8d  %-12s  %s\n",
-				r.Score, r.Cyclo, r.CycloMax, r.Commits, r.Authors, r.LastChanged, r.Path)
+			fmt.Fprintf(&b, "  %5.2f %6d %5d %8d %8d  %-12s  %s%s\n",
+				r.Score, r.Cyclo, r.CycloMax, r.Commits, r.Authors, r.LastChanged, r.Path, zoneSuffix(r.Sensitive))
 		}
 	} else {
 		fmt.Fprintf(&b, "  %5s %6s %5s  %s\n", "score", "cyclo", "cmax", "path")
 		for _, r := range rows {
-			fmt.Fprintf(&b, "  %5.2f %6d %5d  %s\n", r.Score, r.Cyclo, r.CycloMax, r.Path)
+			fmt.Fprintf(&b, "  %5.2f %6d %5d  %s%s\n", r.Score, r.Cyclo, r.CycloMax, r.Path, zoneSuffix(r.Sensitive))
 		}
 	}
 	_, err := os.Stdout.WriteString(b.String())

--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -51,6 +51,11 @@ func runHotspots(top int, pkg, file string) error {
 		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
 	}
 	if len(cycloSum) == 0 {
+		// Preserve the JSON envelope for API/orca consumers in the common
+		// "index not populated yet" case; plain text is for humans only.
+		if GetOutputFormat() == output.OutputJSON {
+			return writeHotspotsJSON(nil, dir, start)
+		}
 		_, werr := os.Stdout.WriteString("hotspots · (no complexity data — run `snipe index` to populate)\n")
 		return werr
 	}

--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -14,14 +14,19 @@ import (
 	"github.com/dkoosis/snipe/internal/store"
 )
 
-// hotspotRow is one file ranked by the Tornhill hotspot model.
+// hotspotRow is one file in the unified risk view. Score is the grounded
+// Tornhill hotspot (complexity × change-frequency); the other fields are the
+// risk components Claude reads to judge the dominant factor — they are NOT
+// folded into the score.
 type hotspotRow struct {
 	Path        string           `json:"path"`
-	Score       float64          `json:"score"`               // 0..1, complexity × change-frequency
-	Cyclo       int              `json:"cyclo"`               // summed McCabe complexity of the file's funcs
+	Score       float64          `json:"score"`               // 0..1, Tornhill hotspot = cyclo × churn
+	Cyclo       int              `json:"cyclo"`               // summed McCabe complexity (cx)
 	CycloMax    int              `json:"cyclo_max"`           // hottest single function
-	Commits     int              `json:"commits"`             // revisions touching the file
-	Authors     int              `json:"authors"`             // distinct committers (bus factor)
+	Cognitive   int              `json:"cognitive"`           // summed SonarSource cognitive complexity (cog)
+	Commits     int              `json:"commits"`             // revisions touching the file (chn)
+	Authors     int              `json:"authors"`             // distinct committers / bus factor (auth)
+	FanIn       int              `json:"fan_in"`              // cross-file callers / blast radius (in)
 	LastChanged string           `json:"last_changed"`        // empty when churn unavailable
 	Sensitive   []sensitive.Zone `json:"sensitive,omitempty"` // auth/crypto/migration/... if any
 }
@@ -53,22 +58,29 @@ func runHotspots(top int, pkg, file string) error {
 	if err != nil {
 		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
 	}
+	cognitiveSum, err := s.ReadTopN("files", "cognitive_sum", 0)
+	if err != nil {
+		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	fanInRows, err := s.ReadTopN("files", "fan_in", 0)
+	if err != nil {
+		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
 	churn, err := s.ReadFileChurnTopN(0)
 	if err != nil {
 		return w.WriteError(cmdNameHotspots, &output.Error{Code: output.ErrInternal, Message: err.Error()})
 	}
 
-	maxByPath := make(map[string]int, len(cycloMax))
-	for _, r := range cycloMax {
-		maxByPath[r.NodeID] = int(r.Value)
-	}
+	maxByPath := intByPath(cycloMax)
+	cogByPath := intByPath(cognitiveSum)
+	fanByPath := intByPath(fanInRows)
 	churnByPath := make(map[string]store.FileChurn, len(churn))
 	for _, c := range churn {
 		churnByPath[c.Path] = c
 	}
 	haveChurn := len(churn) > 0
 
-	rows := buildHotspots(cycloSum, maxByPath, churnByPath, haveChurn)
+	rows := buildHotspots(cycloSum, maxByPath, cogByPath, fanByPath, churnByPath, haveChurn)
 	rows = filterHotspots(rows, pkg, file)
 	// Annotate with sensitive zones so a small-but-critical file (auth, crypto,
 	// migration) is visible even when its complexity × churn score is modest.
@@ -92,12 +104,23 @@ func runHotspots(top int, pkg, file string) error {
 	return writeHotspotsText(rows, haveChurn)
 }
 
-// buildHotspots joins complexity with churn and assigns a normalized score.
-// Complexity is normalized linearly; churn is log-scaled first because commit
-// counts are heavy-tailed (a few files dominate). With churn present, only
-// files that have history are scored (inner join); without it, every file is
-// scored on complexity alone so the command still ranks something useful.
-func buildHotspots(cycloSum []store.MetricRow, maxByPath map[string]int, churnByPath map[string]store.FileChurn, haveChurn bool) []hotspotRow {
+// intByPath collapses metric rows into a path→int lookup.
+func intByPath(rows []store.MetricRow) map[string]int {
+	m := make(map[string]int, len(rows))
+	for _, r := range rows {
+		m[r.NodeID] = int(r.Value)
+	}
+	return m
+}
+
+// buildHotspots assembles the unified risk rows. The score is the grounded
+// Tornhill hotspot — norm(cyclo) × norm(log1p(commits)) — and nothing else;
+// cognitive, fan-in and sensitivity ride along as context columns rather than
+// being folded into an un-grounded composite. Complexity is normalized
+// linearly; churn is log-scaled first because commit counts are heavy-tailed.
+// With churn present, only files with history are scored (inner join); without
+// it, every file is scored on complexity alone so the command still ranks.
+func buildHotspots(cycloSum []store.MetricRow, maxByPath, cogByPath, fanByPath map[string]int, churnByPath map[string]store.FileChurn, haveChurn bool) []hotspotRow {
 	var maxCyclo, maxLogChurn float64
 	for _, r := range cycloSum {
 		if r.Value > maxCyclo {
@@ -131,8 +154,10 @@ func buildHotspots(cycloSum []store.MetricRow, maxByPath map[string]int, churnBy
 			Score:       score,
 			Cyclo:       int(r.Value),
 			CycloMax:    maxByPath[r.NodeID],
+			Cognitive:   cogByPath[r.NodeID],
 			Commits:     c.Commits,
 			Authors:     c.Authors,
+			FanIn:       fanByPath[r.NodeID],
 			LastChanged: c.LastChanged,
 		})
 	}
@@ -184,9 +209,10 @@ func zoneSuffix(zones []sensitive.Zone) string {
 
 func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
 	var b strings.Builder
-	b.WriteString("hotspots · complexity × change-frequency (Tornhill crime-scene: risk peaks where complex code changes often)\n")
+	b.WriteString("hotspots · unified risk (Tornhill crime-scene)\n")
+	b.WriteString("  risk = cyclo × change-frequency; cx=cyclo cog=cognitive chn=commits auth=bus-factor in=fan-in/blast-radius ⚑=sensitive\n")
 	if !haveChurn {
-		b.WriteString("  ⚠ no git churn available (not a git repo) — ranking by complexity only\n")
+		b.WriteString("  ⚠ no git churn (not a git repo) — risk ranked on complexity alone; chn/auth omitted\n")
 	}
 	if len(rows) == 0 {
 		b.WriteString("  (no rows)\n")
@@ -194,15 +220,15 @@ func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
 		return err
 	}
 	if haveChurn {
-		fmt.Fprintf(&b, "  %5s %6s %5s %8s %8s  %-12s  %s\n", "score", "cyclo", "cmax", "commits", "authors", "last-changed", "path")
+		fmt.Fprintf(&b, "  %5s %5s %5s %5s %5s %5s  %s\n", "risk", "cx", "cog", "chn", "auth", "in", "path")
 		for _, r := range rows {
-			fmt.Fprintf(&b, "  %5.2f %6d %5d %8d %8d  %-12s  %s%s\n",
-				r.Score, r.Cyclo, r.CycloMax, r.Commits, r.Authors, r.LastChanged, r.Path, zoneSuffix(r.Sensitive))
+			fmt.Fprintf(&b, "  %5.2f %5d %5d %5d %5d %5d  %s%s\n",
+				r.Score, r.Cyclo, r.Cognitive, r.Commits, r.Authors, r.FanIn, r.Path, zoneSuffix(r.Sensitive))
 		}
 	} else {
-		fmt.Fprintf(&b, "  %5s %6s %5s  %s\n", "score", "cyclo", "cmax", "path")
+		fmt.Fprintf(&b, "  %5s %5s %5s %5s  %s\n", "risk", "cx", "cog", "in", "path")
 		for _, r := range rows {
-			fmt.Fprintf(&b, "  %5.2f %6d %5d  %s%s\n", r.Score, r.Cyclo, r.CycloMax, r.Path, zoneSuffix(r.Sensitive))
+			fmt.Fprintf(&b, "  %5.2f %5d %5d %5d  %s%s\n", r.Score, r.Cyclo, r.Cognitive, r.FanIn, r.Path, zoneSuffix(r.Sensitive))
 		}
 	}
 	_, err := os.Stdout.WriteString(b.String())

--- a/cmd/hotspots_test.go
+++ b/cmd/hotspots_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+func rowByPath(rows []hotspotRow) map[string]hotspotRow {
+	m := make(map[string]hotspotRow, len(rows))
+	for _, r := range rows {
+		m[r.Path] = r
+	}
+	return m
+}
+
+func TestBuildHotspotsJoinsComplexityAndChurn(t *testing.T) {
+	cyclo := []store.MetricRow{
+		{NodeID: "hot.go", Value: 100},   // high complexity + high churn → top
+		{NodeID: "cold.go", Value: 100},  // same complexity, low churn → lower
+		{NodeID: "stable.go", Value: 5},  // low complexity, high churn → lower
+		{NodeID: "orphan.go", Value: 80}, // complexity but NO churn → dropped
+	}
+	maxByPath := map[string]int{"hot.go": 40, "cold.go": 30, "stable.go": 5, "orphan.go": 20}
+	churn := map[string]store.FileChurn{
+		"hot.go":    {Path: "hot.go", Commits: 50, Authors: 3, LastChanged: "2026-06-01"},
+		"cold.go":   {Path: "cold.go", Commits: 2, Authors: 1, LastChanged: "2026-01-01"},
+		"stable.go": {Path: "stable.go", Commits: 50, Authors: 2, LastChanged: "2026-06-01"},
+	}
+
+	rows := buildHotspots(cyclo, maxByPath, churn, true)
+	m := rowByPath(rows)
+
+	if _, ok := m["orphan.go"]; ok {
+		t.Errorf("file without churn should be excluded from hotspots, got %+v", rows)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 (orphan dropped)", len(rows))
+	}
+	// hot.go has max complexity AND max churn → highest score.
+	if m["hot.go"].Score <= m["cold.go"].Score {
+		t.Errorf("hot.go (%.3f) should outscore cold.go (%.3f)", m["hot.go"].Score, m["cold.go"].Score)
+	}
+	if m["hot.go"].Score <= m["stable.go"].Score {
+		t.Errorf("hot.go (%.3f) should outscore stable.go (%.3f)", m["hot.go"].Score, m["stable.go"].Score)
+	}
+	// Fields carried through from churn.
+	if m["hot.go"].Commits != 50 || m["hot.go"].Authors != 3 || m["hot.go"].CycloMax != 40 {
+		t.Errorf("hot.go fields wrong: %+v", m["hot.go"])
+	}
+}
+
+func TestBuildHotspotsFallsBackToComplexityWithoutChurn(t *testing.T) {
+	cyclo := []store.MetricRow{
+		{NodeID: "big.go", Value: 200},
+		{NodeID: "small.go", Value: 50},
+	}
+	maxByPath := map[string]int{"big.go": 30, "small.go": 10}
+
+	rows := buildHotspots(cyclo, maxByPath, map[string]store.FileChurn{}, false)
+	m := rowByPath(rows)
+
+	// No churn → every file scored on complexity alone (no inner-join drop).
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (no churn must not drop files)", len(rows))
+	}
+	// big.go is the max → normalized score 1.0; small.go is 50/200 = 0.25.
+	if m["big.go"].Score != 1.0 {
+		t.Errorf("big.go score = %.3f, want 1.0 (complexity-normalized max)", m["big.go"].Score)
+	}
+	if m["small.go"].Score != 0.25 {
+		t.Errorf("small.go score = %.3f, want 0.25", m["small.go"].Score)
+	}
+}
+
+func TestFilterHotspotsByPath(t *testing.T) {
+	rows := []hotspotRow{
+		{Path: "internal/store/write.go"},
+		{Path: "cmd/index.go"},
+		{Path: "internal/store/schema.go"},
+	}
+	got := filterHotspots(rows, "internal/store", "")
+	if len(got) != 2 {
+		t.Errorf("pkg filter internal/store → %d rows, want 2: %+v", len(got), got)
+	}
+}

--- a/cmd/hotspots_test.go
+++ b/cmd/hotspots_test.go
@@ -22,13 +22,15 @@ func TestBuildHotspotsJoinsComplexityAndChurn(t *testing.T) {
 		{NodeID: "orphan.go", Value: 80}, // complexity but NO churn → dropped
 	}
 	maxByPath := map[string]int{"hot.go": 40, "cold.go": 30, "stable.go": 5, "orphan.go": 20}
+	cogByPath := map[string]int{"hot.go": 200, "cold.go": 50, "stable.go": 3, "orphan.go": 90}
+	fanByPath := map[string]int{"hot.go": 12, "cold.go": 1, "stable.go": 7, "orphan.go": 4}
 	churn := map[string]store.FileChurn{
 		"hot.go":    {Path: "hot.go", Commits: 50, Authors: 3, LastChanged: "2026-06-01"},
 		"cold.go":   {Path: "cold.go", Commits: 2, Authors: 1, LastChanged: "2026-01-01"},
 		"stable.go": {Path: "stable.go", Commits: 50, Authors: 2, LastChanged: "2026-06-01"},
 	}
 
-	rows := buildHotspots(cyclo, maxByPath, churn, true)
+	rows := buildHotspots(cyclo, maxByPath, cogByPath, fanByPath, churn, true)
 	m := rowByPath(rows)
 
 	if _, ok := m["orphan.go"]; ok {
@@ -44,9 +46,12 @@ func TestBuildHotspotsJoinsComplexityAndChurn(t *testing.T) {
 	if m["hot.go"].Score <= m["stable.go"].Score {
 		t.Errorf("hot.go (%.3f) should outscore stable.go (%.3f)", m["hot.go"].Score, m["stable.go"].Score)
 	}
-	// Fields carried through from churn.
+	// Component columns carried through (these ride alongside, not in the score).
 	if m["hot.go"].Commits != 50 || m["hot.go"].Authors != 3 || m["hot.go"].CycloMax != 40 {
-		t.Errorf("hot.go fields wrong: %+v", m["hot.go"])
+		t.Errorf("hot.go churn/cyclo fields wrong: %+v", m["hot.go"])
+	}
+	if m["hot.go"].Cognitive != 200 || m["hot.go"].FanIn != 12 {
+		t.Errorf("hot.go cognitive/fan-in not carried: cog=%d in=%d", m["hot.go"].Cognitive, m["hot.go"].FanIn)
 	}
 }
 
@@ -56,8 +61,9 @@ func TestBuildHotspotsFallsBackToComplexityWithoutChurn(t *testing.T) {
 		{NodeID: "small.go", Value: 50},
 	}
 	maxByPath := map[string]int{"big.go": 30, "small.go": 10}
+	fanByPath := map[string]int{"big.go": 5, "small.go": 9}
 
-	rows := buildHotspots(cyclo, maxByPath, map[string]store.FileChurn{}, false)
+	rows := buildHotspots(cyclo, maxByPath, map[string]int{}, fanByPath, map[string]store.FileChurn{}, false)
 	m := rowByPath(rows)
 
 	// No churn → every file scored on complexity alone (no inner-join drop).
@@ -70,6 +76,10 @@ func TestBuildHotspotsFallsBackToComplexityWithoutChurn(t *testing.T) {
 	}
 	if m["small.go"].Score != 0.25 {
 		t.Errorf("small.go score = %.3f, want 0.25", m["small.go"].Score)
+	}
+	// Fan-in is structural — available and carried even without git churn.
+	if m["big.go"].FanIn != 5 || m["small.go"].FanIn != 9 {
+		t.Errorf("fan-in should be present without churn: big=%d small=%d", m["big.go"].FanIn, m["small.go"].FanIn)
 	}
 }
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -251,8 +251,11 @@ func runIndex(args []string) error {
 		if err := computeCallsGraphMetrics(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: calls-graph metrics computation failed: %v\n", err)
 		}
-		if err := computeFileCyclo(s, symbols); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: file cyclo computation failed: %v\n", err)
+		if err := computeFileComplexity(s, symbols); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: file complexity computation failed: %v\n", err)
+		}
+		if err := computeFileFanIn(s); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: file fan-in computation failed: %v\n", err)
 		}
 		if err := computeChurn(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: git churn computation failed: %v\n", err)
@@ -1068,19 +1071,20 @@ func writeComplexityRollups(s *store.Store, prefix string, rollups map[string]in
 	return nil
 }
 
-// computeFileCyclo aggregates per-symbol McCabe complexity into per-file
-// sum and max, stored under a synthetic "files" graph. `snipe hotspots`
-// joins this against file_churn (path-keyed) to rank complexity ×
-// change-frequency. Test files are excluded to match computeCycloRollups —
-// hotspots targets production risk. Paths are relativized to repo_root so
-// they line up with the churn and symbols tables.
-func computeFileCyclo(s *store.Store, symbols []index.Symbol) error {
+// computeFileComplexity aggregates per-symbol McCabe and cognitive complexity
+// into per-file rollups, stored under a synthetic "files" graph. `snipe
+// hotspots` joins these against file_churn (path-keyed) and fan-in to form the
+// unified risk view. Test files are excluded to match computeCycloRollups —
+// hotspots targets production risk. Paths are relativized to repo_root so they
+// line up with the churn and symbols tables.
+func computeFileComplexity(s *store.Store, symbols []index.Symbol) error {
 	root, err := s.GetMeta("repo_root")
 	if err != nil {
 		return fmt.Errorf("read repo_root: %w", err)
 	}
 	sum := make(map[string]float64)
 	maxv := make(map[string]float64)
+	cog := make(map[string]float64)
 	for i := range symbols {
 		sym := &symbols[i]
 		if sym.Kind != index.KindFunc && sym.Kind != index.KindMethod {
@@ -1095,6 +1099,7 @@ func computeFileCyclo(s *store.Store, symbols []index.Symbol) error {
 		if c > maxv[rel] {
 			maxv[rel] = c
 		}
+		cog[rel] += float64(sym.Cognitive)
 	}
 	if len(sum) == 0 {
 		return nil
@@ -1105,13 +1110,43 @@ func computeFileCyclo(s *store.Store, symbols []index.Symbol) error {
 	if err := s.WriteGraphMetrics("files", "cyclo_max", maxv); err != nil {
 		return fmt.Errorf("write file cyclo_max: %w", err)
 	}
+	if err := s.WriteGraphMetrics("files", "cognitive_sum", cog); err != nil {
+		return fmt.Errorf("write file cognitive_sum: %w", err)
+	}
+	return nil
+}
+
+// computeFileFanIn stores per-file blast-radius (distinct cross-file callers)
+// under the "files" graph for `snipe hotspots`. FileFanIn keys come straight
+// from symbols.file_path (absolute), so they are relativized here to line up
+// with the cyclo/churn keys. Empty graph → no-op.
+func computeFileFanIn(s *store.Store) error {
+	root, err := s.GetMeta("repo_root")
+	if err != nil {
+		return fmt.Errorf("read repo_root: %w", err)
+	}
+	raw, err := s.FileFanIn()
+	if err != nil {
+		return fmt.Errorf("compute file fan-in: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	fanIn := make(map[string]float64, len(raw))
+	for path, n := range raw {
+		fanIn[relToRoot(root, path)] = n
+	}
+	if err := s.WriteGraphMetrics("files", "fan_in", fanIn); err != nil {
+		return fmt.Errorf("write file fan_in: %w", err)
+	}
 	return nil
 }
 
 // relToRoot returns absPath relative to root, falling back to absPath when
-// root is empty or the paths share no base (mirrors store.toRelPath).
+// root is empty, absPath is already relative, or the paths share no base
+// (mirrors store.toRelPath).
 func relToRoot(root, absPath string) string {
-	if root == "" {
+	if root == "" || !filepath.IsAbs(absPath) {
 		return absPath
 	}
 	rel, err := filepath.Rel(root, absPath)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/mod/modfile"
 
 	"github.com/dkoosis/snipe/internal/embed"
+	"github.com/dkoosis/snipe/internal/gitchurn"
 	"github.com/dkoosis/snipe/internal/graphmetrics"
 	"github.com/dkoosis/snipe/internal/index"
 	"github.com/dkoosis/snipe/internal/output"
@@ -246,6 +247,9 @@ func runIndex(args []string) error {
 		}
 		if err := computeCallsGraphMetrics(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: calls-graph metrics computation failed: %v\n", err)
+		}
+		if err := computeChurn(s); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: git churn computation failed: %v\n", err)
 		}
 	}
 
@@ -1045,6 +1049,43 @@ func computeCycloRollups(s *store.Store, symbols []index.Symbol) error {
 	}
 	fmt.Fprintf(os.Stderr, "metrics: cyclo rollups computed for %d packages in %dms\n",
 		len(rollups), time.Since(t0).Milliseconds())
+	return nil
+}
+
+// computeChurn derives per-file git change-frequency (the temporal axis of
+// the Tornhill hotspot model) and replaces the file_churn table. It always
+// writes — even an empty result — so the table tracks HEAD: a repo that
+// loses git history, or a non-git checkout, ends with no stale churn. Git
+// absence is a clean no-op inside gitchurn.Walk, not an error.
+func computeChurn(s *store.Store) error {
+	root, err := s.GetMeta("repo_root")
+	if err != nil {
+		return fmt.Errorf("read repo_root: %w", err)
+	}
+	if root == "" {
+		return nil
+	}
+	t0 := time.Now()
+	rows, err := gitchurn.Walk(root)
+	if err != nil {
+		return fmt.Errorf("walk git history: %w", err)
+	}
+	churn := make([]store.FileChurn, len(rows))
+	for i, r := range rows {
+		churn[i] = store.FileChurn{
+			Path:        r.Path,
+			Commits:     r.Commits,
+			Authors:     r.Authors,
+			FirstSeen:   r.FirstSeen,
+			LastChanged: r.LastChanged,
+			Score:       r.Score,
+		}
+	}
+	if err := s.WriteFileChurn(churn); err != nil {
+		return fmt.Errorf("write file churn: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "metrics: git churn computed for %d files in %dms\n",
+		len(churn), time.Since(t0).Milliseconds())
 	return nil
 }
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1153,7 +1153,9 @@ func relToRoot(root, absPath string) string {
 	if err != nil {
 		return absPath
 	}
-	return rel
+	// Force forward slashes so these keys join against gitchurn.Walk paths
+	// (git emits "/"-separated paths even on Windows, where Rel uses "\").
+	return filepath.ToSlash(rel)
 }
 
 // computeChurn derives per-file git change-frequency (the temporal axis of

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -248,6 +248,9 @@ func runIndex(args []string) error {
 		if err := computeCallsGraphMetrics(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: calls-graph metrics computation failed: %v\n", err)
 		}
+		if err := computeFileCyclo(s, symbols); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: file cyclo computation failed: %v\n", err)
+		}
 		if err := computeChurn(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: git churn computation failed: %v\n", err)
 		}
@@ -1050,6 +1053,59 @@ func computeCycloRollups(s *store.Store, symbols []index.Symbol) error {
 	fmt.Fprintf(os.Stderr, "metrics: cyclo rollups computed for %d packages in %dms\n",
 		len(rollups), time.Since(t0).Milliseconds())
 	return nil
+}
+
+// computeFileCyclo aggregates per-symbol McCabe complexity into per-file
+// sum and max, stored under a synthetic "files" graph. `snipe hotspots`
+// joins this against file_churn (path-keyed) to rank complexity ×
+// change-frequency. Test files are excluded to match computeCycloRollups —
+// hotspots targets production risk. Paths are relativized to repo_root so
+// they line up with the churn and symbols tables.
+func computeFileCyclo(s *store.Store, symbols []index.Symbol) error {
+	root, err := s.GetMeta("repo_root")
+	if err != nil {
+		return fmt.Errorf("read repo_root: %w", err)
+	}
+	sum := make(map[string]float64)
+	maxv := make(map[string]float64)
+	for i := range symbols {
+		sym := &symbols[i]
+		if sym.Kind != index.KindFunc && sym.Kind != index.KindMethod {
+			continue
+		}
+		if strings.HasSuffix(sym.FilePath, "_test.go") {
+			continue
+		}
+		rel := relToRoot(root, sym.FilePath)
+		c := float64(sym.Cyclo)
+		sum[rel] += c
+		if c > maxv[rel] {
+			maxv[rel] = c
+		}
+	}
+	if len(sum) == 0 {
+		return nil
+	}
+	if err := s.WriteGraphMetrics("files", "cyclo_sum", sum); err != nil {
+		return fmt.Errorf("write file cyclo_sum: %w", err)
+	}
+	if err := s.WriteGraphMetrics("files", "cyclo_max", maxv); err != nil {
+		return fmt.Errorf("write file cyclo_max: %w", err)
+	}
+	return nil
+}
+
+// relToRoot returns absPath relative to root, falling back to absPath when
+// root is empty or the paths share no base (mirrors store.toRelPath).
+func relToRoot(root, absPath string) string {
+	if root == "" {
+		return absPath
+	}
+	rel, err := filepath.Rel(root, absPath)
+	if err != nil {
+		return absPath
+	}
+	return rel
 }
 
 // computeChurn derives per-file git change-frequency (the temporal axis of

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -245,6 +245,9 @@ func runIndex(args []string) error {
 		if err := computeCycloRollups(s, symbols); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: cyclo rollup computation failed: %v\n", err)
 		}
+		if err := computeCognitiveRollups(s, symbols); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: cognitive rollup computation failed: %v\n", err)
+		}
 		if err := computeCallsGraphMetrics(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: calls-graph metrics computation failed: %v\n", err)
 		}
@@ -1022,17 +1025,27 @@ func computeLCOM4(s *store.Store) error {
 }
 
 // computeCycloRollups persists per-package McCabe cyclomatic-complexity
-// rollups (sum, p95, max) computed in-memory from already-extracted symbols.
-// Three metric kinds (cyclo_sum, cyclo_p95, cyclo_max) are stored under the
-// imports graph; `snipe metrics --kind=cyclo` joins them at read time.
-//
+// rollups (sum, p95, max) under the imports graph as cyclo_sum/p95/max;
+// `snipe metrics --kind=cyclo` joins them at read time.
 // Hot-package threshold: p95 > 10 OR max > 20.
 func computeCycloRollups(s *store.Store, symbols []index.Symbol) error {
-	t0 := time.Now()
-	rollups := index.PackageCycloRollups(symbols)
+	return writeComplexityRollups(s, "cyclo", index.PackageCycloRollups(symbols))
+}
+
+// computeCognitiveRollups is the cognitive-complexity counterpart, stored as
+// cognitive_sum/p95/max for `snipe metrics --kind=cognitive`.
+func computeCognitiveRollups(s *store.Store, symbols []index.Symbol) error {
+	return writeComplexityRollups(s, "cognitive", index.PackageCognitiveRollups(symbols))
+}
+
+// writeComplexityRollups persists a per-package rollup map under the imports
+// graph as {prefix}_sum/{prefix}_p95/{prefix}_max in one place, so cyclo and
+// cognitive share the storage shape.
+func writeComplexityRollups(s *store.Store, prefix string, rollups map[string]index.CycloRollup) error {
 	if len(rollups) == 0 {
 		return nil
 	}
+	t0 := time.Now()
 	sum := make(map[string]float64, len(rollups))
 	p95 := make(map[string]float64, len(rollups))
 	maxv := make(map[string]float64, len(rollups))
@@ -1041,17 +1054,17 @@ func computeCycloRollups(s *store.Store, symbols []index.Symbol) error {
 		p95[pkg] = r.P95
 		maxv[pkg] = float64(r.Max)
 	}
-	if err := s.WriteGraphMetrics("imports", "cyclo_sum", sum); err != nil {
-		return fmt.Errorf("write cyclo_sum: %w", err)
+	if err := s.WriteGraphMetrics("imports", prefix+"_sum", sum); err != nil {
+		return fmt.Errorf("write %s_sum: %w", prefix, err)
 	}
-	if err := s.WriteGraphMetrics("imports", "cyclo_p95", p95); err != nil {
-		return fmt.Errorf("write cyclo_p95: %w", err)
+	if err := s.WriteGraphMetrics("imports", prefix+"_p95", p95); err != nil {
+		return fmt.Errorf("write %s_p95: %w", prefix, err)
 	}
-	if err := s.WriteGraphMetrics("imports", "cyclo_max", maxv); err != nil {
-		return fmt.Errorf("write cyclo_max: %w", err)
+	if err := s.WriteGraphMetrics("imports", prefix+"_max", maxv); err != nil {
+		return fmt.Errorf("write %s_max: %w", prefix, err)
 	}
-	fmt.Fprintf(os.Stderr, "metrics: cyclo rollups computed for %d packages in %dms\n",
-		len(rollups), time.Since(t0).Milliseconds())
+	fmt.Fprintf(os.Stderr, "metrics: %s rollups computed for %d packages in %dms\n",
+		prefix, len(rollups), time.Since(t0).Milliseconds())
 	return nil
 }
 

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -49,7 +49,7 @@ func runMetrics() error {
 	case "pagerank", "betweenness", "hits", "hub", "authority",
 		cmdKindCycles, cmdKindTopo, "degree", "in_degree", "out_degree", "eigenvector",
 		"ca", "ce", cmdKindCoupling, "instability", "abstractness", cmdKindDistance, kindLCOM4,
-		cmdKindCyclo, "cyclo_sum", "cyclo_p95", "cyclo_max", kindChurn:
+		cmdKindCyclo, "cyclo_sum", "cyclo_p95", "cyclo_max", cmdKindCognitive, kindChurn:
 		// ok
 	default:
 		return w.WriteError(cmdNameMetrics, &output.Error{
@@ -95,6 +95,11 @@ func runMetrics() error {
 	// Cyclo joins per-package sum/p95/max into a hot-package table.
 	if metricsKind == cmdKindCyclo {
 		return runCycloMetrics(s, dir, start)
+	}
+
+	// Cognitive (SonarSource) shares the rollup table shape with cyclo.
+	if metricsKind == cmdKindCognitive {
+		return runCognitiveMetrics(s, dir, start)
 	}
 
 	// Churn reads git change-frequency from file_churn (not the graph).
@@ -409,21 +414,32 @@ type cycloRow struct {
 	Max int     `json:"max"`
 }
 
+// runCycloMetrics and runCognitiveMetrics share one rollup renderer; they
+// differ only in the stored metric prefix/label and the hot-package
+// thresholds (cyclo: p95>10/max>20; cognitive: SonarSource-leaning p95>15/max>30).
 func runCycloMetrics(s *store.Store, dir string, startedAt time.Time) error {
-	sumRows, err := s.ReadTopN(cmdNameImports, "cyclo_sum", 0)
+	return runComplexityRollupMetrics(s, dir, startedAt, cmdKindCyclo, 10, 20)
+}
+
+func runCognitiveMetrics(s *store.Store, dir string, startedAt time.Time) error {
+	return runComplexityRollupMetrics(s, dir, startedAt, cmdKindCognitive, 15, 30)
+}
+
+func runComplexityRollupMetrics(s *store.Store, dir string, startedAt time.Time, label string, hotP95 float64, hotMax int) error {
+	sumRows, err := s.ReadTopN(cmdNameImports, label+"_sum", 0)
 	if err != nil {
-		return fmt.Errorf("read cyclo_sum: %w", err)
+		return fmt.Errorf("read %s_sum: %w", label, err)
 	}
-	p95Rows, err := s.ReadTopN(cmdNameImports, "cyclo_p95", 0)
+	p95Rows, err := s.ReadTopN(cmdNameImports, label+"_p95", 0)
 	if err != nil {
-		return fmt.Errorf("read cyclo_p95: %w", err)
+		return fmt.Errorf("read %s_p95: %w", label, err)
 	}
-	maxRows, err := s.ReadTopN(cmdNameImports, "cyclo_max", 0)
+	maxRows, err := s.ReadTopN(cmdNameImports, label+"_max", 0)
 	if err != nil {
-		return fmt.Errorf("read cyclo_max: %w", err)
+		return fmt.Errorf("read %s_max: %w", label, err)
 	}
 	if len(sumRows) == 0 && len(p95Rows) == 0 && len(maxRows) == 0 {
-		_, werr := os.Stdout.WriteString("imports graph · cyclo · (no rows — run `snipe index` to populate)\n")
+		_, werr := fmt.Fprintf(os.Stdout, "imports graph · %s · (no rows — run `snipe index` to populate)\n", label)
 		return werr
 	}
 
@@ -476,7 +492,7 @@ func runCycloMetrics(s *store.Store, dir string, startedAt time.Time) error {
 			Results:  rows,
 			Meta: output.Meta{
 				Command:  cmdNameMetrics,
-				Query:    map[string]string{cmdKindGraph: cmdNameImports, jsonKeyKind: cmdKindCyclo, flagPkg: metricsPkg},
+				Query:    map[string]string{cmdKindGraph: cmdNameImports, jsonKeyKind: label, flagPkg: metricsPkg},
 				RepoRoot: dir,
 				Ms:       time.Since(startedAt).Milliseconds(),
 				Total:    len(rows),
@@ -488,11 +504,11 @@ func runCycloMetrics(s *store.Store, dir string, startedAt time.Time) error {
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "imports graph · cyclo · %d packages (p95 > 10 OR max > 20 = hot-package flag)\n", len(rows))
+	fmt.Fprintf(&b, "imports graph · %s · %d packages (p95 > %g OR max > %d = hot-package flag)\n", label, len(rows), hotP95, hotMax)
 	fmt.Fprintf(&b, "  %5s %5s %5s  %s\n", "sum", "p95", "max", flagPkg)
 	for _, r := range rows {
 		flag := "  "
-		if r.P95 > 10 || r.Max > 20 {
+		if r.P95 > hotP95 || r.Max > hotMax {
 			flag = "! "
 		}
 		fmt.Fprintf(&b, "%s%5d %5.1f %5d  %s\n", flag, r.Sum, r.P95, r.Max, r.Pkg)

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -49,7 +49,7 @@ func runMetrics() error {
 	case "pagerank", "betweenness", "hits", "hub", "authority",
 		cmdKindCycles, cmdKindTopo, "degree", "in_degree", "out_degree", "eigenvector",
 		"ca", "ce", cmdKindCoupling, "instability", "abstractness", cmdKindDistance, kindLCOM4,
-		cmdKindCyclo, "cyclo_sum", "cyclo_p95", "cyclo_max":
+		cmdKindCyclo, "cyclo_sum", "cyclo_p95", "cyclo_max", kindChurn:
 		// ok
 	default:
 		return w.WriteError(cmdNameMetrics, &output.Error{
@@ -95,6 +95,11 @@ func runMetrics() error {
 	// Cyclo joins per-package sum/p95/max into a hot-package table.
 	if metricsKind == cmdKindCyclo {
 		return runCycloMetrics(s, dir, start)
+	}
+
+	// Churn reads git change-frequency from file_churn (not the graph).
+	if metricsKind == kindChurn {
+		return runChurnMetrics(s, dir, start)
 	}
 
 	// --pkg implies "show this package only" — load all rows, then filter.

--- a/cmd/metrics_churn.go
+++ b/cmd/metrics_churn.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+const kindChurn = "churn"
+
+// runChurnMetrics renders the git change-frequency table populated by
+// `snipe index` (see internal/gitchurn). Files rank by commit count — the
+// CodeScene "revisions" measure, and the temporal axis of the hotspot model
+// (Tornhill, Your Code as a Crime Scene; Nagappan & Ball, ICSE 2005). An
+// empty table means a non-git checkout or an un-indexed repo, not an error.
+func runChurnMetrics(s *store.Store, dir string, startedAt time.Time) error {
+	rows, err := s.ReadFileChurnTopN(0) // read all; filter/truncate below
+	if err != nil {
+		return fmt.Errorf("read file churn: %w", err)
+	}
+	if metricsPkg != "" {
+		filtered := rows[:0]
+		for _, r := range rows {
+			if strings.Contains(r.Path, metricsPkg) {
+				filtered = append(filtered, r)
+			}
+		}
+		rows = filtered
+	}
+	if metricsTopN > 0 && len(rows) > metricsTopN {
+		rows = rows[:metricsTopN]
+	}
+
+	if GetOutputFormat() == output.OutputJSON {
+		resp := output.Response[store.FileChurn]{
+			Protocol: output.ProtocolVersion,
+			Ok:       true,
+			Results:  rows,
+			Meta: output.Meta{
+				Command:  cmdNameMetrics,
+				Query:    map[string]string{jsonKeyKind: kindChurn, flagPkg: metricsPkg},
+				RepoRoot: dir,
+				Ms:       time.Since(startedAt).Milliseconds(),
+				Total:    len(rows),
+			},
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp)
+	}
+
+	var b strings.Builder
+	if len(rows) == 0 {
+		b.WriteString("git history · churn · (no rows — not a git repo, or run `snipe index` to populate)\n")
+		_, err = os.Stdout.WriteString(b.String())
+		return err
+	}
+	fmt.Fprintf(&b, "git history · churn · %d files (commits = revisions; authors = distinct committers / bus factor)\n", len(rows))
+	fmt.Fprintf(&b, "  %7s %7s  %-12s  %s\n", "commits", "authors", "last-changed", "path")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "  %7d %7d  %-12s  %s\n", r.Commits, r.Authors, r.LastChanged, r.Path)
+	}
+	_, err = os.Stdout.WriteString(b.String())
+	return err
+}

--- a/cmd/sensitive.go
+++ b/cmd/sensitive.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/sensitive"
+)
+
+const cmdNameSensitive = "sensitive"
+
+type sensitiveRow struct {
+	Path  string           `json:"path"`
+	Zones []sensitive.Zone `json:"zones"`
+}
+
+// runSensitive lists indexed Go files that fall in a security-sensitive zone
+// (auth, crypto, migration, secret, payment) — code that is always
+// significant regardless of size or churn (Tornhill). Zones come from
+// built-in heuristics plus optional .snipe/sensitive globs.
+func runSensitive() error {
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+	s, dir, err := OpenStore(w, cmdNameSensitive)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	start := time.Now()
+
+	files, err := s.GetAllFiles()
+	if err != nil {
+		return w.WriteError(cmdNameSensitive, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	cls := sensitive.Load(dir)
+
+	var rows []sensitiveRow
+	for path := range files {
+		if !strings.HasSuffix(path, ".go") {
+			continue
+		}
+		rel := path
+		if r, err := filepath.Rel(dir, path); err == nil {
+			rel = r
+		}
+		if z := cls.Zones(rel); len(z) > 0 {
+			rows = append(rows, sensitiveRow{Path: rel, Zones: z})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Path < rows[j].Path })
+
+	if GetOutputFormat() == output.OutputJSON {
+		resp := output.Response[sensitiveRow]{
+			Protocol: output.ProtocolVersion,
+			Ok:       true,
+			Results:  rows,
+			Meta: output.Meta{
+				Command:  cmdNameSensitive,
+				RepoRoot: dir,
+				Ms:       time.Since(start).Milliseconds(),
+				Total:    len(rows),
+			},
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "sensitive zones · %d files (always-significant code: auth/crypto/migration/secret/payment)\n", len(rows))
+	if len(rows) == 0 {
+		b.WriteString("  (none detected — built-in heuristics + optional .snipe/sensitive globs)\n")
+	}
+	for _, r := range rows {
+		fmt.Fprintf(&b, "  %-28s  %s\n", zonesString(r.Zones), r.Path)
+	}
+	_, err = os.Stdout.WriteString(b.String())
+	return err
+}
+
+func zonesString(zones []sensitive.Zone) string {
+	parts := make([]string, len(zones))
+	for i, z := range zones {
+		parts[i] = string(z)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}

--- a/cmd/testdata/help/hotspots.golden
+++ b/cmd/testdata/help/hotspots.golden
@@ -1,0 +1,25 @@
+Usage: snipe hotspots [flags]
+
+Rank files by complexity × git change-frequency (Tornhill hotspot model)
+
+Flags:
+  -h, --help                Show context-sensitive help.
+      --limit=10            Cap results returned (applied after --select)
+      --offset=0            Pagination offset
+      --context=2           Context lines around match
+      --no-body             Exclude function body
+      --no-siblings         Exclude sibling declarations
+      --signature-only      Return only signature (no body, no context)
+      --max-tokens=0        Token budget (0 = unlimited)
+      --format="concise"    concise (LLM default) | detailed | summary | json
+                            (stable, for tooling) | human (TTY)
+      --kg-hints            Include Orca KG hints
+      --suggestions         Include next-step suggestions in Claude output
+      --timeout=DURATION    Timeout for command (e.g., 30s, 5m)
+      --select="all"        Pick top candidates by score: all, best, top3,
+                            top5 (applied before --limit)
+
+      --top=20              Top-N files to print
+      --pkg=STRING          Filter to paths containing this substring (e.g.
+                            internal/store)
+      --file=STRING         Filter to paths containing this substring

--- a/cmd/testdata/help/metrics.golden
+++ b/cmd/testdata/help/metrics.golden
@@ -23,7 +23,7 @@ Flags:
       --top=20              Top-N rows to print
       --kind="pagerank"     Metric kind (or comma-separated
                             list for a merged table):
-                            pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|churn|usage
+                            pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|cognitive|churn|usage
       --graph="imports"     Graph kind ('imports' or 'calls')
       --pkg=STRING          Filter to a single package (suffix-matches package
                             import path)

--- a/cmd/testdata/help/metrics.golden
+++ b/cmd/testdata/help/metrics.golden
@@ -23,7 +23,7 @@ Flags:
       --top=20              Top-N rows to print
       --kind="pagerank"     Metric kind (or comma-separated
                             list for a merged table):
-                            pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|usage
+                            pagerank|hub|authority|in_degree|out_degree|eigenvector|betweenness|cycles|topo|ca|ce|coupling|instability|abstractness|distance|lcom4|cyclo|churn|usage
       --graph="imports"     Graph kind ('imports' or 'calls')
       --pkg=STRING          Filter to a single package (suffix-matches package
                             import path)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -126,6 +126,10 @@ Graph & Structure:
   hotspots [flags]
     Rank files by complexity × git change-frequency (Tornhill hotspot model)
 
+  sensitive [flags]
+    List files in security-sensitive zones
+    (auth/crypto/migration/secret/payment)
+
   diagram arch [flags]
     Package import graph trimmed to the top-N by PageRank, grouped by layer
 

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -123,6 +123,9 @@ Graph & Structure:
     Show graph metrics (PageRank, coupling, HITS, etc.) over the import or call
     graph
 
+  hotspots [flags]
+    Rank files by complexity × git change-frequency (Tornhill hotspot model)
+
   diagram arch [flags]
     Package import graph trimmed to the top-N by PageRank, grouped by layer
 

--- a/cmd/testdata/help/sensitive.golden
+++ b/cmd/testdata/help/sensitive.golden
@@ -1,0 +1,20 @@
+Usage: snipe sensitive [flags]
+
+List files in security-sensitive zones (auth/crypto/migration/secret/payment)
+
+Flags:
+  -h, --help                Show context-sensitive help.
+      --limit=10            Cap results returned (applied after --select)
+      --offset=0            Pagination offset
+      --context=2           Context lines around match
+      --no-body             Exclude function body
+      --no-siblings         Exclude sibling declarations
+      --signature-only      Return only signature (no body, no context)
+      --max-tokens=0        Token budget (0 = unlimited)
+      --format="concise"    concise (LLM default) | detailed | summary | json
+                            (stable, for tooling) | human (TTY)
+      --kg-hints            Include Orca KG hints
+      --suggestions         Include next-step suggestions in Claude output
+      --timeout=DURATION    Timeout for command (e.g., 30s, 5m)
+      --select="all"        Pick top candidates by score: all, best, top3,
+                            top5 (applied before --limit)

--- a/internal/gitchurn/gitchurn.go
+++ b/internal/gitchurn/gitchurn.go
@@ -1,0 +1,183 @@
+// Package gitchurn derives per-file change-frequency from git history.
+//
+// Change-frequency is the temporal axis of code risk. Nagappan & Ball
+// ("Use of Relative Code Churn Measures to Predict System Defect Density",
+// ICSE 2005) showed that how often a file changes predicts its defect
+// density better than size or complexity alone. Tornhill's hotspot model
+// (Your Code as a Crime Scene, 2015; CodeScene) pairs this churn signal
+// with complexity to rank risk — see the `snipe hotspots` command.
+//
+// The unit of change-frequency here is the number of non-merge commits that
+// touched a file (CodeScene calls these "revisions"). The package is a thin,
+// dependency-free wrapper over `git log`; it degrades to a clean no-op
+// (nil, nil) outside a git repository, when git is absent, or on an unborn
+// branch with no commits.
+package gitchurn
+
+import (
+	"bufio"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// halfLifeDays sets the exponential decay for the recency-weighted Score:
+// a commit this old contributes half the weight of one made at the
+// reference (newest) commit. Tornhill weights recent changes higher because
+// stale churn is paid-down risk; 180 days is a pragmatic default.
+const halfLifeDays = 180.0
+
+// commitSentinel (SOH) prefixes each commit-header line in the git log
+// stream so it can never collide with a file path. It is followed by the
+// author date and author name; subsequent non-empty lines are file paths.
+const commitSentinel = "\x01"
+
+// FileChurn is the git change-frequency record for one file, keyed by a
+// repo-relative path so it joins directly against the symbols table.
+type FileChurn struct {
+	Path        string  // repo-relative path (matches symbols.file_path)
+	Commits     int     // non-merge commits touching the file (CodeScene revisions)
+	Authors     int     // distinct commit authors (bus-factor / knowledge-map signal)
+	FirstSeen   string  // YYYY-MM-DD of the earliest touching commit
+	LastChanged string  // YYYY-MM-DD of the latest touching commit
+	Score       float64 // recency-weighted churn (see halfLifeDays)
+}
+
+// Walk returns the change-frequency of every tracked *.go file in repoRoot,
+// sorted by commit count descending (ties broken by path). It returns
+// (nil, nil) — never an error — when git is unavailable, repoRoot is not a
+// work tree, or history is empty: a missing temporal axis is a clean no-op,
+// not a failure, per the git-when-available constraint.
+func Walk(repoRoot string) ([]FileChurn, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, nil //nolint:nilerr // git absent → no churn, not an error
+	}
+	// Confirm a work tree before logging so "not a repo" stays a no-op
+	// rather than surfacing git's error text.
+	if err := exec.Command("git", "-C", repoRoot, "rev-parse", "--is-inside-work-tree").Run(); err != nil {
+		return nil, nil //nolint:nilerr // not a git work tree → no churn
+	}
+
+	// --no-renames keeps paths literal (no "{old => new}" arrows to parse);
+	// the "-- *.go" pathspec restricts both the commits and the listed files
+	// to Go sources, which is all snipe indexes.
+	cmd := exec.Command("git", "-C", repoRoot, "log",
+		"--no-merges", "--no-renames",
+		"--pretty=tformat:"+commitSentinel+"%aI\t%aN",
+		"--name-only", "--", "*.go")
+	out, err := cmd.Output()
+	if err != nil {
+		// Most likely an unborn branch (no commits yet). Treat as empty.
+		return nil, nil //nolint:nilerr // empty history → no churn
+	}
+
+	// Keep only files that still exist in the work tree and are first-party.
+	// History includes long-deleted paths (misleading as hotspots, and they
+	// never join the current symbols table), and vendor/ holds third-party
+	// code snipe doesn't index — churn there isn't actionable.
+	tracked := trackedGoFiles(repoRoot)
+	rows := parseLog(string(out))
+	live := rows[:0]
+	for _, r := range rows {
+		if strings.HasPrefix(r.Path, "vendor/") {
+			continue
+		}
+		if tracked != nil {
+			if _, ok := tracked[r.Path]; !ok {
+				continue
+			}
+		}
+		live = append(live, r)
+	}
+	return live, nil
+}
+
+// trackedGoFiles returns the set of currently-tracked *.go paths, or nil if
+// the listing fails (in which case the caller keeps the unfiltered history).
+func trackedGoFiles(repoRoot string) map[string]struct{} {
+	out, err := exec.Command("git", "-C", repoRoot, "ls-files", "--", "*.go").Output()
+	if err != nil {
+		return nil
+	}
+	set := make(map[string]struct{})
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	for sc.Scan() {
+		if p := sc.Text(); p != "" {
+			set[p] = struct{}{}
+		}
+	}
+	return set
+}
+
+// parseLog turns the `git log --name-only` stream into per-file churn.
+// The stream is newest-commit-first, so the first commit's date is the
+// recency reference (weight 1.0) and decay grows with age.
+func parseLog(stream string) []FileChurn {
+	type acc struct {
+		commits     int
+		authors     map[string]struct{}
+		first, last time.Time
+		score       float64
+	}
+	byPath := make(map[string]*acc)
+
+	var (
+		curDate time.Time
+		curAuth string
+		haveCur bool
+		refDate time.Time // newest commit date, set from the first header
+	)
+
+	sc := bufio.NewScanner(strings.NewReader(stream))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, commitSentinel) {
+			rest := line[len(commitSentinel):]
+			iso, author, _ := strings.Cut(rest, "\t")
+			t, err := time.Parse(time.RFC3339, iso)
+			if err != nil {
+				haveCur = false
+				continue
+			}
+			curDate, curAuth, haveCur = t, author, true
+			if refDate.IsZero() {
+				refDate = t
+			}
+			continue
+		}
+		if line == "" || !haveCur {
+			continue
+		}
+		path := line
+		a := byPath[path]
+		if a == nil {
+			a = &acc{authors: make(map[string]struct{}), first: curDate, last: curDate}
+			byPath[path] = a
+		}
+		a.commits++
+		a.authors[curAuth] = struct{}{}
+		if curDate.Before(a.first) {
+			a.first = curDate
+		}
+		if curDate.After(a.last) {
+			a.last = curDate
+		}
+		ageDays := refDate.Sub(curDate).Hours() / 24.0
+		a.score += pow2(-ageDays / halfLifeDays)
+	}
+
+	out := make([]FileChurn, 0, len(byPath))
+	for p, a := range byPath {
+		out = append(out, FileChurn{
+			Path:        p,
+			Commits:     a.commits,
+			Authors:     len(a.authors),
+			FirstSeen:   a.first.Format("2006-01-02"),
+			LastChanged: a.last.Format("2006-01-02"),
+			Score:       a.score,
+		})
+	}
+	sortByCommits(out)
+	return out
+}

--- a/internal/gitchurn/gitchurn_test.go
+++ b/internal/gitchurn/gitchurn_test.go
@@ -1,0 +1,222 @@
+package gitchurn
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitRepo builds a throwaway repository in a temp dir and returns its root.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(env []string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), env...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run(nil, "init", "-q")
+	run(nil, "config", "user.email", "test@example.com")
+	run(nil, "config", "user.name", "Tester")
+	return dir
+}
+
+// commit writes files then commits them with a fixed date and author.
+func commit(t *testing.T, dir, date, author string, files map[string]string) {
+	t.Helper()
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add := exec.Command("git", "add", "-A")
+	add.Dir = dir
+	if out, err := add.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	env := []string{
+		"GIT_AUTHOR_DATE=" + date,
+		"GIT_COMMITTER_DATE=" + date,
+		"GIT_AUTHOR_NAME=" + author,
+		"GIT_AUTHOR_EMAIL=" + author + "@example.com",
+		"GIT_COMMITTER_NAME=" + author,
+		"GIT_COMMITTER_EMAIL=" + author + "@example.com",
+	}
+	c := exec.Command("git", "commit", "-q", "-m", "c")
+	c.Dir = dir
+	c.Env = append(os.Environ(), env...)
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+}
+
+func byPath(rows []FileChurn) map[string]FileChurn {
+	m := make(map[string]FileChurn, len(rows))
+	for _, r := range rows {
+		m[r.Path] = r
+	}
+	return m
+}
+
+func TestWalkCountsCommitsAndAuthors(t *testing.T) {
+	dir := gitRepo(t)
+	// hot.go touched by 3 commits across 2 authors; cold.go once.
+	commit(t, dir, "2026-01-01T00:00:00Z", "alice", map[string]string{
+		"hot.go":  "package p\nvar A int\n",
+		"cold.go": "package p\nvar C int\n",
+	})
+	commit(t, dir, "2026-02-01T00:00:00Z", "bob", map[string]string{
+		"hot.go": "package p\nvar A, B int\n",
+	})
+	commit(t, dir, "2026-03-01T00:00:00Z", "alice", map[string]string{
+		"hot.go": "package p\nvar A, B, D int\n",
+	})
+
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	m := byPath(rows)
+
+	hot, ok := m["hot.go"]
+	if !ok {
+		t.Fatalf("hot.go missing from %+v", rows)
+	}
+	if hot.Commits != 3 {
+		t.Errorf("hot.go commits = %d, want 3", hot.Commits)
+	}
+	if hot.Authors != 2 {
+		t.Errorf("hot.go authors = %d, want 2 (alice, bob)", hot.Authors)
+	}
+	if hot.FirstSeen != "2026-01-01" || hot.LastChanged != "2026-03-01" {
+		t.Errorf("hot.go span = %s..%s, want 2026-01-01..2026-03-01", hot.FirstSeen, hot.LastChanged)
+	}
+
+	cold := m["cold.go"]
+	if cold.Commits != 1 {
+		t.Errorf("cold.go commits = %d, want 1", cold.Commits)
+	}
+
+	// Sorted by commits desc → hot.go first.
+	if rows[0].Path != "hot.go" {
+		t.Errorf("rows[0] = %s, want hot.go (highest churn)", rows[0].Path)
+	}
+}
+
+func TestWalkIgnoresNonGoAndMerges(t *testing.T) {
+	dir := gitRepo(t)
+	commit(t, dir, "2026-01-01T00:00:00Z", "alice", map[string]string{
+		"keep.go":   "package p\n",
+		"README.md": "# doc\n",
+		"go.mod":    "module x\n",
+	})
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	m := byPath(rows)
+	if _, ok := m["keep.go"]; !ok {
+		t.Errorf("keep.go should be tracked, got %+v", rows)
+	}
+	if _, ok := m["README.md"]; ok {
+		t.Errorf("non-Go README.md should be excluded")
+	}
+	if _, ok := m["go.mod"]; ok {
+		t.Errorf("non-Go go.mod should be excluded")
+	}
+}
+
+func TestWalkRecencyWeighting(t *testing.T) {
+	dir := gitRepo(t)
+	// Newer file gets full weight; older file decays below it despite equal commits.
+	commit(t, dir, "2026-06-01T00:00:00Z", "alice", map[string]string{"new.go": "package p\n"})
+	commit(t, dir, "2020-01-01T00:00:00Z", "alice", map[string]string{"old.go": "package p\n"})
+	// Reorder so newest commit (new.go) is the recency reference.
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	m := byPath(rows)
+	if m["new.go"].Score <= m["old.go"].Score {
+		t.Errorf("recent file should outscore stale file: new=%.4f old=%.4f",
+			m["new.go"].Score, m["old.go"].Score)
+	}
+}
+
+func TestWalkExcludesDeletedFiles(t *testing.T) {
+	dir := gitRepo(t)
+	commit(t, dir, "2026-01-01T00:00:00Z", "alice", map[string]string{
+		"gone.go": "package p\n",
+		"live.go": "package p\n",
+	})
+	// Delete gone.go in a later commit; its history remains but it is no
+	// longer tracked, so it must not appear as a hotspot.
+	if err := os.Remove(filepath.Join(dir, "gone.go")); err != nil {
+		t.Fatal(err)
+	}
+	commit(t, dir, "2026-02-01T00:00:00Z", "alice", map[string]string{
+		"live.go": "package p\nvar X int\n",
+	})
+
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	m := byPath(rows)
+	if _, ok := m["gone.go"]; ok {
+		t.Errorf("deleted gone.go should be excluded, got %+v", rows)
+	}
+	if _, ok := m["live.go"]; !ok {
+		t.Errorf("live.go should remain, got %+v", rows)
+	}
+}
+
+func TestWalkExcludesVendor(t *testing.T) {
+	dir := gitRepo(t)
+	commit(t, dir, "2026-01-01T00:00:00Z", "alice", map[string]string{
+		"main.go":                 "package p\n",
+		"vendor/x.com/dep/dep.go": "package dep\n",
+	})
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	m := byPath(rows)
+	if _, ok := m["main.go"]; !ok {
+		t.Errorf("main.go should be tracked, got %+v", rows)
+	}
+	if _, ok := m["vendor/x.com/dep/dep.go"]; ok {
+		t.Errorf("vendored file should be excluded, got %+v", rows)
+	}
+}
+
+func TestWalkNonGitDirIsNoOp(t *testing.T) {
+	dir := t.TempDir() // no git init
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("non-git dir should be a clean no-op, got err: %v", err)
+	}
+	if rows != nil {
+		t.Errorf("non-git dir should yield nil rows, got %+v", rows)
+	}
+}
+
+func TestWalkEmptyRepoIsNoOp(t *testing.T) {
+	dir := gitRepo(t) // init but no commits (unborn branch)
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("empty repo should be a clean no-op, got err: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("empty repo should yield no churn, got %+v", rows)
+	}
+}

--- a/internal/gitchurn/util.go
+++ b/internal/gitchurn/util.go
@@ -1,0 +1,20 @@
+package gitchurn
+
+import (
+	"math"
+	"sort"
+)
+
+// pow2 returns 2**x (x may be negative/fractional) — the recency decay term.
+func pow2(x float64) float64 { return math.Exp2(x) }
+
+// sortByCommits orders churn rows by commit count descending, breaking ties
+// by path ascending so output is deterministic.
+func sortByCommits(rows []FileChurn) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Commits != rows[j].Commits {
+			return rows[i].Commits > rows[j].Commits
+		}
+		return rows[i].Path < rows[j].Path
+	})
+}

--- a/internal/index/cognitive.go
+++ b/internal/index/cognitive.go
@@ -1,0 +1,163 @@
+package index
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// computeCognitive returns the SonarSource cognitive complexity of a function
+// body (Campbell, "Cognitive Complexity: A new way of measuring
+// understandability", SonarSource 2017).
+//
+// Where McCabe's cyclomatic complexity counts independent paths, cognitive
+// complexity estimates how hard code is to *understand*: it penalizes nesting
+// and counts a switch once (not once per case), so a flat dispatch scores low
+// while deeply nested control flow scores high. It complements, not replaces,
+// cyclo. Body=nil (interface methods, external decls) → 0.
+//
+// Three rules from the white paper:
+//
+//	B1 — +1 for each break in linear flow: if / else-if / else, switch,
+//	     for / range, select, labeled break|continue|goto, and each sequence
+//	     of like binary boolean operators (&& / ||).
+//	B2 — +1 extra for each level of nesting around a B1 control structure.
+//	B3 — no increment for shorthand: the bare `else`/`else if` take only the
+//	     flat B1 increment (no nesting penalty), and a nested func literal adds
+//	     a nesting level but no increment of its own.
+func computeCognitive(body *ast.BlockStmt) int {
+	if body == nil {
+		return 0
+	}
+	c := &cognitiveCounter{}
+	c.walkStmts(body.List, 0)
+	return c.total
+}
+
+type cognitiveCounter struct{ total int }
+
+func (c *cognitiveCounter) walkStmts(stmts []ast.Stmt, nesting int) {
+	for _, s := range stmts {
+		c.walkStmt(s, nesting)
+	}
+}
+
+func (c *cognitiveCounter) walkStmt(stmt ast.Stmt, nesting int) {
+	switch s := stmt.(type) {
+	case *ast.IfStmt:
+		c.total += 1 + nesting // B1 + B2
+		if s.Init != nil {
+			c.walkStmt(s.Init, nesting)
+		}
+		c.walkExpr(s.Cond, nesting)
+		c.walkStmts(s.Body.List, nesting+1)
+		c.walkElse(s.Else, nesting)
+	case *ast.ForStmt:
+		c.total += 1 + nesting
+		if s.Cond != nil {
+			c.walkExpr(s.Cond, nesting)
+		}
+		c.walkStmts(s.Body.List, nesting+1)
+	case *ast.RangeStmt:
+		c.total += 1 + nesting
+		c.walkStmts(s.Body.List, nesting+1)
+	case *ast.SwitchStmt:
+		c.total += 1 + nesting // counted once, regardless of case count
+		if s.Tag != nil {
+			c.walkExpr(s.Tag, nesting)
+		}
+		c.walkStmts(s.Body.List, nesting+1)
+	case *ast.TypeSwitchStmt:
+		c.total += 1 + nesting
+		c.walkStmts(s.Body.List, nesting+1)
+	case *ast.SelectStmt:
+		c.total += 1 + nesting
+		c.walkStmts(s.Body.List, nesting+1)
+	case *ast.CaseClause:
+		for _, e := range s.List {
+			c.walkExpr(e, nesting)
+		}
+		c.walkStmts(s.Body, nesting) // case body stays at the switch's nesting
+	case *ast.CommClause:
+		c.walkStmts(s.Body, nesting)
+	case *ast.BranchStmt:
+		if s.Label != nil { // labeled break / continue / goto break linear flow
+			c.total++
+		}
+	case *ast.LabeledStmt:
+		c.walkStmt(s.Stmt, nesting)
+	case *ast.BlockStmt:
+		c.walkStmts(s.List, nesting)
+	case *ast.ExprStmt:
+		c.walkExpr(s.X, nesting)
+	case *ast.AssignStmt:
+		for _, e := range s.Rhs {
+			c.walkExpr(e, nesting)
+		}
+	case *ast.ReturnStmt:
+		for _, e := range s.Results {
+			c.walkExpr(e, nesting)
+		}
+	case *ast.GoStmt:
+		c.walkExpr(s.Call, nesting)
+	case *ast.DeferStmt:
+		c.walkExpr(s.Call, nesting)
+	}
+}
+
+// walkElse handles the else chain. Both `else if` and a bare `else` take a
+// single flat increment with no nesting penalty (rule B3); their bodies sit
+// at the same depth as the matching if-block.
+func (c *cognitiveCounter) walkElse(e ast.Stmt, nesting int) {
+	switch s := e.(type) {
+	case nil:
+		return
+	case *ast.IfStmt: // else if
+		c.total++
+		c.walkExpr(s.Cond, nesting)
+		c.walkStmts(s.Body.List, nesting+1)
+		c.walkElse(s.Else, nesting)
+	case *ast.BlockStmt: // bare else
+		c.total++
+		c.walkStmts(s.List, nesting+1)
+	}
+}
+
+func (c *cognitiveCounter) walkExpr(expr ast.Expr, nesting int) {
+	switch e := expr.(type) {
+	case *ast.BinaryExpr:
+		if e.Op == token.LAND || e.Op == token.LOR {
+			c.countLogical(e, token.ILLEGAL, nesting)
+			return
+		}
+		c.walkExpr(e.X, nesting)
+		c.walkExpr(e.Y, nesting)
+	case *ast.ParenExpr:
+		c.walkExpr(e.X, nesting)
+	case *ast.UnaryExpr:
+		c.walkExpr(e.X, nesting)
+	case *ast.CallExpr:
+		c.walkExpr(e.Fun, nesting)
+		for _, a := range e.Args {
+			c.walkExpr(a, nesting)
+		}
+	case *ast.FuncLit: // nested function: a nesting level, no flat increment
+		if e.Body != nil {
+			c.walkStmts(e.Body.List, nesting+1)
+		}
+	}
+}
+
+// countLogical adds +1 for each maximal run of the same boolean operator.
+// `a && b && c` is one sequence (+1); `a && b || c` alternates (+2).
+func (c *cognitiveCounter) countLogical(expr ast.Expr, parentOp token.Token, nesting int) {
+	be, ok := expr.(*ast.BinaryExpr)
+	if !ok || (be.Op != token.LAND && be.Op != token.LOR) {
+		c.walkExpr(expr, nesting) // operand may hold a func literal, etc.
+		return
+	}
+	if be.Op != parentOp {
+		c.total++
+	}
+	c.countLogical(be.X, be.Op, nesting)
+	c.countLogical(be.Y, be.Op, nesting)
+}

--- a/internal/index/cognitive_test.go
+++ b/internal/index/cognitive_test.go
@@ -1,0 +1,126 @@
+package index
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// cognitiveOf parses a single Go func and returns its cognitive complexity.
+func cognitiveOf(t *testing.T, src string) int {
+	t.Helper()
+	f, err := parser.ParseFile(token.NewFileSet(), "x.go", "package p\n"+src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, d := range f.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok {
+			return computeCognitive(fn.Body)
+		}
+	}
+	t.Fatal("no func found")
+	return -1
+}
+
+func TestCognitiveWhitePaperExamples(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+		src  string
+	}{
+		{
+			// SonarSource white-paper canonical example: nesting drives the score.
+			// for(+1) > for(+2) > if(+3) > continue OUTER(+1) = 7.
+			name: "sumOfPrimes",
+			want: 7,
+			src: `func sumOfPrimes(max int) int {
+				total := 0
+			OUTER:
+				for i := 1; i <= max; i++ {
+					for j := 2; j < i; j++ {
+						if i%j == 0 {
+							continue OUTER
+						}
+					}
+					total += i
+				}
+				return total
+			}`,
+		},
+		{
+			// A switch counts once, no matter how many cases — the white paper's
+			// contrast case to cyclomatic complexity (which would score ~4 here).
+			name: "switchCountsOnce",
+			want: 1,
+			src: `func words(n int) string {
+				switch n {
+				case 1:
+					return "one"
+				case 2:
+					return "a couple"
+				default:
+					return "lots"
+				}
+			}`,
+		},
+		{
+			// if/else-if/else: each takes a flat +1, no nesting penalty.
+			name: "ifElseChain",
+			want: 3,
+			src: `func grade(n int) string {
+				if n > 90 {
+					return "A"
+				} else if n > 80 {
+					return "B"
+				} else {
+					return "C"
+				}
+			}`,
+		},
+		{
+			// Boolean sequences: one run of && = +1 on top of the if's +1.
+			name: "booleanSequence",
+			want: 2,
+			src: `func ok(a, b, c bool) bool {
+				if a && b && c {
+					return true
+				}
+				return false
+			}`,
+		},
+		{
+			// Alternating operators count as two sequences: if(+1) + && (+1) + || (+1).
+			name: "booleanAlternation",
+			want: 3,
+			src: `func ok(a, b, c bool) bool {
+				if a && b || c {
+					return true
+				}
+				return false
+			}`,
+		},
+		{
+			// Linear code with no control flow → 0.
+			name: "linear",
+			want: 0,
+			src: `func add(a, b int) int {
+				s := a + b
+				return s
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cognitiveOf(t, tt.src); got != tt.want {
+				t.Errorf("cognitive(%s) = %d, want %d", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCognitiveNilBody(t *testing.T) {
+	if got := computeCognitive(nil); got != 0 {
+		t.Errorf("nil body = %d, want 0", got)
+	}
+}

--- a/internal/index/cyclo.go
+++ b/internal/index/cyclo.go
@@ -18,6 +18,19 @@ type CycloRollup struct {
 // per-package sum/p95/max. Filters production funcs+methods only (no tests,
 // no zero-cyclo entries from non-function symbols). Empty packages → no entry.
 func PackageCycloRollups(symbols []Symbol) map[string]CycloRollup {
+	return packageRollups(symbols, func(s *Symbol) int { return s.Cyclo })
+}
+
+// PackageCognitiveRollups is the cognitive-complexity counterpart of
+// PackageCycloRollups, using the same per-package sum/p95/max shape.
+func PackageCognitiveRollups(symbols []Symbol) map[string]CycloRollup {
+	return packageRollups(symbols, func(s *Symbol) int { return s.Cognitive })
+}
+
+// packageRollups groups production funcs+methods by package and rolls up the
+// per-symbol value selected by val into sum/p95/max. Test files and
+// non-function symbols are excluded; empty packages produce no entry.
+func packageRollups(symbols []Symbol, val func(*Symbol) int) map[string]CycloRollup {
 	byPkg := make(map[string][]int)
 	for i := range symbols {
 		s := &symbols[i]
@@ -30,7 +43,7 @@ func PackageCycloRollups(symbols []Symbol) map[string]CycloRollup {
 		if isTestFile(s.FilePath) {
 			continue
 		}
-		byPkg[s.PkgPath] = append(byPkg[s.PkgPath], s.Cyclo)
+		byPkg[s.PkgPath] = append(byPkg[s.PkgPath], val(s))
 	}
 	out := make(map[string]CycloRollup, len(byPkg))
 	for pkg, vals := range byPkg {

--- a/internal/index/symbols.go
+++ b/internal/index/symbols.go
@@ -47,6 +47,10 @@ type Symbol struct {
 	// In-memory only (not persisted); used for per-package rollups via
 	// PackageCycloRollups. Zero for non-function symbols.
 	Cyclo int
+	// Cognitive is the SonarSource cognitive complexity for func/method
+	// symbols. In-memory only; used for per-package rollups via
+	// PackageCognitiveRollups. Zero for non-function symbols.
+	Cognitive int
 }
 
 // ExtractSymbols extracts all symbols from loaded packages
@@ -113,6 +117,7 @@ func extractFuncSymbol(pkg *packages.Package, decl *ast.FuncDecl, filePath, pkgP
 	sig := formatFuncSignatureTyped(pkg, decl)
 	doc := extractDoc(decl.Doc)
 	cyclo := computeCyclo(decl.Body)
+	cognitive := computeCognitive(decl.Body)
 
 	return &Symbol{
 		// ID uses identifier position for posKey matching with call graph
@@ -133,6 +138,7 @@ func extractFuncSymbol(pkg *packages.Package, decl *ast.FuncDecl, filePath, pkgP
 		Doc:       doc,
 		Receiver:  receiver,
 		Cyclo:     cyclo,
+		Cognitive: cognitive,
 	}
 }
 

--- a/internal/sensitive/sensitive.go
+++ b/internal/sensitive/sensitive.go
@@ -120,7 +120,12 @@ func matchGlob(glob, path string) bool {
 		return strings.HasPrefix(path, strings.TrimSuffix(glob, "**"))
 	}
 	if suffix, ok := strings.CutPrefix(glob, "**/"); ok {
-		return strings.HasSuffix(path, suffix) || strings.Contains(path, "/"+suffix)
+		// Match only on full path segments: the suffix must be the whole path,
+		// end after a separator, or sit between separators — never a partial
+		// filename ("xfoo.go") or a directory named like the file.
+		return path == suffix ||
+			strings.HasSuffix(path, "/"+suffix) ||
+			strings.Contains(path, "/"+suffix+"/")
 	}
 	if ok, _ := filepath.Match(glob, path); ok {
 		return true

--- a/internal/sensitive/sensitive.go
+++ b/internal/sensitive/sensitive.go
@@ -1,0 +1,131 @@
+// Package sensitive classifies files into security-sensitive zones —
+// authentication, cryptography, schema migrations, secrets, payments.
+//
+// Tornhill (Your Code as a Crime Scene) notes that some code is always
+// significant regardless of size, churn, or complexity: a 20-line auth check
+// matters more than a 2000-line churning UI file because a defect's cost is
+// decoupled from the file's metrics. Flagging these zones keeps risk ranking
+// from under-weighting small-but-critical code, mirroring the intent of
+// GitHub CODEOWNERS path ownership.
+//
+// Classification has two layers: zero-config built-in heuristics over path
+// and file names, plus an optional .snipe/sensitive file of CODEOWNERS-style
+// "glob zone" rules that extend or add to the defaults.
+package sensitive
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Zone is a category of always-significant code.
+type Zone string
+
+const (
+	ZoneAuth      Zone = "auth"
+	ZoneCrypto    Zone = "crypto"
+	ZoneMigration Zone = "migration"
+	ZoneSecret    Zone = "secret"
+	ZonePayment   Zone = "payment"
+)
+
+// builtinKeywords maps a lower-cased substring (matched against the path) to
+// the zone it implies. Ordered scanning is fine; matches accumulate.
+var builtinKeywords = []struct {
+	kw   string
+	zone Zone
+}{
+	{"auth", ZoneAuth}, {"login", ZoneAuth}, {"session", ZoneAuth},
+	{"oauth", ZoneAuth}, {"jwt", ZoneAuth}, {"credential", ZoneAuth},
+	{"crypto", ZoneCrypto}, {"cipher", ZoneCrypto}, {"encrypt", ZoneCrypto},
+	{"decrypt", ZoneCrypto}, {"x509", ZoneCrypto}, {"tls", ZoneCrypto},
+	{"migration", ZoneMigration}, {"migrate", ZoneMigration}, {"schema", ZoneMigration},
+	{"secret", ZoneSecret}, {"password", ZoneSecret}, {"apikey", ZoneSecret},
+	{"vault", ZoneSecret}, {"token", ZoneSecret},
+	{"payment", ZonePayment}, {"billing", ZonePayment}, {"invoice", ZonePayment},
+	{"charge", ZonePayment},
+}
+
+// rule is one parsed line from .snipe/sensitive.
+type rule struct {
+	glob string
+	zone Zone
+}
+
+// Classifier assigns zones to repo-relative paths.
+type Classifier struct {
+	rules []rule // user-supplied globs (may be empty)
+}
+
+// Load reads .snipe/sensitive from repoRoot if present. A missing file is
+// fine — the classifier still applies built-in heuristics. A malformed line
+// is skipped rather than failing the whole load.
+func Load(repoRoot string) *Classifier {
+	c := &Classifier{}
+	f, err := os.Open(filepath.Join(repoRoot, ".snipe", "sensitive"))
+	if err != nil {
+		return c
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		c.rules = append(c.rules, rule{glob: fields[0], zone: Zone(fields[1])})
+	}
+	return c
+}
+
+// Zones returns the sorted, de-duplicated zones for a repo-relative path,
+// combining built-in keyword heuristics with any matching config globs.
+func (c *Classifier) Zones(path string) []Zone {
+	lower := strings.ToLower(path)
+	set := make(map[Zone]struct{})
+	for _, kw := range builtinKeywords {
+		if strings.Contains(lower, kw.kw) {
+			set[kw.zone] = struct{}{}
+		}
+	}
+	for _, r := range c.rules {
+		if matchGlob(r.glob, path) {
+			set[r.zone] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]Zone, 0, len(set))
+	for z := range set {
+		out = append(out, z)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// matchGlob supports a leading/trailing "**" for recursive matching plus the
+// single-segment semantics of filepath.Match. "internal/auth/**" matches any
+// path under internal/auth; "*.sql" matches by base name.
+func matchGlob(glob, path string) bool {
+	if strings.HasSuffix(glob, "/**") {
+		return strings.HasPrefix(path, strings.TrimSuffix(glob, "**"))
+	}
+	if suffix, ok := strings.CutPrefix(glob, "**/"); ok {
+		return strings.HasSuffix(path, suffix) || strings.Contains(path, "/"+suffix)
+	}
+	if ok, _ := filepath.Match(glob, path); ok {
+		return true
+	}
+	// Also try matching against the base name so "*.sql" works at any depth.
+	ok, _ := filepath.Match(glob, filepath.Base(path))
+	return ok
+}

--- a/internal/sensitive/sensitive_test.go
+++ b/internal/sensitive/sensitive_test.go
@@ -1,0 +1,68 @@
+package sensitive
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestBuiltinHeuristics(t *testing.T) {
+	c := &Classifier{} // no config — built-ins only
+	tests := []struct {
+		path string
+		want []Zone
+	}{
+		{"internal/auth/login.go", []Zone{ZoneAuth}},
+		{"pkg/crypto/cipher.go", []Zone{ZoneCrypto}},
+		{"internal/store/migrations/001_init.go", []Zone{ZoneMigration}},
+		{"internal/billing/charge.go", []Zone{ZonePayment}},
+		{"internal/query/lookup.go", nil}, // ordinary code → no zone
+	}
+	for _, tt := range tests {
+		got := c.Zones(tt.path)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("Zones(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestConfigGlobExtendsBuiltins(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".snipe"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "# project sensitive zones\ninternal/secrets/** secret\n*.sql migration\n"
+	if err := os.WriteFile(filepath.Join(dir, ".snipe", "sensitive"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := Load(dir)
+
+	if got := c.Zones("internal/secrets/keys.go"); !reflect.DeepEqual(got, []Zone{ZoneSecret}) {
+		t.Errorf("glob rule: Zones = %v, want [secret]", got)
+	}
+	if got := c.Zones("db/0001_init.sql"); !reflect.DeepEqual(got, []Zone{ZoneMigration}) {
+		t.Errorf("*.sql rule: Zones = %v, want [migration]", got)
+	}
+	// Built-ins still fire alongside config.
+	if got := c.Zones("internal/auth/jwt.go"); !reflect.DeepEqual(got, []Zone{ZoneAuth}) {
+		t.Errorf("built-in still active: Zones = %v, want [auth]", got)
+	}
+}
+
+func TestLoadMissingFileIsFine(t *testing.T) {
+	c := Load(t.TempDir()) // no .snipe/sensitive
+	if got := c.Zones("internal/auth/x.go"); !reflect.DeepEqual(got, []Zone{ZoneAuth}) {
+		t.Errorf("missing config should still apply built-ins, got %v", got)
+	}
+}
+
+func TestMultipleZones(t *testing.T) {
+	c := &Classifier{}
+	// path mentions both crypto and token(secret) → both zones, sorted.
+	got := c.Zones("internal/crypto/token_store.go")
+	want := []Zone{ZoneCrypto, ZoneSecret}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Zones = %v, want %v", got, want)
+	}
+}

--- a/internal/sensitive/sensitive_test.go
+++ b/internal/sensitive/sensitive_test.go
@@ -50,6 +50,26 @@ func TestConfigGlobExtendsBuiltins(t *testing.T) {
 	}
 }
 
+func TestGlobMatchesFullSegmentsOnly(t *testing.T) {
+	// matchGlob in isolation — paths chosen to avoid built-in keywords.
+	cases := []struct {
+		glob, path string
+		want       bool
+	}{
+		{"**/widget.go", "internal/ui/widget.go", true},    // ends after a separator
+		{"**/widget.go", "widget.go", true},                // whole path
+		{"**/widget.go", "a/widget.go/b.go", true},         // between separators
+		{"**/widget.go", "internal/ui/mywidget.go", false}, // partial filename — must NOT match
+		{"internal/ui/**", "internal/ui/panel.go", true},   // /** prefix dir
+		{"internal/ui/**", "internal/uix/panel.go", false}, // prefix must be a real dir boundary
+	}
+	for _, tc := range cases {
+		if got := matchGlob(tc.glob, tc.path); got != tc.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tc.glob, tc.path, got, tc.want)
+		}
+	}
+}
+
 func TestLoadMissingFileIsFine(t *testing.T) {
 	c := Load(t.TempDir()) // no .snipe/sensitive
 	if got := c.Zones("internal/auth/x.go"); !reflect.DeepEqual(got, []Zone{ZoneAuth}) {

--- a/internal/store/churn.go
+++ b/internal/store/churn.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// FileChurn is the persisted git change-frequency record for one file,
+// keyed by a repo-relative path so it joins against symbols.file_path.
+// Populated by `snipe index` from git history; see internal/gitchurn.
+type FileChurn struct {
+	Path        string  `json:"path"`
+	Commits     int     `json:"commits"`
+	Authors     int     `json:"authors"`
+	FirstSeen   string  `json:"first_seen"`
+	LastChanged string  `json:"last_changed"`
+	Score       float64 `json:"score"`
+}
+
+// WriteFileChurn replaces the whole file_churn table with rows in a single
+// transaction. Churn is recomputed wholesale from git history each reindex,
+// so a full replace keeps the table consistent with HEAD.
+func (s *Store) WriteFileChurn(rows []FileChurn) (err error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { rollbackOnError(tx, &err) }()
+
+	if _, err := tx.Exec(`DELETE FROM file_churn`); err != nil {
+		return fmt.Errorf("clear file_churn: %w", err)
+	}
+
+	stmt, err := tx.Prepare(
+		`INSERT INTO file_churn (path, commits, authors, first_seen, last_changed, score)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for _, r := range rows {
+		if _, err := stmt.Exec(r.Path, r.Commits, r.Authors, r.FirstSeen, r.LastChanged, r.Score); err != nil {
+			return fmt.Errorf("insert churn row %q: %w", r.Path, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// ReadFileChurnTopN returns files ranked by commit count descending (ties
+// broken by path ascending). n <= 0 returns all rows.
+func (s *Store) ReadFileChurnTopN(n int) ([]FileChurn, error) {
+	const base = `SELECT path, commits, authors, first_seen, last_changed, score
+		FROM file_churn ORDER BY commits DESC, path ASC`
+	var (
+		rs  *sql.Rows
+		err error
+	)
+	if n <= 0 {
+		rs, err = s.db.Query(base)
+	} else {
+		rs, err = s.db.Query(base+` LIMIT ?`, n)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query file_churn: %w", err)
+	}
+	defer func() { _ = rs.Close() }()
+
+	var out []FileChurn
+	for rs.Next() {
+		var r FileChurn
+		if err := rs.Scan(&r.Path, &r.Commits, &r.Authors, &r.FirstSeen, &r.LastChanged, &r.Score); err != nil {
+			return nil, fmt.Errorf("scan churn row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rs.Err(); err != nil {
+		return nil, fmt.Errorf("iterate churn rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/churn_test.go
+++ b/internal/store/churn_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func churnTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestWriteAndReadFileChurn(t *testing.T) {
+	s := churnTestStore(t)
+
+	rows := []FileChurn{
+		{Path: "a.go", Commits: 10, Authors: 3, FirstSeen: "2026-01-01", LastChanged: "2026-06-01", Score: 4.5},
+		{Path: "b.go", Commits: 25, Authors: 1, FirstSeen: "2025-01-01", LastChanged: "2026-05-01", Score: 9.0},
+		{Path: "c.go", Commits: 25, Authors: 2, FirstSeen: "2025-06-01", LastChanged: "2026-04-01", Score: 7.0},
+	}
+	if err := s.WriteFileChurn(rows); err != nil {
+		t.Fatalf("WriteFileChurn: %v", err)
+	}
+
+	got, err := s.ReadFileChurnTopN(0)
+	if err != nil {
+		t.Fatalf("ReadFileChurnTopN: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d rows, want 3", len(got))
+	}
+	// Ordered by commits desc, then path asc: b(25), c(25), a(10).
+	if got[0].Path != "b.go" || got[1].Path != "c.go" || got[2].Path != "a.go" {
+		t.Errorf("order = %s,%s,%s; want b.go,c.go,a.go", got[0].Path, got[1].Path, got[2].Path)
+	}
+	if got[0].Authors != 1 || got[0].Score != 9.0 {
+		t.Errorf("b.go fields not round-tripped: %+v", got[0])
+	}
+
+	// Top-N truncates after ranking.
+	top, err := s.ReadFileChurnTopN(2)
+	if err != nil {
+		t.Fatalf("ReadFileChurnTopN(2): %v", err)
+	}
+	if len(top) != 2 || top[0].Path != "b.go" || top[1].Path != "c.go" {
+		t.Errorf("top-2 = %+v; want b.go,c.go", top)
+	}
+}
+
+func TestWriteFileChurnReplaces(t *testing.T) {
+	s := churnTestStore(t)
+	if err := s.WriteFileChurn([]FileChurn{{Path: "old.go", Commits: 5}}); err != nil {
+		t.Fatal(err)
+	}
+	// Second write replaces the whole table.
+	if err := s.WriteFileChurn([]FileChurn{{Path: "new.go", Commits: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ReadFileChurnTopN(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Path != "new.go" {
+		t.Errorf("replace failed, got %+v", got)
+	}
+
+	// Empty write clears the table (non-git reindex path).
+	if err := s.WriteFileChurn(nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.ReadFileChurnTopN(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty write should clear table, got %+v", got)
+	}
+}

--- a/internal/store/fanin_test.go
+++ b/internal/store/fanin_test.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/index"
+)
+
+func TestFileFanInCountsCrossFileCallersOnly(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	fn := func(id, file string) index.Symbol {
+		return index.Symbol{ID: id, Name: id, Kind: index.KindFunc, FilePath: file}
+	}
+	symbols := []index.Symbol{
+		fn("a", "a.go"), // callee — depended on from elsewhere
+		fn("b", "b.go"), // cross-file caller
+		fn("d", "d.go"), // cross-file caller
+		fn("c", "a.go"), // same-file caller (must be excluded)
+	}
+	edges := []index.CallEdge{
+		{CallerID: "b", CalleeID: "a"}, // cross-file → counts
+		{CallerID: "d", CalleeID: "a"}, // cross-file → counts
+		{CallerID: "c", CalleeID: "a"}, // same file (a.go) → excluded
+	}
+	if err := s.WriteIndex(symbols, nil, edges); err != nil {
+		t.Fatalf("WriteIndex: %v", err)
+	}
+
+	fanIn, err := s.FileFanIn()
+	if err != nil {
+		t.Fatalf("FileFanIn: %v", err)
+	}
+	if got := fanIn["a.go"]; got != 2 {
+		t.Errorf("a.go fan-in = %v, want 2 (b, d — not same-file c)", got)
+	}
+	if _, ok := fanIn["b.go"]; ok {
+		t.Errorf("b.go has no incoming cross-file calls, should be absent: %v", fanIn)
+	}
+}

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -65,6 +65,40 @@ func (s *Store) WriteGraphMetrics(graphKind, metric string, values map[string]fl
 	return nil
 }
 
+// FileFanIn returns, per file, the number of distinct caller symbols in other
+// files that call into it — a blast-radius proxy for `snipe hotspots`: how
+// much elsewhere depends on this file. Same-file calls are excluded (not
+// external risk) and callers are counted distinctly so repeated calls from one
+// function don't inflate the number. Keys come from symbols.file_path as
+// stored (absolute); the caller relativizes to match the cyclo/churn keys.
+func (s *Store) FileFanIn() (map[string]float64, error) {
+	rows, err := s.db.Query(`
+		SELECT callee.file_path AS f, COUNT(DISTINCT cg.caller_id) AS n
+		FROM call_graph cg
+		JOIN symbols caller ON cg.caller_id = caller.id
+		JOIN symbols callee ON cg.callee_id = callee.id
+		WHERE caller.file_path <> callee.file_path
+		GROUP BY callee.file_path`)
+	if err != nil {
+		return nil, fmt.Errorf("query file fan-in: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]float64)
+	for rows.Next() {
+		var f string
+		var n float64
+		if err := rows.Scan(&f, &n); err != nil {
+			return nil, fmt.Errorf("scan fan-in row: %w", err)
+		}
+		out[f] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fan-in rows: %w", err)
+	}
+	return out, nil
+}
+
 // ReadTopN returns the top-n rows for (graphKind, metric) ordered by rank ascending.
 // If n <= 0, all rows are returned.
 func (s *Store) ReadTopN(graphKind, metric string, n int) ([]MetricRow, error) {

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const schemaVersion = 18
+const schemaVersion = 19
 
 // migration represents a database migration.
 type migration struct {
@@ -268,6 +268,21 @@ var migrations = []migration{
 		name:    "refs_ast_ctx",
 		up: `
 		ALTER TABLE refs ADD COLUMN ast_ctx TEXT;
+		`,
+	},
+	{
+		version: 19,
+		name:    "file_churn_table",
+		up: `
+		CREATE TABLE IF NOT EXISTS file_churn (
+			path         TEXT PRIMARY KEY,
+			commits      INT  NOT NULL,
+			authors      INT  NOT NULL,
+			first_seen   TEXT NOT NULL,
+			last_changed TEXT NOT NULL,
+			score        REAL NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_file_churn_commits ON file_churn(commits);
 		`,
 	},
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -120,8 +120,8 @@ func TestSchemaCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMeta(schema_version) failed: %v", err)
 	}
-	if version != "18" {
-		t.Errorf("schema_version = %q, want %q", version, "18")
+	if version != "19" {
+		t.Errorf("schema_version = %q, want %q", version, "19")
 	}
 }
 


### PR DESCRIPTION
Adds the temporal axis of code risk and turns `snipe hotspots` into the unified, Claude-facing risk view. Implements Adam Tornhill's crime-scene model: defect risk concentrates where complexity meets change-frequency.

Covers the five risk heuristics requested (three new metrics, two already shipped) and synthesizes them into one command optimized for Claude (D1).

| Heuristic | Source | Command | This PR |
|---|---|---|---|
| Churn → defects | Nagappan & Ball, ICSE 2005 | `metrics --kind=churn` | sn-64a.1 |
| Hotspots (complexity × churn) | Tornhill / CodeScene | `snipe hotspots` | sn-64a.2 |
| Cognitive complexity | Campbell, SonarSource 2017 | `metrics --kind=cognitive` | sn-64a.3 |
| Sensitive zones | Tornhill + CODEOWNERS | `snipe sensitive` + ⚑ in hotspots | sn-64a.4 |
| **Unified risk view** (+ fan-in/blast-radius) | Tornhill + snipe call graph | `snipe hotspots` (enriched) | sn-64a.5 |
| McCabe cyclomatic | McCabe 1976 | `metrics --kind=cyclo` | (already shipped) |
| Fan-in / afferent coupling | — | `metrics --kind=in_degree\|ca\|pagerank` | (already shipped) |

## The risk view (sn-64a.5)
D1: Claude doesn't browse 18 `--kind` primitives — it asks "where's the risk / what's fragile if I touch this?". `snipe hotspots` answers in one command, showing all four risk axes with components visible so Claude reasons about the dominant factor:

```
  risk    cx   cog   chn  auth    in  path
  0.96   670   984    53     2    94  internal/output/json.go     ← top hotspot AND 94 dependents
  0.72   482   582    62     2     1  cmd/index.go                ← high score but entry point (in=1)
  0.24   170   162    53     2    71  cmd/root.go                 ← calm score, load-bearing (in=71)
```

The composite `risk` stays the grounded Tornhill hotspot (cyclo × change-frequency); fan-in/cognitive/sensitivity ride alongside as context columns rather than an un-grounded 4-way formula. The 18 `--kind` primitives remain as the precision layer (D2). No `--kind=all`.

## Commits
- `feat(churn)` — `internal/gitchurn` walks `git log` once at index time → `file_churn` (schema v19): commits/revisions, authors (bus factor), first/last seen, recency-weighted score. Excludes vendored + deleted files.
- `feat(hotspots)` — `snipe hotspots` joins per-file complexity with churn.
- `feat(cognitive)` — `internal/index/cognitive.go`, SonarSource B1/B2/B3, verified against white-paper oracles (sumOfPrimes=7, switch=1).
- `feat(sensitive)` — `internal/sensitive` classifier (heuristics + `.snipe/sensitive` globs); `snipe sensitive` + ⚑ annotations.
- `feat(hotspots)` — unified risk view: per-file fan-in (cross-file callers) + cognitive columns.

## Git when available
Every git-derived metric degrades to a clean no-op (clear note, never an error) outside a git repo, on a shallow clone, or an unborn branch. Fan-in is structural — available without git.

## Verification
`make audit` green after every commit (race + blackbox + eval 100%/100% + govulncheck). Unit tests: gitchurn walker, file_churn round-trip, hotspots scoring + fallback, cognitive white-paper oracles, sensitive heuristics + globs, fan-in cross-file-only counting.

Closes: sn-64a, sn-64a.1, sn-64a.2, sn-64a.3, sn-64a.4, sn-64a.5