### PR TITLE
fix(hotspots): file fan-in = distinct caller files (Martin Ca), not caller symbols

### DIFF
--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -26,7 +26,7 @@ type hotspotRow struct {
 	Cognitive   int              `json:"cognitive"`           // summed SonarSource cognitive complexity (cog)
 	Commits     int              `json:"commits"`             // revisions touching the file (chn)
 	Authors     int              `json:"authors"`             // distinct committers / bus factor (auth)
-	FanIn       int              `json:"fan_in"`              // cross-file callers / blast radius (in)
+	FanIn       int              `json:"fan_in"`              // distinct caller files / blast radius (in)
 	LastChanged string           `json:"last_changed"`        // empty when churn unavailable
 	Sensitive   []sensitive.Zone `json:"sensitive,omitempty"` // auth/crypto/migration/... if any
 }

--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -215,7 +215,8 @@ func zoneSuffix(zones []sensitive.Zone) string {
 func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
 	var b strings.Builder
 	b.WriteString("hotspots · unified risk (Tornhill crime-scene)\n")
-	b.WriteString("  risk = cyclo × change-frequency; cx=cyclo cog=cognitive chn=commits auth=bus-factor in=fan-in/blast-radius ⚑=sensitive\n")
+	b.WriteString("  risk = cyclo × change-frequency; cx=cyclo cxmax=worst-func cyclo cog=cognitive chn=commits auth=bus-factor in=fan-in/blast-radius ⚑=sensitive\n")
+	b.WriteString("  high cx + low cxmax → broad file, split; high cxmax → one gnarly func, simplify\n")
 	if !haveChurn {
 		b.WriteString("  ⚠ no git churn (not a git repo) — risk ranked on complexity alone; chn/auth omitted\n")
 	}
@@ -225,15 +226,15 @@ func writeHotspotsText(rows []hotspotRow, haveChurn bool) error {
 		return err
 	}
 	if haveChurn {
-		fmt.Fprintf(&b, "  %5s %5s %5s %5s %5s %5s  %s\n", "risk", "cx", "cog", "chn", "auth", "in", "path")
+		fmt.Fprintf(&b, "  %5s %5s %5s %5s %5s %5s %5s  %s\n", "risk", "cx", "cxmax", "cog", "chn", "auth", "in", "path")
 		for _, r := range rows {
-			fmt.Fprintf(&b, "  %5.2f %5d %5d %5d %5d %5d  %s%s\n",
-				r.Score, r.Cyclo, r.Cognitive, r.Commits, r.Authors, r.FanIn, r.Path, zoneSuffix(r.Sensitive))
+			fmt.Fprintf(&b, "  %5.2f %5d %5d %5d %5d %5d %5d  %s%s\n",
+				r.Score, r.Cyclo, r.CycloMax, r.Cognitive, r.Commits, r.Authors, r.FanIn, r.Path, zoneSuffix(r.Sensitive))
 		}
 	} else {
-		fmt.Fprintf(&b, "  %5s %5s %5s %5s  %s\n", "risk", "cx", "cog", "in", "path")
+		fmt.Fprintf(&b, "  %5s %5s %5s %5s %5s  %s\n", "risk", "cx", "cxmax", "cog", "in", "path")
 		for _, r := range rows {
-			fmt.Fprintf(&b, "  %5.2f %5d %5d %5d  %s%s\n", r.Score, r.Cyclo, r.Cognitive, r.FanIn, r.Path, zoneSuffix(r.Sensitive))
+			fmt.Fprintf(&b, "  %5.2f %5d %5d %5d %5d  %s%s\n", r.Score, r.Cyclo, r.CycloMax, r.Cognitive, r.FanIn, r.Path, zoneSuffix(r.Sensitive))
 		}
 	}
 	_, err := os.Stdout.WriteString(b.String())

--- a/cmd/hotspots_test.go
+++ b/cmd/hotspots_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"math"
 	"testing"
 
 	"github.com/dkoosis/snipe/internal/store"
@@ -81,6 +82,78 @@ func TestBuildHotspotsFallsBackToComplexityWithoutChurn(t *testing.T) {
 	if m["big.go"].FanIn != 5 || m["small.go"].FanIn != 9 {
 		t.Errorf("fan-in should be present without churn: big=%d small=%d", m["big.go"].FanIn, m["small.go"].FanIn)
 	}
+}
+
+// TestBuildHotspotsScoreReconstruction pins the exact score formula —
+// norm(cyclo) × norm(log1p(commits)) — so the displayed score stays
+// reconstructable from its component columns. Each case computes the expected
+// value the same way the production code does and asserts equality.
+func TestBuildHotspotsScoreReconstruction(t *testing.T) {
+	const eps = 1e-9
+	churn := func(commits int) store.FileChurn {
+		return store.FileChurn{Commits: commits, Authors: 1}
+	}
+
+	t.Run("equal complexity, churn drives the spread", func(t *testing.T) {
+		cyclo := []store.MetricRow{{NodeID: "a", Value: 100}, {NodeID: "b", Value: 100}}
+		ch := map[string]store.FileChurn{"a": churn(50), "b": churn(2)}
+		m := rowByPath(buildHotspots(cyclo, nil, nil, nil, ch, true))
+		maxLog := math.Log1p(50)
+		wantA := 1.0 * (math.Log1p(50) / maxLog) // = 1.0
+		wantB := 1.0 * (math.Log1p(2) / maxLog)
+		if math.Abs(m["a"].Score-wantA) > eps || math.Abs(m["b"].Score-wantB) > eps {
+			t.Errorf("scores a=%.6f (want %.6f) b=%.6f (want %.6f)", m["a"].Score, wantA, m["b"].Score, wantB)
+		}
+	})
+
+	t.Run("equal churn, complexity drives the spread", func(t *testing.T) {
+		cyclo := []store.MetricRow{{NodeID: "a", Value: 100}, {NodeID: "b", Value: 25}}
+		ch := map[string]store.FileChurn{"a": churn(10), "b": churn(10)}
+		m := rowByPath(buildHotspots(cyclo, nil, nil, nil, ch, true))
+		// churn factor is 1.0 for both (equal, both == max) → score == cycloNorm.
+		if math.Abs(m["a"].Score-1.0) > eps || math.Abs(m["b"].Score-0.25) > eps {
+			t.Errorf("scores a=%.6f (want 1.0) b=%.6f (want 0.25)", m["a"].Score, m["b"].Score)
+		}
+	})
+
+	t.Run("ties produce identical scores", func(t *testing.T) {
+		cyclo := []store.MetricRow{{NodeID: "a", Value: 40}, {NodeID: "b", Value: 40}}
+		ch := map[string]store.FileChurn{"a": churn(7), "b": churn(7)}
+		m := rowByPath(buildHotspots(cyclo, nil, nil, nil, ch, true))
+		if m["a"].Score != m["b"].Score {
+			t.Errorf("tied inputs gave different scores: a=%v b=%v", m["a"].Score, m["b"].Score)
+		}
+	})
+
+	t.Run("single row normalizes to 1.0", func(t *testing.T) {
+		cyclo := []store.MetricRow{{NodeID: "a", Value: 17}}
+		ch := map[string]store.FileChurn{"a": churn(99)}
+		m := rowByPath(buildHotspots(cyclo, nil, nil, nil, ch, true))
+		if math.Abs(m["a"].Score-1.0) > eps {
+			t.Errorf("lone row score = %.6f, want 1.0 (it is both maxes)", m["a"].Score)
+		}
+	})
+
+	t.Run("zero max complexity → score 0, no divide-by-zero", func(t *testing.T) {
+		cyclo := []store.MetricRow{{NodeID: "a", Value: 0}, {NodeID: "b", Value: 0}}
+		ch := map[string]store.FileChurn{"a": churn(10), "b": churn(3)}
+		rows := buildHotspots(cyclo, nil, nil, nil, ch, true)
+		for _, r := range rows {
+			if r.Score != 0 || math.IsNaN(r.Score) {
+				t.Errorf("%s score = %v, want 0 when maxCyclo==0", r.Path, r.Score)
+			}
+		}
+	})
+
+	t.Run("zero max churn → falls back to complexity, no divide-by-zero", func(t *testing.T) {
+		cyclo := []store.MetricRow{{NodeID: "a", Value: 80}, {NodeID: "b", Value: 20}}
+		// commits==0 everywhere → log1p(0)==0 → maxLogChurn==0.
+		ch := map[string]store.FileChurn{"a": churn(0), "b": churn(0)}
+		m := rowByPath(buildHotspots(cyclo, nil, nil, nil, ch, true))
+		if math.Abs(m["a"].Score-1.0) > eps || math.Abs(m["b"].Score-0.25) > eps {
+			t.Errorf("maxLogChurn==0 should fall back to cycloNorm: a=%.6f b=%.6f", m["a"].Score, m["b"].Score)
+		}
+	})
 }
 
 func TestFilterHotspotsByPath(t *testing.T) {

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1132,7 +1132,7 @@ func computeFileComplexity(s *store.Store, symbols []index.Symbol) error {
 	return nil
 }
 
-// computeFileFanIn stores per-file blast-radius (distinct cross-file callers)
+// computeFileFanIn stores per-file blast-radius (distinct caller files)
 // under the "files" graph for `snipe hotspots`. FileFanIn keys come straight
 // from symbols.file_path (absolute), so they are relativized here to line up
 // with the cyclo/churn keys. Empty graph → no-op.

--- a/internal/graphmetrics/pagerank.go
+++ b/internal/graphmetrics/pagerank.go
@@ -4,7 +4,8 @@ package graphmetrics
 import "math"
 
 // PageRank computes PageRank scores for all nodes in g using the Brin & Page
-// formulation with dangling-node mass redistribution. Damping is typically 0.85.
+// formulation ("The Anatomy of a Large-Scale Hypertextual Web Search Engine",
+// WWW7 1998) with dangling-node mass redistribution. Damping is typically 0.85.
 // Iteration stops when the L1 delta falls below 1e-6 or maxIter is reached.
 // Returned scores sum to ~1.0.
 func PageRank(g *Graph, damping float64, maxIter int) map[string]float64 {

--- a/internal/index/symbols.go
+++ b/internal/index/symbols.go
@@ -142,7 +142,8 @@ func extractFuncSymbol(pkg *packages.Package, decl *ast.FuncDecl, filePath, pkgP
 	}
 }
 
-// computeCyclo returns the McCabe cyclomatic complexity of a function body.
+// computeCyclo returns the McCabe cyclomatic complexity of a function body
+// (McCabe, "A Complexity Measure", IEEE TSE 1976).
 // 1 + count of decision points (if/for/range/case/comm/&&/||). Body=nil
 // (interface methods, external decls) → 1.
 func computeCyclo(body *ast.BlockStmt) int {

--- a/internal/store/fanin_test.go
+++ b/internal/store/fanin_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dkoosis/snipe/internal/index"
 )
 
-func TestFileFanInCountsCrossFileCallersOnly(t *testing.T) {
+func TestFileFanInCountsDistinctCallerFiles(t *testing.T) {
 	s, err := Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
@@ -17,16 +17,21 @@ func TestFileFanInCountsCrossFileCallersOnly(t *testing.T) {
 	fn := func(id, file string) index.Symbol {
 		return index.Symbol{ID: id, Name: id, Kind: index.KindFunc, FilePath: file}
 	}
+	// a.go is called by two functions in b.go and one in d.go, plus a
+	// same-file caller. Distinct caller FILES = 2 (b.go, d.go); distinct
+	// caller SYMBOLS would be 3. The "want 2" below pins the file semantics.
 	symbols := []index.Symbol{
-		fn("a", "a.go"), // callee — depended on from elsewhere
-		fn("b", "b.go"), // cross-file caller
-		fn("d", "d.go"), // cross-file caller
-		fn("c", "a.go"), // same-file caller (must be excluded)
+		fn("a", "a.go"),  // callee — depended on from elsewhere
+		fn("b1", "b.go"), // cross-file caller #1 in b.go
+		fn("b2", "b.go"), // cross-file caller #2 in b.go (same file as b1)
+		fn("d", "d.go"),  // cross-file caller in d.go
+		fn("c", "a.go"),  // same-file caller (must be excluded)
 	}
 	edges := []index.CallEdge{
-		{CallerID: "b", CalleeID: "a"}, // cross-file → counts
-		{CallerID: "d", CalleeID: "a"}, // cross-file → counts
-		{CallerID: "c", CalleeID: "a"}, // same file (a.go) → excluded
+		{CallerID: "b1", CalleeID: "a"}, // b.go → counts
+		{CallerID: "b2", CalleeID: "a"}, // b.go again → same file, no double-count
+		{CallerID: "d", CalleeID: "a"},  // d.go → counts
+		{CallerID: "c", CalleeID: "a"},  // same file (a.go) → excluded
 	}
 	if err := s.WriteIndex(symbols, nil, edges); err != nil {
 		t.Fatalf("WriteIndex: %v", err)
@@ -37,7 +42,7 @@ func TestFileFanInCountsCrossFileCallersOnly(t *testing.T) {
 		t.Fatalf("FileFanIn: %v", err)
 	}
 	if got := fanIn["a.go"]; got != 2 {
-		t.Errorf("a.go fan-in = %v, want 2 (b, d — not same-file c)", got)
+		t.Errorf("a.go fan-in = %v, want 2 distinct caller files (b.go, d.go — not 3 symbols, not same-file c)", got)
 	}
 	if _, ok := fanIn["b.go"]; ok {
 		t.Errorf("b.go has no incoming cross-file calls, should be absent: %v", fanIn)

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -65,15 +65,16 @@ func (s *Store) WriteGraphMetrics(graphKind, metric string, values map[string]fl
 	return nil
 }
 
-// FileFanIn returns, per file, the number of distinct caller symbols in other
-// files that call into it — a blast-radius proxy for `snipe hotspots`: how
-// much elsewhere depends on this file. Same-file calls are excluded (not
-// external risk) and callers are counted distinctly so repeated calls from one
-// function don't inflate the number. Keys come from symbols.file_path as
-// stored (absolute); the caller relativizes to match the cyclo/churn keys.
+// FileFanIn returns, per file, the number of distinct other files that call
+// into it — afferent coupling at file granularity (Martin's Ca), the
+// blast-radius proxy for `snipe hotspots`: how many files depend on this one.
+// Distinct files, not call sites: a file that calls in from five functions is
+// one dependent unit, so it counts once. Same-file calls are excluded (not
+// external risk). Keys come from symbols.file_path as stored (absolute); the
+// caller relativizes to match the cyclo/churn keys.
 func (s *Store) FileFanIn() (map[string]float64, error) {
 	rows, err := s.db.Query(`
-		SELECT callee.file_path AS f, COUNT(DISTINCT cg.caller_id) AS n
+		SELECT callee.file_path AS f, COUNT(DISTINCT caller.file_path) AS n
 		FROM call_graph cg
 		JOIN symbols caller ON cg.caller_id = caller.id
 		JOIN symbols callee ON cg.callee_id = callee.id


### PR DESCRIPTION
Review follow-up on the crime-scene metrics (#180/#181).

## fan-in semantics (the substantive fix)

`FileFanIn` used `COUNT(DISTINCT caller_id)` — it answered *"how many external functions call into this file?"* But every comment and the column header sell it as blast radius / *"how many files depend on this?"* The doc was at war with the code.

At **file** granularity the grounded metric is Martin's afferent coupling (Ca): **distinct depending components, not call sites**. Henry-Kafura procedure flow (count of call sites) is the right unit for a *procedure* row, not a file-keyed one. Switched to `COUNT(DISTINCT caller.file_path)` — a file that calls in from five functions is one dependent unit.

`fan_in` is a **context column, not folded into the score**, so hotspot rankings are unchanged; only the displayed number and its meaning change. Values refresh on next reindex.

Sanity check after reindex: `internal/output/json.go` → 94 dependents (top hotspot); `cmd/index.go` → 2 despite being huge (nothing imports a `cmd/` entrypoint). The `internal/*` high-in vs `cmd/*` near-zero asymmetry is the file-count semantics behaving correctly.

Test strengthened: `fanin_test` now puts two callers in the same file, so it discriminates file-count (2) from symbol-count (3) — the old test had callers in separate files and couldn't tell the interpretations apart.

## algorithm citations (docs only)

Brought `computeCyclo` (McCabe, IEEE TSE 1976) and `PageRank` (Brin & Page, WWW7 1998) up to the author+year+title standard `cognitive.go` already set.

Closes: none
