### PR TITLE
fix(index): backfill file-level risk metrics on a stale existing index (sn-64a.6)

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -101,6 +101,17 @@ func runIndex(args []string) error {
 			fmt.Fprintf(os.Stderr, "Change detection failed: %v (proceeding with full index)\n", detectErr)
 			detection = &changeDetection{result: skipResultProceedFull}
 		}
+		// Backfill guard: an index built before the current file-level metrics
+		// existed carries a stale (or absent) version marker. A skip or
+		// incremental run would never populate file_churn / the "files" graph,
+		// leaving `snipe hotspots` and `metrics --kind=churn` empty until the
+		// user discovers --force. Force a one-time full reindex to backfill;
+		// the marker is written at the end of the metrics block, so subsequent
+		// runs skip normally.
+		if detection.result != skipResultProceedFull && metricsNeedBackfill(s) {
+			fmt.Fprintf(os.Stderr, "Index predates current risk metrics — running full reindex to backfill (one-time)\n")
+			detection = &changeDetection{result: skipResultProceedFull}
+		}
 		if detection.result == skipResultSkipped {
 			return nil
 		}
@@ -260,6 +271,9 @@ func runIndex(args []string) error {
 		if err := computeChurn(s); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: git churn computation failed: %v\n", err)
 		}
+		// Mark which generation of file-level metrics this index carries, so a
+		// later skip/incremental run can detect a stale index and backfill.
+		_ = s.SetMeta(metaFileMetricsVersion, fileMetricsVersion)
 	}
 
 	// Extract and write string literals (env var calls + named consts)
@@ -1140,6 +1154,28 @@ func computeFileFanIn(s *store.Store) error {
 		return fmt.Errorf("write file fan_in: %w", err)
 	}
 	return nil
+}
+
+// metaFileMetricsVersion names the meta key tracking the generation of
+// file-level risk metrics (file_churn + the "files" complexity/fan-in graph)
+// an index carries. fileMetricsVersion is the current generation — bump it
+// whenever a new file-level metric is added so existing indexes auto-backfill
+// on their next `snipe index`.
+const (
+	metaFileMetricsVersion = "file_metrics_version"
+	fileMetricsVersion     = "1"
+)
+
+// metricsNeedBackfill reports whether the index lacks the current generation of
+// file-level metrics — true for any index built before the marker was written
+// (or before a metric was added). It is the signal to force a full reindex
+// even when change detection would otherwise skip or go incremental.
+func metricsNeedBackfill(s *store.Store) bool {
+	// A missing key returns ("", err); an unreadable DB returns ("", err) too.
+	// Either way the value won't equal the current version, so we backfill —
+	// a one-time full reindex is the safe outcome, never data loss.
+	v, _ := s.GetMeta(metaFileMetricsVersion)
+	return v != fileMetricsVersion
 }
 
 // relToRoot returns absPath relative to root, falling back to absPath when

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -108,7 +108,7 @@ func runIndex(args []string) error {
 		// user discovers --force. Force a one-time full reindex to backfill;
 		// the marker is written at the end of the metrics block, so subsequent
 		// runs skip normally.
-		if detection.result != skipResultProceedFull && metricsNeedBackfill(s) {
+		if detection.result != skipResultProceedFull && !skipMetrics && metricsNeedBackfill(s) {
 			fmt.Fprintf(os.Stderr, "Index predates current risk metrics — running full reindex to backfill (one-time)\n")
 			detection = &changeDetection{result: skipResultProceedFull}
 		}
@@ -273,7 +273,9 @@ func runIndex(args []string) error {
 		}
 		// Mark which generation of file-level metrics this index carries, so a
 		// later skip/incremental run can detect a stale index and backfill.
-		_ = s.SetMeta(metaFileMetricsVersion, fileMetricsVersion)
+		if err := s.SetMeta(metaFileMetricsVersion, fileMetricsVersion); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write file metrics version: %v\n", err)
+		}
 	}
 
 	// Extract and write string literals (env var calls + named consts)

--- a/cmd/index_backfill_test.go
+++ b/cmd/index_backfill_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+func TestMetricsNeedBackfill(t *testing.T) {
+	s, err := store.Open(filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Fresh / pre-feature index — no marker → must backfill.
+	if !metricsNeedBackfill(s) {
+		t.Error("index with no metrics-version marker should need backfill")
+	}
+
+	// Current generation written → no backfill.
+	if err := s.SetMeta(metaFileMetricsVersion, fileMetricsVersion); err != nil {
+		t.Fatal(err)
+	}
+	if metricsNeedBackfill(s) {
+		t.Error("index at the current metrics version should not need backfill")
+	}
+
+	// An older generation → backfill again (forward-compat for new metrics).
+	if err := s.SetMeta(metaFileMetricsVersion, "0"); err != nil {
+		t.Fatal(err)
+	}
+	if !metricsNeedBackfill(s) {
+		t.Error("index at a stale metrics version should need backfill")
+	}
+}


### PR DESCRIPTION
Closes the deferred finding from #180's codex review and completes epic sn-64a.

## Problem
A repo indexed before the file-level risk metrics existed (file_churn, the "files" complexity/fan-in graph) never gets them on a plain `snipe index` — change detection takes the skip or incremental path, which skips the metrics block. `snipe hotspots` and `metrics --kind=churn` then report empty until the user happens to run `--force`.

## Fix
A `file_metrics_version` meta marker, written at the end of the metrics block. On a would-be skip/incremental run, `metricsNeedBackfill` compares the marker to the current version; if stale or absent it forces a one-time full reindex to backfill. The marker is then current, so subsequent runs skip normally. Bumping `fileMetricsVersion` auto-backfills any future file-level metric the same way.

A spurious meta read error falls through to backfill (a redundant reindex is safe; never data loss).

## Verification
- Unit: `metricsNeedBackfill` — absent marker → backfill, current → skip, stale → backfill.
- Live: wiped the marker + `file_churn` + `files` graph to simulate a pre-feature index; a plain `snipe index` (no `--force`, no file changes) self-healed —
  ```
  Index predates current risk metrics — running full reindex to backfill (one-time)
  → 518 file-metric rows + 245 churn rows restored, marker = 1
  ```
  A second run skipped normally with no re-backfill (idempotent).
- `make audit` green.

Closes: sn-64a.6