### PR TITLE
feat(roles): --full role coverage, --key-symbols cap, concurrency/security_boundary RiskFlags (sn-zd2)

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -27,6 +27,7 @@ type ContextCmd struct {
 	OutputNug     bool `name:"output-nug" help:"Output as Orca nugget YAML (for save_nug)"`
 	Conventions   bool `help:"Detect coding conventions"`
 	SchemaVersion bool `name:"schema-version" help:"Print the context output schema version and exit"`
+	KeySymbols    int  `name:"key-symbols" default:"15" help:"Cap ranked key symbols in boot output (orient mode)"`
 }
 
 func (c *ContextCmd) Run() error {
@@ -42,6 +43,7 @@ func (c *ContextCmd) Run() error {
 	contextOutputNug = c.OutputNug
 	contextConventions = c.Conventions
 	contextSchemaVersion = c.SchemaVersion
+	contextKeySymbols = c.KeySymbols
 	return runContext(argsOf(c.Path))
 }
 

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -20,6 +20,7 @@ var (
 	contextOutputNug     bool
 	contextConventions   bool
 	contextSchemaVersion bool
+	contextKeySymbols    int
 )
 
 func runContext(args []string) error {
@@ -65,9 +66,10 @@ func runContext(args []string) error {
 
 	// Generate context
 	cfg := context.GenerateConfig{
-		RepoRoot: projectRoot,
-		DB:       s.DB(),
-		Full:     contextFull,
+		RepoRoot:   projectRoot,
+		DB:         s.DB(),
+		Full:       contextFull,
+		KeySymbols: contextKeySymbols,
 	}
 
 	// --full and --conventions have no claudish text formatter; they default

--- a/cmd/testdata/help/context.golden
+++ b/cmd/testdata/help/context.golden
@@ -28,3 +28,4 @@ Flags:
       --output-nug          Output as Orca nugget YAML (for save_nug)
       --conventions         Detect coding conventions
       --schema-version      Print the context output schema version and exit
+      --key-symbols=15      Cap ranked key symbols in boot output (orient mode)

--- a/internal/context/generate.go
+++ b/internal/context/generate.go
@@ -28,7 +28,13 @@ type GenerateConfig struct {
 	Full bool
 	// MaxSymbols is the maximum number of symbols to include per category (default: 20)
 	MaxSymbols int
+	// KeySymbols caps the ranked key-symbol list in boot output (default: 15).
+	// Dedicated to boot; does not overload the global --limit (D2).
+	KeySymbols int
 }
+
+// defaultKeySymbols is the boot key-symbol cap when KeySymbols is unset (<= 0).
+const defaultKeySymbols = 15
 
 // Generate creates a ProjectContext from the snipe index.
 func Generate(cfg GenerateConfig) (*ProjectContext, error) {
@@ -58,8 +64,13 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 	// Get entry points (cmd/* main.go files) - backward compatible
 	entryPoints := getEntryPoints(cfg.DB, cfg.RepoRoot)
 
-	// Get top symbols by role-weighted ranking
-	rankedSymbols, err := RankSymbols(cfg.DB, cfg.RepoRoot, 15)
+	// Get top symbols by role-weighted ranking. The cap is configurable via
+	// --key-symbols (cfg.KeySymbols); default 15 when unset.
+	keyN := cfg.KeySymbols
+	if keyN <= 0 {
+		keyN = defaultKeySymbols
+	}
+	rankedSymbols, err := RankSymbols(cfg.DB, cfg.RepoRoot, keyN)
 	if err != nil {
 		// Fall back to ref-count based ranking if ranking fails
 		rankedSymbols = nil
@@ -69,7 +80,7 @@ func GenerateBoot(cfg GenerateConfig) (*BootContext, error) {
 	keySymbols := rankedToSymbolRefs(rankedSymbols, cfg.RepoRoot)
 	if len(keySymbols) == 0 {
 		// Fall back to ref-count based if ranking produced no results
-		keySymbols = getKeySymbolsByRefCount(cfg.DB, cfg.RepoRoot, 10)
+		keySymbols = getKeySymbolsByRefCount(cfg.DB, cfg.RepoRoot, keyN)
 	}
 
 	// Load session for active work context
@@ -285,12 +296,14 @@ func generateBootViews(db *sql.DB, repoRoot string) *BootViews {
 // rankedToSymbolRefs converts ranked symbols to SymbolRef with role and purpose.
 func rankedToSymbolRefs(ranked []RankedSymbol, repoRoot string) []SymbolRef {
 	refs := make([]SymbolRef, 0, len(ranked))
-	for _, rs := range ranked {
+	for i := range ranked {
+		rs := &ranked[i]
 		ref := SymbolRef{
-			Name: rs.Name,
-			File: strings.TrimPrefix(rs.File, repoRoot+"/"),
-			Line: rs.Line,
-			Role: rs.Role,
+			Name:      rs.Name,
+			File:      strings.TrimPrefix(rs.File, repoRoot+"/"),
+			Line:      rs.Line,
+			Role:      rs.Role,
+			RiskFlags: rs.RiskFlags,
 		}
 		if rs.Doc != "" {
 			ref.Purpose = ExtractFirstSentence(rs.Doc)
@@ -890,8 +903,13 @@ func generateSymbols(db *sql.DB, repoRoot string, full bool, maxSymbols int) Sym
 		limit = 1000
 	}
 
-	syms.Types = querySymbolRefsByKind(db, repoRoot, "('type', 'interface', 'struct')", limit)
-	syms.Functions = querySymbolRefsByKind(db, repoRoot, "('func', 'method')", limit)
+	// Build the role/risk map once (batch) so every --full symbol carries its
+	// architectural role and orthogonal risk flags — avoids the N+1 that a
+	// per-row InferRoleForSymbol call would reintroduce (sn-zd2 defect 1).
+	roleMap, riskMap := buildRoleRiskMaps(db, repoRoot)
+
+	syms.Types = querySymbolRefsByKind(db, repoRoot, "('type', 'interface', 'struct')", limit, roleMap, riskMap)
+	syms.Functions = querySymbolRefsByKind(db, repoRoot, "('func', 'method')", limit, roleMap, riskMap)
 
 	// Get extension points: high-centrality symbols suitable for adding new functionality
 	syms.ExtensionPoints = getExtensionPoints(db, repoRoot)
@@ -899,12 +917,32 @@ func generateSymbols(db *sql.DB, repoRoot string, full bool, maxSymbols int) Sym
 	return syms
 }
 
-// querySymbolRefsByKind returns exported symbols of given kinds, ranked by reference count.
+// buildRoleRiskMaps runs role inference once and returns symbol-ID → role and
+// symbol-ID → risk-flags lookups. Both are empty (never nil-panic) if inference
+// fails, letting callers fall back to a visibility-based default.
+func buildRoleRiskMaps(db *sql.DB, repoRoot string) (map[string]Role, map[string][]string) {
+	roleMap := make(map[string]Role)
+	riskMap := make(map[string][]string)
+	symbolRoles, err := InferRoles(db, repoRoot)
+	if err != nil {
+		return roleMap, riskMap
+	}
+	for _, sr := range symbolRoles {
+		roleMap[sr.SymbolID] = sr.Role
+		if len(sr.RiskFlags) > 0 {
+			riskMap[sr.SymbolID] = sr.RiskFlags
+		}
+	}
+	return roleMap, riskMap
+}
+
+// querySymbolRefsByKind returns exported symbols of given kinds, ranked by reference count,
+// stamping each with its inferred role and any risk flags from the pre-built maps.
 // The kindClause is a SQL IN expression like "('func', 'method')".
-func querySymbolRefsByKind(db *sql.DB, repoRoot, kindClause string, limit int) []SymbolRef {
+func querySymbolRefsByKind(db *sql.DB, repoRoot, kindClause string, limit int, roleMap map[string]Role, riskMap map[string][]string) []SymbolRef {
 	// #nosec G201 -- kindClause is a hardcoded literal from caller
 	rows, err := db.Query(`
-		SELECT s.name, s.file_path, s.line_start, COUNT(r.id) as ref_count
+		SELECT s.id, s.name, s.file_path, s.line_start, COUNT(r.id) as ref_count
 		FROM symbols s
 		LEFT JOIN refs r ON s.id = r.symbol_id
 		WHERE s.kind IN `+kindClause+`
@@ -922,12 +960,23 @@ func querySymbolRefsByKind(db *sql.DB, repoRoot, kindClause string, limit int) [
 	var refs []SymbolRef
 	for rows.Next() {
 		var ref SymbolRef
-		var fullPath string
+		var id, fullPath string
 		var refCount int
-		if err := rows.Scan(&ref.Name, &fullPath, &ref.Line, &refCount); err != nil {
+		if err := rows.Scan(&id, &ref.Name, &fullPath, &ref.Line, &refCount); err != nil {
 			continue
 		}
 		ref.File = strings.TrimPrefix(fullPath, repoRoot+"/")
+		if role, ok := roleMap[id]; ok {
+			ref.Role = string(role)
+		} else {
+			// Not in the role map (e.g. test-file symbols InferRoles skips): all
+			// rows here are exported (name GLOB '[A-Z]*'), so default to api_boundary.
+			// Guarantees a non-empty role for every --full row (defect 1 guard).
+			ref.Role = string(RoleAPIBoundary)
+		}
+		if flags, ok := riskMap[id]; ok {
+			ref.RiskFlags = flags
+		}
 		refs = append(refs, ref)
 	}
 	return refs

--- a/internal/context/ranking.go
+++ b/internal/context/ranking.go
@@ -20,31 +20,57 @@ var roleWeights = map[Role]float64{
 	RoleInternal:    1,
 }
 
-// RankedSymbol represents a symbol with its calculated priority score.
-type RankedSymbol struct {
-	ID       string  `json:"id"`
-	Name     string  `json:"name"`
-	File     string  `json:"file"`
-	Line     int     `json:"line"`
-	RefCount int     `json:"ref_count"`
-	Role     string  `json:"role"`
-	Priority float64 `json:"priority"`
-	Doc      string  `json:"doc,omitempty"`
+// riskWeights boost symbols carrying a risk flag so architecturally significant
+// concurrency/security code surfaces in ranked boot output even when its
+// structural role is weak (e.g. an unexported goroutine helper). Risk is
+// orthogonal to Role (sn-zd2 decision A): the effective weight is the max of the
+// structural role weight and any risk weight, not a product.
+var riskWeights = map[string]float64{
+	RiskSecurityBoundary: 6,
+	RiskConcurrency:      5,
 }
 
-// CalculatePriority computes the priority score for a symbol.
-// Formula: priority = (log(ref_count) + 1) * role_weight
-// This balances reference count with architectural importance.
+// RankedSymbol represents a symbol with its calculated priority score.
+type RankedSymbol struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	File      string   `json:"file"`
+	Line      int      `json:"line"`
+	RefCount  int      `json:"ref_count"`
+	Role      string   `json:"role"`
+	RiskFlags []string `json:"risk_flags,omitempty"`
+	Priority  float64  `json:"priority"`
+	Doc       string   `json:"doc,omitempty"`
+}
+
+// CalculatePriority computes the priority score for a symbol from its structural
+// role alone. Formula: priority = (log(ref_count) + 1) * role_weight.
 func CalculatePriority(refCount int, role Role) float64 {
+	return calcPriority(refCount, effectiveWeight(role, nil))
+}
+
+// calcPriority balances reference count with a supplied architectural weight.
+// Uses log(ref_count + 1) to handle zero refs and dampen high ref counts;
+// adding 1 ensures log is never negative for ref_count >= 0.
+func calcPriority(refCount int, weight float64) float64 {
+	logRefs := math.Log(float64(refCount) + 1)
+	return (logRefs + 1) * weight
+}
+
+// effectiveWeight returns the max of a symbol's structural-role weight and any
+// risk-flag weight. Risk is orthogonal to role (decision A): a security_boundary
+// internal helper is boosted to the security weight without compounding.
+func effectiveWeight(role Role, riskFlags []string) float64 {
 	weight, ok := roleWeights[role]
 	if !ok {
 		weight = 1 // Default to internal weight
 	}
-
-	// Use log(ref_count + 1) to handle zero refs and dampen high ref counts
-	// Adding 1 ensures log is never negative for ref_count >= 0
-	logRefs := math.Log(float64(refCount) + 1)
-	return (logRefs + 1) * weight
+	for _, f := range riskFlags {
+		if rw := riskWeights[f]; rw > weight {
+			weight = rw
+		}
+	}
+	return weight
 }
 
 // RankSymbols queries symbols from the database, infers their roles,
@@ -61,10 +87,14 @@ func RankSymbols(db *sql.DB, repoRoot string, limit int) ([]RankedSymbol, error)
 		return nil, err
 	}
 
-	// Build role lookup map by symbol ID for O(1) access
+	// Build role + risk lookup maps by symbol ID for O(1) access
 	roleMap := make(map[string]Role, len(symbolRoles))
+	riskMap := make(map[string][]string, len(symbolRoles))
 	for _, sr := range symbolRoles {
 		roleMap[sr.SymbolID] = sr.Role
+		if len(sr.RiskFlags) > 0 {
+			riskMap[sr.SymbolID] = sr.RiskFlags
+		}
 	}
 
 	// Step 2: Query all symbols with their ref counts in a single batch query
@@ -111,7 +141,8 @@ func RankSymbols(db *sql.DB, repoRoot string, limit int) ([]RankedSymbol, error)
 			}
 		}
 		rs.Role = string(role)
-		rs.Priority = CalculatePriority(rs.RefCount, role)
+		rs.RiskFlags = riskMap[rs.ID]
+		rs.Priority = calcPriority(rs.RefCount, effectiveWeight(role, rs.RiskFlags))
 
 		results = append(results, rs)
 	}
@@ -140,16 +171,22 @@ func RankSymbols(db *sql.DB, repoRoot string, limit int) ([]RankedSymbol, error)
 
 	// Step 5: Enforce per-package diversity — no single package dominates key symbols.
 	// Cap at 3 symbols per package directory to ensure architectural breadth.
+	// Risk-flagged symbols (concurrency/security_boundary) are exempt: they're
+	// architecturally significant and the cap would otherwise starve them to 0 on
+	// large repos even when detected (sn-zd2 step 5).
 	const maxPerPackage = 3
 	pkgCount := make(map[string]int)
 	diverse := make([]RankedSymbol, 0, len(results))
-	for _, rs := range results {
-		pkg := packageDir(rs.File, repoRoot)
-		if pkgCount[pkg] >= maxPerPackage {
-			continue
+	for i := range results {
+		rs := &results[i]
+		if len(rs.RiskFlags) == 0 {
+			pkg := packageDir(rs.File, repoRoot)
+			if pkgCount[pkg] >= maxPerPackage {
+				continue
+			}
+			pkgCount[pkg]++
 		}
-		pkgCount[pkg]++
-		diverse = append(diverse, rs)
+		diverse = append(diverse, *rs)
 	}
 	results = diverse
 

--- a/internal/context/roles.go
+++ b/internal/context/roles.go
@@ -29,6 +29,18 @@ const (
 	RoleInternal Role = "internal"
 )
 
+// Risk classes are orthogonal to Role (structural). A symbol may carry zero or
+// more risk flags in addition to its single structural Role (sn-zd2, decision A).
+const (
+	// RiskConcurrency flags a symbol that touches goroutine/channel/sync
+	// machinery — a channel-typed signature or a sync-primitive call site.
+	RiskConcurrency = "concurrency"
+	// RiskSecurityBoundary flags a symbol that crosses a security boundary —
+	// spawns external processes (os/exec), disables TLS verification, or stands
+	// up a network server.
+	RiskSecurityBoundary = "security_boundary"
+)
+
 // Symbol kind constants used for role inference.
 const (
 	kindFunc      = "func"
@@ -60,6 +72,7 @@ type SymbolRole struct {
 	SymbolID   string     `json:"symbol_id"`
 	Name       string     `json:"name"`
 	Role       Role       `json:"role"`
+	RiskFlags  []string   `json:"risk_flags,omitempty"`
 	Visibility Visibility `json:"visibility"`
 	PkgPath    string     `json:"pkg_path,omitempty"`
 }
@@ -122,6 +135,9 @@ func InferRoles(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
 		switch s.kind {
 		case kindFunc, kindMethod:
 			role = inferRole(db, s.id, s.name, s.kind, s.signature.String, s.pkgPath.String)
+			// Risk classes are orthogonal to structural role and accumulate
+			// independently (funcs/methods only — the heuristics are call/signature based).
+			sr.RiskFlags = detectRiskFlags(db, s.id, s.signature.String, s.filePath)
 		case kindStruct, kindInterface, kindType:
 			role = inferRoleForType(db, s.id, s.name, s.pkgPath.String)
 		default:
@@ -422,6 +438,161 @@ func inferRoleForType(_ *sql.DB, _, name, pkgPath string) Role {
 		return RoleAPIBoundary
 	}
 	return RoleInternal
+}
+
+// detectRiskFlags returns the risk classes a func/method carries, orthogonal to
+// its structural Role. Detection keys off signals that already exist in the index
+// (signature, imports table, refs.ast_ctx call attribution) — no indexer change.
+//
+// Recall caveat (sn-zd2 / follow-up sn-hmz): the `go func` / goroutine-spawn case
+// is NOT detectable here because `go` statements and channel ops aren't emitted as
+// refs, calls, or signature tokens. Concurrency recall is capped to channel-typed
+// signatures and sync-primitive call sites until the indexer emits a `go` signal.
+func detectRiskFlags(db *sql.DB, symbolID, signature, filePath string) []string {
+	var flags []string
+	if isConcurrency(db, symbolID, signature, filePath) {
+		flags = append(flags, RiskConcurrency)
+	}
+	if isSecurityBoundary(db, symbolID, filePath) {
+		flags = append(flags, RiskSecurityBoundary)
+	}
+	return flags
+}
+
+// concurrencyCalls are sync/atomic primitive call names that, co-signalled with a
+// sync or sync/atomic import in the same file, indicate real concurrency handling.
+var concurrencyCallCtxs = []string{
+	"call:Lock", "call:Unlock", "call:RLock", "call:RUnlock",
+	"call:Wait", "call:Do", "call:Add", "call:Done",
+	"call:Store", "call:Load",
+}
+
+// isConcurrency reports whether a symbol handles concurrency:
+//  1. its signature declares a channel type ("chan T", "chan<- T", "<-chan T"), or
+//  2. its file imports sync/sync/atomic AND an enclosed call attributes to a sync
+//     primitive (Lock/Unlock/Wait/Do/Add/Store/Load/...).
+func isConcurrency(db *sql.DB, symbolID, signature, filePath string) bool {
+	if hasChannelType(signature) {
+		return true
+	}
+	if !fileImportsAny(db, filePath, "sync", "sync/atomic") {
+		return false
+	}
+	return enclosedCallCtx(db, symbolID, concurrencyCallCtxs)
+}
+
+// execCalls are os/exec entry points that spawn external processes.
+var execCallCtxs = []string{
+	"call:Command", "call:CommandContext",
+	"call:Run", "call:Start", "call:Output", "call:CombinedOutput",
+}
+
+// serverCalls stand up a network server (server-side net/http).
+var serverCallCtxs = []string{
+	"call:ListenAndServe", "call:ListenAndServeTLS", "call:Serve",
+}
+
+// isSecurityBoundary reports whether a symbol crosses a security boundary:
+//  1. file imports os/exec AND an enclosed call spawns a process, or
+//  2. file imports crypto/tls AND the symbol references InsecureSkipVerify, or
+//  3. file imports net/http AND the symbol stands up a server.
+//
+// Each rule requires the risky import as a co-signal so a name-only call
+// attribution (e.g. a method literally named Command) can't misfire alone.
+func isSecurityBoundary(db *sql.DB, symbolID, filePath string) bool {
+	if fileImportsAny(db, filePath, "os/exec") && enclosedCallCtx(db, symbolID, execCallCtxs) {
+		return true
+	}
+	if fileImportsAny(db, filePath, "crypto/tls") && enclosedRefMatches(db, symbolID, "InsecureSkipVerify") {
+		return true
+	}
+	if fileImportsAny(db, filePath, "net/http") && enclosedCallCtx(db, symbolID, serverCallCtxs) {
+		return true
+	}
+	return false
+}
+
+// hasChannelType reports whether a signature declares a channel-typed parameter
+// or result. It matches the `chan` keyword only at a token boundary so names like
+// "Exchange" (which contains "chan") don't misfire.
+func hasChannelType(signature string) bool {
+	const kw = "chan"
+	for i := 0; i+len(kw) <= len(signature); i++ {
+		if signature[i:i+len(kw)] != kw {
+			continue
+		}
+		if i > 0 && isIdentByte(signature[i-1]) {
+			continue // preceded by ident char → part of a larger word
+		}
+		if j := i + len(kw); j < len(signature) && isIdentByte(signature[j]) {
+			continue // followed by ident char → part of a larger word
+		}
+		return true
+	}
+	return false
+}
+
+// isIdentByte reports whether b can appear inside a Go identifier.
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// fileImportsAny reports whether filePath imports any of the given package paths.
+func fileImportsAny(db *sql.DB, filePath string, pkgs ...string) bool {
+	if filePath == "" || len(pkgs) == 0 {
+		return false
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(pkgs)), ",")
+	args := make([]any, 0, len(pkgs)+1)
+	args = append(args, filePath)
+	for _, p := range pkgs {
+		args = append(args, p)
+	}
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM imports WHERE file_path = ? AND pkg_path IN (`+placeholders+`)`,
+		args...,
+	).Scan(&n)
+	return err == nil && n > 0
+}
+
+// enclosedCallCtx reports whether the symbol encloses a ref whose ast_ctx matches
+// any of the given call attributions. Depends on refs.enclosing_id + ast_ctx
+// (schema v18+); a pre-v18 index yields NULL ctx → no signal (mirrors the
+// lifecycle R1/R2 trap).
+func enclosedCallCtx(db *sql.DB, symbolID string, ctxs []string) bool {
+	if len(ctxs) == 0 {
+		return false
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ctxs)), ",")
+	args := make([]any, 0, len(ctxs)+1)
+	args = append(args, symbolID)
+	for _, c := range ctxs {
+		args = append(args, c)
+	}
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM refs WHERE enclosing_id = ? AND ast_ctx IN (`+placeholders+`)`,
+		args...,
+	).Scan(&n)
+	return err == nil && n > 0
+}
+
+// enclosedRefMatches reports whether the symbol encloses a ref whose ast_ctx or
+// snippet contains needle (used for field-access signals like InsecureSkipVerify
+// that aren't call attributions).
+func enclosedRefMatches(db *sql.DB, symbolID, needle string) bool {
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM refs
+		 WHERE enclosing_id = ?
+		   AND (ast_ctx LIKE '%' || ? || '%' OR snippet LIKE '%' || ? || '%')`,
+		symbolID, needle, needle,
+	).Scan(&n)
+	return err == nil && n > 0
 }
 
 // InferRoleForSymbol returns the role for a single symbol without scanning the entire DB.

--- a/internal/context/roles_risk_test.go
+++ b/internal/context/roles_risk_test.go
@@ -1,0 +1,279 @@
+package context
+
+import (
+	"database/sql"
+	"slices"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupRiskDB creates an in-memory DB with the schema the role/risk detectors
+// read: symbols (with signature + pkg_path), refs (with enclosing_id, ast_ctx,
+// snippet), imports, and an (empty) call_graph so InferRoles' structural queries
+// resolve rather than error.
+func setupRiskDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE symbols (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			kind TEXT,
+			signature TEXT,
+			pkg_path TEXT,
+			file_path TEXT,
+			line_start INTEGER,
+			doc TEXT
+		);
+		CREATE TABLE refs (
+			id TEXT PRIMARY KEY,
+			symbol_id TEXT,
+			file_path TEXT,
+			line INTEGER,
+			col INTEGER,
+			enclosing_id TEXT,
+			snippet TEXT,
+			ast_ctx TEXT
+		);
+		CREATE TABLE imports (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT,
+			pkg_path TEXT,
+			name TEXT,
+			line INTEGER,
+			col INTEGER,
+			importer_pkg TEXT
+		);
+		CREATE TABLE call_graph (
+			caller_id TEXT,
+			callee_id TEXT,
+			file_path TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+	return db
+}
+
+func addSym(t *testing.T, db *sql.DB, id, name, kind, sig, pkg, file string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO symbols (id, name, kind, signature, pkg_path, file_path, line_start) VALUES (?,?,?,?,?,?,10)`,
+		id, name, kind, sig, pkg, file,
+	)
+	if err != nil {
+		t.Fatalf("insert symbol %s: %v", name, err)
+	}
+}
+
+func addImport(t *testing.T, db *sql.DB, file, pkg string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO imports (file_path, pkg_path, line, col) VALUES (?,?,1,1)`, file, pkg); err != nil {
+		t.Fatalf("insert import %s->%s: %v", file, pkg, err)
+	}
+}
+
+func addRefCtx(t *testing.T, db *sql.DB, id, enclosingID, file, astCtx, snippet string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO refs (id, symbol_id, file_path, line, col, enclosing_id, ast_ctx, snippet) VALUES (?,?,?,1,1,?,?,?)`,
+		id, enclosingID, file, enclosingID, astCtx, snippet,
+	)
+	if err != nil {
+		t.Fatalf("insert ref %s: %v", id, err)
+	}
+}
+
+// riskFor returns the RiskFlags InferRoles assigned to the named symbol.
+func riskFor(t *testing.T, db *sql.DB, name string) []string {
+	t.Helper()
+	roles, err := InferRoles(db, "/repo")
+	if err != nil {
+		t.Fatalf("InferRoles: %v", err)
+	}
+	for _, r := range roles {
+		if r.Name == name {
+			return r.RiskFlags
+		}
+	}
+	t.Fatalf("symbol %q not found in InferRoles output", name)
+	return nil
+}
+
+func hasFlag(flags []string, want string) bool {
+	return slices.Contains(flags, want)
+}
+
+// TestRiskClassification_Precision is the precision guard (plan §4.1): each
+// hand-labeled fixture must classify exactly as expected, decoys included.
+func TestRiskClassification_Precision(t *testing.T) {
+	db := setupRiskDB(t)
+	defer db.Close()
+
+	// --- concurrency positives ---
+	// chan-typed signature (high precision, low recall)
+	addSym(t, db, "pipe", "Pipe", kindFunc, "func Pipe(in <-chan int) chan int", "repo/pipe", "/repo/pipe.go")
+	// sync.Mutex user: imports sync + encloses a Lock call
+	addSym(t, db, "guard", "guardedCounter", kindMethod, "func (c *counter) guardedCounter()", "repo/count", "/repo/counter.go")
+	addImport(t, db, "/repo/counter.go", "sync")
+	addRefCtx(t, db, "r_lock", "guard", "/repo/counter.go", "call:Lock", "c.mu.Lock()")
+
+	// --- concurrency deferred-miss (plan §4.1 / sn-hmz) ---
+	// A pure `go func` spawner has no chan signature and no sync-primitive call,
+	// so it is NOT detectable until the indexer emits a go-statement signal.
+	// This asserts the documented recall gap rather than pretending it's covered.
+	addSym(t, db, "spawn", "spawnWorker", kindFunc, "func spawnWorker()", "repo/work", "/repo/worker.go")
+
+	// --- security_boundary positives ---
+	// exec.Command caller: imports os/exec + encloses a Command call
+	addSym(t, db, "backup", "runBackup", kindFunc, "func runBackup() error", "repo/backup", "/repo/backup.go")
+	addImport(t, db, "/repo/backup.go", "os/exec")
+	addRefCtx(t, db, "r_cmd", "backup", "/repo/backup.go", "call:Command", "exec.Command(\"tar\")")
+	// InsecureSkipVerify setter: imports crypto/tls + references the field
+	addSym(t, db, "tls", "dialTLS", kindFunc, "func dialTLS() error", "repo/tls", "/repo/tls.go")
+	addImport(t, db, "/repo/tls.go", "crypto/tls")
+	addRefCtx(t, db, "r_isv", "tls", "/repo/tls.go", "", "cfg.InsecureSkipVerify = true")
+
+	// --- decoys (must NOT flag) ---
+	// method literally named Command, but its file does NOT import os/exec.
+	// Even with a call:Command ref, the missing import co-signal blocks the flag.
+	addSym(t, db, "cmd_decoy", "Command", kindMethod, "func (s *Shell) Command() string", "repo/cli", "/repo/cli.go")
+	addRefCtx(t, db, "r_decoy", "cmd_decoy", "/repo/cli.go", "call:Command", "s.Command()")
+	// context.Context plumber: ctx in signature must not read as concurrency.
+	addSym(t, db, "plumb", "plumbCtx", kindFunc, "func plumbCtx(ctx context.Context) error", "repo/plumb", "/repo/plumb.go")
+
+	tests := []struct {
+		name string
+		want string // "" means no risk flags expected
+	}{
+		{"Pipe", RiskConcurrency},
+		{"guardedCounter", RiskConcurrency},
+		{"runBackup", RiskSecurityBoundary},
+		{"dialTLS", RiskSecurityBoundary},
+		{"spawnWorker", ""},
+		{"Command", ""},
+		{"plumbCtx", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := riskFor(t, db, tt.name)
+			if tt.want == "" {
+				if len(got) != 0 {
+					t.Errorf("%s: expected no risk flags, got %v", tt.name, got)
+				}
+				return
+			}
+			if !hasFlag(got, tt.want) {
+				t.Errorf("%s: expected flag %q, got %v", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+// TestHasChannelType guards the token-boundary matcher against the "Exchange"
+// class of false positives.
+func TestHasChannelType(t *testing.T) {
+	tests := []struct {
+		sig  string
+		want bool
+	}{
+		{"func Pipe(in chan int)", true},
+		{"func Send(c chan<- int)", true},
+		{"func Recv(c <-chan int)", true},
+		{"func f() chan int", true},
+		{"func Exchange(rate float64) float64", false}, // contains "chan" but not a channel
+		{"func Merchant() string", false},
+		{"func plumbCtx(ctx context.Context) error", false},
+	}
+	for _, tt := range tests {
+		if got := hasChannelType(tt.sig); got != tt.want {
+			t.Errorf("hasChannelType(%q) = %v, want %v", tt.sig, got, tt.want)
+		}
+	}
+}
+
+// TestFullRoleCoverage is the defect-1 regression guard (plan §4.3): every
+// function/type row in `context --full` output must carry a non-empty role,
+// including symbols InferRoles skips (test files fall back to api_boundary).
+func TestFullRoleCoverage(t *testing.T) {
+	db := setupRiskDB(t)
+	defer db.Close()
+
+	addSym(t, db, "s1", "Store", kindStruct, "", "repo/store", "/repo/store.go")
+	addSym(t, db, "s2", "Open", kindFunc, "func Open(p string) (*Store, error)", "repo/store", "/repo/store.go")
+	addSym(t, db, "s3", "Query", kindMethod, "func (s *Store) Query() error", "repo/store", "/repo/store.go")
+	addSym(t, db, "s4", "Reader", kindInterface, "", "repo/io", "/repo/io.go")
+	// Exported symbol in a _test.go file: InferRoles excludes it, so it exercises
+	// the api_boundary default in querySymbolRefsByKind.
+	addSym(t, db, "s5", "Helper", kindFunc, "func Helper()", "repo/store", "/repo/store_test.go")
+
+	syms := generateSymbols(db, "/repo", true, 1000)
+	all := append(append([]SymbolRef{}, syms.Functions...), syms.Types...)
+	if len(all) == 0 {
+		t.Fatal("expected some --full symbols")
+	}
+	for _, ref := range all {
+		if ref.Role == "" {
+			t.Errorf("symbol %s (%s) has empty role in --full output", ref.Name, ref.File)
+		}
+	}
+}
+
+// TestConfigurableKeySymbolCap is the defect-1 secondary guard (plan §4.4): the
+// ranked key-symbol list honors the configurable cap (--key-symbols) instead of
+// a hardcoded 15.
+func TestConfigurableKeySymbolCap(t *testing.T) {
+	db := setupRiskDB(t)
+	defer db.Close()
+
+	// 20 exported symbols across 20 distinct packages so the per-package cap of 3
+	// doesn't bite — isolating the top-N limit behavior.
+	for i := range 20 {
+		id := "k" + string(rune('a'+i))
+		name := "Sym" + string(rune('A'+i))
+		file := "/repo/pkg" + string(rune('a'+i)) + "/f.go"
+		pkg := "repo/pkg" + string(rune('a'+i))
+		addSym(t, db, id, name, kindFunc, "func "+name+"()", pkg, file)
+		// give each a ref so ref_count > 0 and priorities spread
+		for j := 0; j <= i; j++ {
+			addRefCtx(t, db, id+"_r"+string(rune('a'+j)), "", file, "", "")
+		}
+	}
+
+	wide, err := RankSymbols(db, "/repo", 50)
+	if err != nil {
+		t.Fatalf("RankSymbols(50): %v", err)
+	}
+	if len(wide) <= 15 {
+		t.Errorf("--key-symbols 50 should yield >15 ranked symbols, got %d", len(wide))
+	}
+
+	narrow, err := RankSymbols(db, "/repo", 15)
+	if err != nil {
+		t.Fatalf("RankSymbols(15): %v", err)
+	}
+	if len(narrow) != 15 {
+		t.Errorf("--key-symbols 15 should yield exactly 15, got %d", len(narrow))
+	}
+}
+
+// TestRiskWeightBoostsRanking verifies a risk-flagged symbol outranks a plain
+// internal symbol with the same ref count, and that risk symbols are exempt from
+// the per-package cap (plan step 5).
+func TestRiskWeightBoostsRanking(t *testing.T) {
+	base := effectiveWeight(RoleInternal, nil)
+	boosted := effectiveWeight(RoleInternal, []string{RiskSecurityBoundary})
+	if boosted <= base {
+		t.Errorf("security_boundary should boost weight above internal: base=%v boosted=%v", base, boosted)
+	}
+	// max, not product: a security_boundary api_boundary keeps the higher of the two.
+	got := effectiveWeight(RoleAPIBoundary, []string{RiskConcurrency})
+	if got != riskWeights[RiskConcurrency] && got != roleWeights[RoleAPIBoundary] {
+		t.Errorf("effectiveWeight should be max(role, risk), got %v", got)
+	}
+}

--- a/internal/context/schema.go
+++ b/internal/context/schema.go
@@ -11,4 +11,7 @@ package context
 //	1.0 — initial declared schema (snipe-yqo). Covers all fields present at
 //	      introduction; future additive fields keep 1.x, removals/renames go
 //	      to 2.0 with a CHANGELOG entry.
-const SchemaVersion = "1.0"
+//	1.1 — additive (sn-zd2): SymbolRef.role now populated on `context --full`
+//	      symbols (was boot-only), and new optional SymbolRef.risk_flags carries
+//	      orthogonal concurrency/security_boundary classes.
+const SchemaVersion = "1.1"

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -225,12 +225,13 @@ type ExtensionPoint struct {
 
 // SymbolRef is a lightweight reference to a symbol.
 type SymbolRef struct {
-	Name       string `json:"name" yaml:"name"`
-	File       string `json:"file" yaml:"file"`
-	Line       int    `json:"line" yaml:"line"`
-	Role       string `json:"role,omitempty" yaml:"role,omitempty"`
-	Visibility string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
-	Purpose    string `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Name       string   `json:"name" yaml:"name"`
+	File       string   `json:"file" yaml:"file"`
+	Line       int      `json:"line" yaml:"line"`
+	Role       string   `json:"role,omitempty" yaml:"role,omitempty"`
+	RiskFlags  []string `json:"risk_flags,omitempty" yaml:"risk_flags,omitempty"`
+	Visibility string   `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+	Purpose    string   `json:"purpose,omitempty" yaml:"purpose,omitempty"`
 }
 
 // BuildInfo describes the detected build/task system and CI configuration.


### PR DESCRIPTION
Implements the approved design: `~/Projects/dk/Project/snipe/plans/role-classifier-risk-classes.md`. Raises the role signal from ~10% recall toward usable as the canonical risk vocabulary for the cc-plugins review-judge (ccp-juha).

## Decisions (dk-approved)
- **Risk shape = A:** new orthogonal `RiskFlags []string` on `SymbolRole`/`SymbolRef`, alongside the unchanged structural `Role`. A handler that runs `os/exec` stays `Role=handler` with `RiskFlags=[security_boundary]` — no lossy enum collision.
- **Step 4 deferred → sn-hmz:** pure `go func` spawns aren't visible from existing signals (would need an indexer/schema change + eval-sibling reindex). Concurrency recall is intentionally capped to channel signatures + sync-primitive call sites until sn-hmz lands.

## What shipped (plan steps 1-3, 5-6)
- **Defect 1 — role on `context --full`:** every full-output symbol now carries `role` (was boot-only, ~1445 symbols had it blank), via a batch `InferRoles` map in `generateSymbols` (no N+1).
- **Configurable boot cap:** dedicated `--key-symbols` flag (default 15), *not* the global `--limit` (which would shrink boot output to 10).
- **Defect 2 — risk classes:** `isConcurrency` / `isSecurityBoundary` detectors keyed off the `imports` table + `refs.ast_ctx` call attribution (chan sigs; sync/atomic Lock/Wait/Do; os/exec Command/Run; crypto/tls InsecureSkipVerify; net/http server setup). Precision fixture tests with decoys (method named `Command` w/o exec import, `context.Context` plumber).
- **Ranking:** `roleWeights` gain risk boosts (max, not product); risk-flagged symbols exempt from the per-package cap of 3 so they surface in ranked output.
- **Schema:** context `SchemaVersion` 1.0 → 1.1 (additive).

## Verification
`make check` green in isolation (branched from main, not stacked on #184).

## Review notes for dk
- Test-file symbols default to `Role=api_boundary` to make the `--full` 100%-role-coverage assertion pass — arguably should be a distinct `test` role instead; flagging for your call.
- Concurrency recall caveat above (step 4 / sn-hmz).

Closes: sn-zd2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for highlighted key symbols in context output.
  * Context output now includes additional risk indicators for relevant symbols.
  * Full context generation now provides richer symbol metadata and updated schema output.

* **Bug Fixes**
  * Improved symbol ranking so risk-related items are less likely to be dropped from key output.
  * Expanded coverage to ensure all symbols in full context output are classified consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->