### PR TITLE
fix: /team backlog wave 1 — test flake, N+1 batch, lock hardening, SQL idiom

### DIFF
--- a/cmd/types.go
+++ b/cmd/types.go
@@ -265,7 +265,10 @@ func runTypesForPackage(w *output.Writer, s interface {
 	results := make([]output.TypesResult, 0, len(typeSymbols))
 	for i := range typeSymbols {
 		sym := &typeSymbols[i]
-		info, err := query.GetTypeInfo(s.DB(), sym.ID)
+		// sym is already loaded from FindPackageSymbols above, so use the
+		// *SymbolRow entry point directly instead of re-running LookupByID
+		// per symbol (N+1 avoidance).
+		info, err := query.GetTypeInfoFromSymbol(s.DB(), sym)
 		if err != nil {
 			continue
 		}

--- a/internal/kg/hints_test.go
+++ b/internal/kg/hints_test.go
@@ -90,7 +90,26 @@ esac
 				t.Setenv("PATH", t.TempDir())
 			}
 
-			got := kg.GetHints(context.Background(), tc.cfg)
+			// GetHints applies a 2s per-query timeout (up to 3 queries in the
+			// success case). Under `go test ./...` with GOMAXPROCS saturated by
+			// concurrent packages, the shim subprocess can be scheduled late
+			// enough to blow that budget even though it does real work in
+			// milliseconds. Retry with a generous overall ceiling instead of
+			// asserting on the first attempt, so the result is load-independent
+			// rather than timing-sensitive.
+			const (
+				retryBudget = 10 * time.Second
+				retryPoll   = 100 * time.Millisecond
+			)
+			var got []kg.Hint
+			deadline := time.Now().Add(retryBudget)
+			for {
+				got = kg.GetHints(context.Background(), tc.cfg)
+				if cmp.Diff(tc.want, got) == "" || time.Now().After(deadline) {
+					break
+				}
+				time.Sleep(retryPoll)
+			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatalf("hints mismatch (-want +got):\n%s", diff)

--- a/internal/query/types.go
+++ b/internal/query/types.go
@@ -53,7 +53,11 @@ type ImplementsInfo struct {
 	Note       string   `json:"note,omitempty"`
 }
 
-// GetTypeInfo retrieves type information for a symbol.
+// GetTypeInfo retrieves type information for a symbol by ID.
+// It performs a LookupByID then delegates to GetTypeInfoFromSymbol. Callers
+// that already hold the *SymbolRow (e.g. from a prior FindPackageSymbols/
+// LookupByName call) should call GetTypeInfoFromSymbol directly to avoid the
+// redundant lookup.
 func GetTypeInfo(db *sql.DB, symbolID string) (*TypeInfo, error) {
 	sym, err := LookupByID(db, symbolID)
 	if err != nil {
@@ -61,6 +65,18 @@ func GetTypeInfo(db *sql.DB, symbolID string) (*TypeInfo, error) {
 	}
 	if sym == nil {
 		return nil, fmt.Errorf("symbol not found: %s", symbolID)
+	}
+
+	return GetTypeInfoFromSymbol(db, sym)
+}
+
+// GetTypeInfoFromSymbol retrieves type information for an already-loaded
+// symbol row, skipping the LookupByID that GetTypeInfo performs. Use this
+// when the *SymbolRow is already in hand (e.g. from FindPackageSymbols or
+// LookupByName) to avoid an N+1 lookup pattern.
+func GetTypeInfoFromSymbol(db *sql.DB, sym *SymbolRow) (*TypeInfo, error) {
+	if sym == nil {
+		return nil, fmt.Errorf("symbol is nil")
 	}
 
 	// Only struct, interface, type alias kinds are valid
@@ -84,14 +100,14 @@ func GetTypeInfo(db *sql.DB, symbolID string) (*TypeInfo, error) {
 	info.Methods = methods
 
 	// Get embeds (from refs where the reference is in this type's definition)
-	embeds, err := getEmbedsForType(db, symbolID, sym.FilePath, sym.LineStart, sym.LineEnd)
+	embeds, err := getEmbedsForType(db, sym.ID, sym.FilePath, sym.LineStart, sym.LineEnd)
 	if err != nil {
 		return nil, fmt.Errorf("get embeds for %s: %w", sym.Name, err)
 	}
 	info.Embeds = embeds
 
 	// Get fields (from symbols with kind=field in this type)
-	fields, err := getFieldsForType(db, symbolID, sym.FilePath, sym.LineStart, sym.LineEnd)
+	fields, err := getFieldsForType(db, sym.ID, sym.FilePath, sym.LineStart, sym.LineEnd)
 	if err != nil {
 		return nil, fmt.Errorf("get fields for %s: %w", sym.Name, err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -198,17 +198,25 @@ func lockHeldByDeadProcess(lockPath string) (stale bool, observed string) {
 		return true, ""
 	}
 	pid, err := strconv.Atoi(observed)
-	if err != nil {
-		// Unparseable — treat as stale.
+	if err != nil || pid <= 0 {
+		// Unparseable, or a non-positive PID that only a corrupt/hand-edited
+		// lock could hold (real writers store os.Getpid(), always > 0). Signal(0)
+		// to 0 or a negative value targets a process group on Unix and would
+		// read as alive, wedging the lock forever — treat as stale instead.
 		return true, observed
 	}
 
 	// On Unix, os.FindProcess never fails for any int — liveness is decided
 	// below by Signal(0). On Windows, FindProcess itself opens a process
 	// handle (OpenProcess) and fails when the PID doesn't resolve to a live
-	// process, so a lookup error there means the holder is dead.
+	// process, so a lookup error there means the holder is dead — EXCEPT for a
+	// permission error (ACCESS_DENIED), which means the PID resolves to a live
+	// process we simply can't inspect (e.g. an elevated holder). Don't reap it.
 	proc, err := os.FindProcess(pid)
 	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return false, observed
+		}
 		return true, observed
 	}
 	defer func() { _ = proc.Release() }() // release the Windows handle FindProcess opened; no-op on Unix

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -180,6 +181,15 @@ func AcquireLock(dbPath string) error {
 func lockHeldByDeadProcess(lockPath string) (stale bool, observed string) {
 	data, err := os.ReadFile(lockPath) // #nosec G304
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// TOCTOU: the lock was removed between the caller's os.Stat and
+			// this read (e.g. the holder released it). There is no lock to
+			// be stale — report stale so IsIndexing/reap treat it as gone,
+			// not as an in-progress hold.
+			return true, ""
+		}
+		// Some other read error (permissions, I/O) — we can't tell either
+		// way; don't reap a lock we couldn't inspect.
 		return false, ""
 	}
 	observed = strings.TrimSpace(string(data))
@@ -192,16 +202,43 @@ func lockHeldByDeadProcess(lockPath string) (stale bool, observed string) {
 		// Unparseable — treat as stale.
 		return true, observed
 	}
-	// os.FindProcess on Unix never fails for any int; the actual liveness
-	// check is Signal(0), which returns ESRCH for dead PIDs.
-	proc, _ := os.FindProcess(pid)
-	if proc == nil {
+
+	// On Unix, os.FindProcess never fails for any int — liveness is decided
+	// below by Signal(0). On Windows, FindProcess itself opens a process
+	// handle (OpenProcess) and fails when the PID doesn't resolve to a live
+	// process, so a lookup error there means the holder is dead.
+	proc, err := os.FindProcess(pid)
+	if err != nil {
 		return true, observed
 	}
-	if err := proc.Signal(syscall.Signal(0)); err != nil {
+	defer func() { _ = proc.Release() }() // release the Windows handle FindProcess opened; no-op on Unix
+
+	sigErr := proc.Signal(syscall.Signal(0))
+	switch {
+	case sigErr == nil:
+		// Holder alive.
+		return false, observed
+	case errors.Is(sigErr, os.ErrProcessDone) || errors.Is(sigErr, syscall.ESRCH):
+		// Unix: no such process — holder is dead. Go's os package translates
+		// the raw ESRCH errno from Kill into the os.ErrProcessDone sentinel
+		// before returning it, so that's the one that actually matches in
+		// practice; syscall.ESRCH is kept as a belt-and-suspenders check.
 		return true, observed
+	case errors.Is(sigErr, syscall.EPERM):
+		// Unix: process exists but is owned by another user, so Signal(0)
+		// is denied. It's alive — don't reap another user's live lock.
+		return false, observed
+	case runtime.GOOS == "windows":
+		// Windows: Signal(0) isn't a supported signal type and always
+		// errors here, live holder or not. FindProcess above already
+		// confirmed the PID resolves to a real process, so treat as alive.
+		return false, observed
+	default:
+		// Unknown error on a platform/signal combination we don't
+		// specifically handle — err toward "alive" so we never reap a lock
+		// we can't positively confirm is dead.
+		return false, observed
 	}
-	return false, observed
 }
 
 // tryRemoveStaleLock reaps the lock at lockPath when its holder is dead, removing

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -590,7 +590,7 @@ func (s *Store) WriteIndexIncremental(
 	// symbols whose defining files *were* changed, where the symbol no
 	// longer exists. Without this, orphaned_refs grows monotonically over
 	// many incremental reindexes — which was the user-visible symptom.
-	if _, err := tx.Exec(`DELETE FROM refs WHERE symbol_id NOT IN (SELECT id FROM symbols)`); err != nil {
+	if _, err := tx.Exec(`DELETE FROM refs WHERE NOT EXISTS (SELECT 1 FROM symbols WHERE symbols.id = refs.symbol_id)`); err != nil {
 		return nil, fmt.Errorf("sweep orphaned refs: %w", err)
 	}
 
@@ -600,7 +600,7 @@ func (s *Store) WriteIndexIncremental(
 	// pointing at a now-deleted symbol id. callers/callees/impact INNER-JOIN
 	// call_graph→symbols and silently drop these, so they accumulate
 	// monotonically and under-report the graph (snipe-bzw).
-	if _, err := tx.Exec(`DELETE FROM call_graph WHERE caller_id NOT IN (SELECT id FROM symbols) OR callee_id NOT IN (SELECT id FROM symbols)`); err != nil {
+	if _, err := tx.Exec(`DELETE FROM call_graph WHERE NOT EXISTS (SELECT 1 FROM symbols WHERE symbols.id = call_graph.caller_id) OR NOT EXISTS (SELECT 1 FROM symbols WHERE symbols.id = call_graph.callee_id)`); err != nil {
 		return nil, fmt.Errorf("sweep orphaned call edges: %w", err)
 	}
 
@@ -608,7 +608,7 @@ func (s *Store) WriteIndexIncremental(
 	// counters trailing the on-disk schema, and concurrent readers can't see
 	// orphaned_refs and incremental_count from different generations.
 	var orphanCount int
-	if err := tx.QueryRow(`SELECT COUNT(*) FROM refs WHERE symbol_id NOT IN (SELECT id FROM symbols)`).Scan(&orphanCount); err != nil {
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM refs WHERE NOT EXISTS (SELECT 1 FROM symbols WHERE symbols.id = refs.symbol_id)`).Scan(&orphanCount); err != nil {
 		return nil, fmt.Errorf("count orphaned refs: %w", err)
 	}
 	if _, err := tx.Exec(`INSERT OR REPLACE INTO meta (key, value) VALUES ('orphaned_refs', ?)`, fmt.Sprintf("%d", orphanCount)); err != nil {


### PR DESCRIPTION
Batched wave from `/team backlog` (one commit per bead, verified together via `make check` — vet/lint/tests all green).

## Commits
- **sn-mo9** `2a1c080` — `fix(kg)`: make GetHints orca-shim test timeout load-independent. Was flaking under full-suite parallel load (2s×3 timeout blows when GOMAXPROCS saturated). Test-only.
- **sn-btq** `bff668c` — `perf(types)`: add `*SymbolRow` entry point in internal/query, drop redundant per-symbol `LookupByID` N+1 in `cmd/types.go`. Additive — `GetTypeInfo(id)` delegates, existing callers unchanged.
- **sn-77t** `edf6096` — `fix(store)`: harden `lockHeldByDeadProcess` — `fs.ErrNotExist`→stale, release process handle, distinguish EPERM/Windows-unsupported (alive) from ESRCH (dead). From gemini review on #172.
- **sn-053** — `chore(store)`: convert refs + call_graph orphan sweeps (and the orphan COUNT) from `NOT IN` to `NOT EXISTS`. Idiom cleanup for consistency; no behavior change (ids non-nullable, PK). From gemini review on #169.

## Verification
`make check` green (vet, golangci-lint 0 issues, `go test ./...` pass).

Closes: sn-btq, sn-mo9, sn-77t, sn-053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of hint retrieval under load by retrying until results match expectations.
  * Improved type detail fetching for package-discovered symbols by reusing already-resolved symbol data.
  * Enhanced index lock staleness detection for safer cleanup across platforms, including handling disappearing locks.
  * Improved incremental reindex orphan cleanup to more accurately remove dangling refs and call-graph edges.
* **Tests**
  * Updated hint-related test behavior to be resilient to timing variability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->