### PR TITLE
fix(gitchurn): count authors by email, not display name

### DIFF
--- a/internal/gitchurn/gitchurn.go
+++ b/internal/gitchurn/gitchurn.go
@@ -29,7 +29,11 @@ const halfLifeDays = 180.0
 
 // commitSentinel (SOH) prefixes each commit-header line in the git log
 // stream so it can never collide with a file path. It is followed by the
-// author date and author name; subsequent non-empty lines are file paths.
+// author date and author email; subsequent non-empty lines are file paths.
+// Email (%aE) keys author identity rather than display name (%aN): the same
+// person often commits under several names (user.name drift), which would
+// inflate the distinct-author count. %aE also honors .mailmap, so the reverse
+// — one person, several emails — coalesces on repos that maintain one.
 const commitSentinel = "\x01"
 
 // FileChurn is the git change-frequency record for one file, keyed by a
@@ -37,7 +41,7 @@ const commitSentinel = "\x01"
 type FileChurn struct {
 	Path        string  // repo-relative path (matches symbols.file_path)
 	Commits     int     // non-merge commits touching the file (CodeScene revisions)
-	Authors     int     // distinct commit authors (bus-factor / knowledge-map signal)
+	Authors     int     // distinct commit authors by email (bus-factor / knowledge-map signal)
 	FirstSeen   string  // YYYY-MM-DD of the earliest touching commit
 	LastChanged string  // YYYY-MM-DD of the latest touching commit
 	Score       float64 // recency-weighted churn (see halfLifeDays)
@@ -63,7 +67,7 @@ func Walk(repoRoot string) ([]FileChurn, error) {
 	// to Go sources, which is all snipe indexes.
 	cmd := exec.Command("git", "-C", repoRoot, "log",
 		"--no-merges", "--no-renames",
-		"--pretty=tformat:"+commitSentinel+"%aI\t%aN",
+		"--pretty=tformat:"+commitSentinel+"%aI\t%aE",
 		"--name-only", "--", "*.go")
 	out, err := cmd.Output()
 	if err != nil {
@@ -122,10 +126,10 @@ func parseLog(stream string) []FileChurn {
 	byPath := make(map[string]*acc)
 
 	var (
-		curDate time.Time
-		curAuth string
-		haveCur bool
-		refDate time.Time // newest commit date, set from the first header
+		curDate  time.Time
+		curEmail string
+		haveCur  bool
+		refDate  time.Time // newest commit date, set from the first header
 	)
 
 	sc := bufio.NewScanner(strings.NewReader(stream))
@@ -134,13 +138,13 @@ func parseLog(stream string) []FileChurn {
 		line := sc.Text()
 		if strings.HasPrefix(line, commitSentinel) {
 			rest := line[len(commitSentinel):]
-			iso, author, _ := strings.Cut(rest, "\t")
+			iso, email, _ := strings.Cut(rest, "\t")
 			t, err := time.Parse(time.RFC3339, iso)
 			if err != nil {
 				haveCur = false
 				continue
 			}
-			curDate, curAuth, haveCur = t, author, true
+			curDate, curEmail, haveCur = t, email, true
 			if refDate.IsZero() {
 				refDate = t
 			}
@@ -156,7 +160,7 @@ func parseLog(stream string) []FileChurn {
 			byPath[path] = a
 		}
 		a.commits++
-		a.authors[curAuth] = struct{}{}
+		a.authors[curEmail] = struct{}{}
 		if curDate.Before(a.first) {
 			a.first = curDate
 		}

--- a/internal/gitchurn/gitchurn_test.go
+++ b/internal/gitchurn/gitchurn_test.go
@@ -112,6 +112,53 @@ func TestWalkCountsCommitsAndAuthors(t *testing.T) {
 	}
 }
 
+// commitNameEmail commits one file with an explicit, decoupled author name and
+// email — used to prove author identity keys on email, not display name.
+func commitNameEmail(t *testing.T, dir, date, name, email, file, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	add := exec.Command("git", "add", "-A")
+	add.Dir = dir
+	if out, err := add.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	env := []string{
+		"GIT_AUTHOR_DATE=" + date, "GIT_COMMITTER_DATE=" + date,
+		"GIT_AUTHOR_NAME=" + name, "GIT_AUTHOR_EMAIL=" + email,
+		"GIT_COMMITTER_NAME=" + name, "GIT_COMMITTER_EMAIL=" + email,
+	}
+	c := exec.Command("git", "commit", "-q", "-m", "c")
+	c.Dir = dir
+	c.Env = append(os.Environ(), env...)
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+}
+
+// TestWalkCountsAuthorsByEmailNotName guards the bus-factor signal against
+// user.name drift: one person committing under two display names but a single
+// email is one author, not two. (Observed live: "David Koosis" and
+// "dkoosis@gmail.com" both at <dkoosis@gmail.com> made every file read auth=2.)
+func TestWalkCountsAuthorsByEmailNotName(t *testing.T) {
+	dir := gitRepo(t)
+	commitNameEmail(t, dir, "2026-01-01T00:00:00Z", "David Koosis", "dk@example.com", "f.go", "package p\nvar A int\n")
+	commitNameEmail(t, dir, "2026-02-01T00:00:00Z", "dk@example.com", "dk@example.com", "f.go", "package p\nvar A, B int\n")
+
+	rows, err := Walk(dir)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	f := byPath(rows)["f.go"]
+	if f.Commits != 2 {
+		t.Errorf("f.go commits = %d, want 2", f.Commits)
+	}
+	if f.Authors != 1 {
+		t.Errorf("f.go authors = %d, want 1 (same email, two display names)", f.Authors)
+	}
+}
+
 func TestWalkIgnoresNonGoAndMerges(t *testing.T) {
 	dir := gitRepo(t)
 	commit(t, dir, "2026-01-01T00:00:00Z", "alice", map[string]string{


### PR DESCRIPTION
The bus-factor column (auth) read 2 on every file. Root cause was identity, not parsing: gitchurn deduped authors by display name (%aN), and dk had committed under two names at one email — every file looked like it had 2 authors.

Fix: dedup by email (%aE), which is stable under user.name drift and honors .mailmap for the reverse case (one person, many emails). Bus-factor stays correct on multi-author repos.

Test: TestWalkCountsAuthorsByEmailNotName — two names, one email → 1 author. Verified live: every hotspot row now auth=1.

Closes: none
