### PR TITLE
feat(risk): snipe risk — diff → code-graph risk verdict (sn-v87)

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -43,6 +43,7 @@ type CLI struct {
 	Boundary  BoundaryCmd  `cmd:"" group:"Graph & Structure:" help:"Show symbols whose refs cross between two package sets"`
 	Metrics   MetricsCmd   `cmd:"" group:"Graph & Structure:" help:"Show graph metrics (PageRank, coupling, HITS, etc.) over the import or call graph"`
 	Hotspots  HotspotsCmd  `cmd:"" group:"Graph & Structure:" help:"Rank files by complexity × git change-frequency (Tornhill hotspot model)"`
+	Risk      RiskCmd      `cmd:"" group:"Graph & Structure:" help:"Assess a diff's risk (base→head): code-graph verdict (roles, centrality, blast, churn)"`
 	Sensitive SensitiveCmd `cmd:"" group:"Graph & Structure:" help:"List files in security-sensitive zones (auth/crypto/migration/secret/payment)"`
 	Diagram   DiagramCmd   `cmd:"" group:"Graph & Structure:" help:"Render snipe graphs as D2 diagram source"`
 	Lifecycle LifecycleCmd `cmd:"" group:"Graph & Structure:" help:"Trace every function creating, mutating, reading, or deleting a type"`

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -339,6 +339,15 @@ func (c *HotspotsCmd) Run() error {
 	return runHotspots(c.Top, c.Pkg, c.File)
 }
 
+type RiskCmd struct {
+	Base string `arg:"" help:"Base git ref (e.g. main, origin/main, a SHA)"`
+	Head string `arg:"" optional:"" default:"HEAD" help:"Head git ref (default HEAD)"`
+}
+
+func (c *RiskCmd) Run() error {
+	return runRisk(c.Base, c.Head)
+}
+
 type SensitiveCmd struct{}
 
 func (c *SensitiveCmd) Run() error {

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -15,6 +15,7 @@ const (
 	cmdNameSim         = "sim"
 	cmdNameMetrics     = "metrics"
 	cmdNameHotspots    = "hotspots"
+	cmdNameRisk        = "risk"
 	cmdNameSym         = "sym"
 	cmdNameSearch      = "search"
 	cmdNameShow        = "show"

--- a/cmd/risk.go
+++ b/cmd/risk.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/risk"
+)
+
+// runRisk assesses the risk of the diff between two git refs and prints the verdict.
+// It never errors on a missing index or non-git repo — those degrade to a low
+// verdict — so the review-judge can call it uniformly on any repo.
+func runRisk(base, head string) error {
+	start := time.Now()
+
+	// nil writer: suppress OpenStore's missing-index error envelope. Risk degrades
+	// to a low verdict instead, still emitting a valid contract.
+	s, root, err := OpenStore(nil, cmdNameRisk)
+	if err != nil {
+		v := risk.Fuse(nil, risk.ChangeStats{}, true, "index unavailable: "+err.Error())
+		return writeRisk(v, root, start)
+	}
+	defer s.Close()
+
+	v := risk.Assess(s, root, base, head)
+	return writeRisk(v, root, start)
+}
+
+func writeRisk(v risk.Verdict, root string, start time.Time) error {
+	if GetOutputFormat() == output.OutputJSON {
+		return writeRiskJSON(v, root, start)
+	}
+	return writeRiskText(v)
+}
+
+// writeRiskJSON emits the verdict inside the standard envelope. The single verdict
+// is the sole result; consumers read `.results[0]` (e.g. `jq '.results[0].verdict'`).
+func writeRiskJSON(v risk.Verdict, root string, start time.Time) error {
+	resp := output.Response[risk.Verdict]{
+		Protocol: output.ProtocolVersion,
+		Ok:       true,
+		Results:  []risk.Verdict{v},
+		Meta: output.Meta{
+			Command:  cmdNameRisk,
+			RepoRoot: root,
+			Ms:       time.Since(start).Milliseconds(),
+			Total:    1,
+		},
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+func writeRiskText(v risk.Verdict) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "risk · %s (score %d)\n", v.Verdict, v.Score)
+	if v.Degraded {
+		fmt.Fprintf(&b, "  ⚠ degraded: %s\n", v.Note)
+	}
+	if len(v.Reasons) == 0 && !v.Degraded {
+		b.WriteString("  (no risk signals)\n")
+	}
+	for _, r := range v.Reasons {
+		fmt.Fprintf(&b, "  %-22s %s  (+%d)\n", r.Signal, r.Detail, r.Weight)
+	}
+	fmt.Fprintf(&b, "  changed: %d files · %d go · %d symbols\n",
+		v.Changed.Files, v.Changed.GoFiles, v.Changed.Symbols)
+	_, err := os.Stdout.WriteString(b.String())
+	return err
+}

--- a/cmd/testdata/help/risk.golden
+++ b/cmd/testdata/help/risk.golden
@@ -1,0 +1,25 @@
+Usage: snipe risk <base> [<head>] [flags]
+
+Assess a diff's risk (base→head): code-graph verdict (roles, centrality, blast,
+churn)
+
+Arguments:
+  <base>      Base git ref (e.g. main, origin/main, a SHA)
+  [<head>]    Head git ref (default HEAD)
+
+Flags:
+  -h, --help                Show context-sensitive help.
+      --limit=10            Cap results returned (applied after --select)
+      --offset=0            Pagination offset
+      --context=2           Context lines around match
+      --no-body             Exclude function body
+      --no-siblings         Exclude sibling declarations
+      --signature-only      Return only signature (no body, no context)
+      --max-tokens=0        Token budget (0 = unlimited)
+      --format="concise"    concise (LLM default) | detailed | summary | json
+                            (stable, for tooling) | human (TTY)
+      --kg-hints            Include Orca KG hints
+      --suggestions         Include next-step suggestions in Claude output
+      --timeout=DURATION    Timeout for command (e.g., 30s, 5m)
+      --select="all"        Pick top candidates by score: all, best, top3,
+                            top5 (applied before --limit)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -126,6 +126,10 @@ Graph & Structure:
   hotspots [flags]
     Rank files by complexity × git change-frequency (Tornhill hotspot model)
 
+  risk <base> [<head>] [flags]
+    Assess a diff's risk (base→head): code-graph verdict (roles, centrality,
+    blast, churn)
+
   sensitive [flags]
     List files in security-sensitive zones
     (auth/crypto/migration/secret/payment)

--- a/internal/context/roles.go
+++ b/internal/context/roles.go
@@ -77,11 +77,58 @@ type SymbolRole struct {
 	PkgPath    string     `json:"pkg_path,omitempty"`
 }
 
+// symbolInfo is the raw metadata a symbol needs for role classification.
+type symbolInfo struct {
+	id        string
+	name      string
+	kind      string
+	signature sql.NullString
+	pkgPath   sql.NullString
+	filePath  string
+}
+
+// classifySymbol applies the structural role + orthogonal risk-flag heuristics to
+// one symbol. Shared by the whole-repo InferRoles and the targeted RolesForSymbols
+// so both classify identically.
+func classifySymbol(db *sql.DB, imports importsCache, s symbolInfo) SymbolRole {
+	sr := SymbolRole{
+		SymbolID:   s.id,
+		Name:       s.name,
+		Visibility: inferVisibility(s.name),
+	}
+	if s.pkgPath.Valid {
+		sr.PkgPath = s.pkgPath.String
+	}
+	switch s.kind {
+	case kindFunc, kindMethod:
+		sr.Role = inferRole(db, s.id, s.name, s.kind, s.signature.String, s.pkgPath.String)
+		// Risk classes are orthogonal to structural role and accumulate
+		// independently (funcs/methods only — the heuristics are call/signature based).
+		sr.RiskFlags = detectRiskFlags(db, imports, s.id, s.signature.String, s.filePath)
+	case kindStruct, kindInterface, kindType:
+		sr.Role = inferRoleForType(db, s.id, s.name, s.pkgPath.String)
+	default:
+		sr.Role = RoleInternal
+	}
+	return sr
+}
+
+// scanSymbolInfos collects symbolInfo rows from a query over the symbols table.
+func scanSymbolInfos(rows *sql.Rows) ([]symbolInfo, error) {
+	var symbols []symbolInfo
+	for rows.Next() {
+		var s symbolInfo
+		if err := rows.Scan(&s.id, &s.name, &s.kind, &s.signature, &s.pkgPath, &s.filePath); err != nil {
+			continue
+		}
+		symbols = append(symbols, s)
+	}
+	return symbols, rows.Err()
+}
+
 // InferRoles analyzes symbols in the database and classifies them by architectural role.
 // It queries the symbols, refs, call_graph, and imports tables to determine each symbol's role.
 func InferRoles(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
-	var results []SymbolRole
-
 	// Query all functions, methods, and types with their metadata
 	rows, err := db.Query(`
 		SELECT id, name, kind, signature, pkg_path, file_path
@@ -97,25 +144,8 @@ func InferRoles(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
 	}
 	defer rows.Close()
 
-	// Collect symbols for processing
-	type symbolInfo struct {
-		id        string
-		name      string
-		kind      string
-		signature sql.NullString
-		pkgPath   sql.NullString
-		filePath  string
-	}
-	var symbols []symbolInfo
-
-	for rows.Next() {
-		var s symbolInfo
-		if err := rows.Scan(&s.id, &s.name, &s.kind, &s.signature, &s.pkgPath, &s.filePath); err != nil {
-			continue
-		}
-		symbols = append(symbols, s)
-	}
-	if err := rows.Err(); err != nil {
+	symbols, err := scanSymbolInfos(rows)
+	if err != nil {
 		return nil, err
 	}
 
@@ -126,36 +156,52 @@ func InferRoles(db *sql.DB, repoRoot string) ([]SymbolRole, error) {
 		return nil, err
 	}
 
-	// Process each symbol to determine its role
+	results := make([]SymbolRole, 0, len(symbols))
 	for _, s := range symbols {
-		sr := SymbolRole{
-			SymbolID:   s.id,
-			Name:       s.name,
-			Visibility: inferVisibility(s.name),
-		}
-		if s.pkgPath.Valid {
-			sr.PkgPath = s.pkgPath.String
-		}
+		results = append(results, classifySymbol(db, imports, s))
+	}
+	return results, nil
+}
 
-		// Determine role based on kind
-		var role Role
-		switch s.kind {
-		case kindFunc, kindMethod:
-			role = inferRole(db, s.id, s.name, s.kind, s.signature.String, s.pkgPath.String)
-			// Risk classes are orthogonal to structural role and accumulate
-			// independently (funcs/methods only — the heuristics are call/signature based).
-			sr.RiskFlags = detectRiskFlags(db, imports, s.id, s.signature.String, s.filePath)
-		case kindStruct, kindInterface, kindType:
-			role = inferRoleForType(db, s.id, s.name, s.pkgPath.String)
-		default:
-			role = RoleInternal
-		}
-		sr.Role = role
+// RolesForSymbols classifies a specific set of symbol IDs — the fast path for
+// callers (e.g. `snipe risk`) that already know which symbols changed and don't
+// want a whole-repo InferRoles pass. Returns a map keyed by symbol ID; IDs that
+// don't resolve to a func/method/type symbol are simply absent.
+func RolesForSymbols(db *sql.DB, repoRoot string, ids []string) (map[string]SymbolRole, error) {
+	if len(ids) == 0 {
+		return map[string]SymbolRole{}, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	rows, err := db.Query(`
+		SELECT id, name, kind, signature, pkg_path, file_path
+		FROM symbols
+		WHERE id IN (`+placeholders+`)
+		  AND kind IN ('func', 'method', 'struct', 'interface', 'type')
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-		results = append(results, sr)
+	symbols, err := scanSymbolInfos(rows)
+	if err != nil {
+		return nil, err
 	}
 
-	return results, nil
+	imports, err := loadImportsCache(db, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]SymbolRole, len(symbols))
+	for _, s := range symbols {
+		out[s.id] = classifySymbol(db, imports, s)
+	}
+	return out, nil
 }
 
 // inferVisibility determines if a symbol is exported based on its name.

--- a/internal/context/roles.go
+++ b/internal/context/roles.go
@@ -171,35 +171,40 @@ func RolesForSymbols(db *sql.DB, repoRoot string, ids []string) (map[string]Symb
 	if len(ids) == 0 {
 		return map[string]SymbolRole{}, nil
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	rows, err := db.Query(`
-		SELECT id, name, kind, signature, pkg_path, file_path
-		FROM symbols
-		WHERE id IN (`+placeholders+`)
-		  AND kind IN ('func', 'method', 'struct', 'interface', 'type')
-	`, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	symbols, err := scanSymbolInfos(rows)
-	if err != nil {
-		return nil, err
-	}
-
 	imports, err := loadImportsCache(db, repoRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	out := make(map[string]SymbolRole, len(symbols))
-	for _, s := range symbols {
-		out[s.id] = classifySymbol(db, imports, s)
+	out := make(map[string]SymbolRole, len(ids))
+	// Chunk the IN clause under SQLite's default host-parameter limit (999) — a
+	// large diff can touch more symbols than a single query can bind.
+	const batchSize = 900
+	for start := 0; start < len(ids); start += batchSize {
+		batch := ids[start:min(start+batchSize, len(ids))]
+
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.Query(`
+			SELECT id, name, kind, signature, pkg_path, file_path
+			FROM symbols
+			WHERE id IN (`+placeholders+`)
+			  AND kind IN ('func', 'method', 'struct', 'interface', 'type')
+		`, args...)
+		if err != nil {
+			return nil, err
+		}
+		symbols, err := scanSymbolInfos(rows)
+		_ = rows.Close()
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range symbols {
+			out[s.id] = classifySymbol(db, imports, s)
+		}
 	}
 	return out, nil
 }

--- a/internal/risk/diff.go
+++ b/internal/risk/diff.go
@@ -1,0 +1,111 @@
+// Package risk turns a git diff into a code-graph risk verdict. It maps changed
+// lines to changed symbols, fuses the signals snipe already owns (roles, package
+// centrality, blast radius, churn), and emits one repo-agnostic verdict + reasons.
+//
+// Consumer: cc-plugins review-judge maps the verdict → a CI review tier. snipe owns
+// the risk answer; the judge owns the policy. Every code path degrades silently to a
+// low verdict rather than erroring, so the judge can call `snipe risk` on any repo.
+package risk
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// FileChange is one changed file with its head-side (added/modified) line ranges.
+// Ranges are inclusive [start, end] in head coordinates; pure deletions yield none.
+type FileChange struct {
+	Path       string
+	LineRanges [][2]int
+}
+
+// gitDiff runs `git diff --unified=0 <base> <head> -- '*.go'` at repoRoot and
+// returns the raw diff stream. ok is false — with no error — when git is absent,
+// repoRoot is not a work tree, or a ref won't resolve, so callers degrade to a low
+// verdict instead of failing (mirrors gitchurn.Walk's git-when-available contract).
+func gitDiff(repoRoot, base, head string) (stream string, ok bool) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", false
+	}
+	if err := exec.Command("git", "-C", repoRoot, "rev-parse", "--is-inside-work-tree").Run(); err != nil {
+		return "", false
+	}
+	out, err := exec.Command("git", "-C", repoRoot, "diff",
+		"--unified=0", "--no-color", base, head, "--", "*.go").Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+// parseDiff turns a `git diff --unified=0` stream into per-file head-side line
+// ranges. It tracks the current file from the `+++ b/<path>` header (so renames
+// resolve to the head path) and reads each `@@ -a,b +c,d @@` hunk's + side. A
+// deleted file (`+++ /dev/null`) or a zero-count head hunk contributes nothing.
+func parseDiff(stream string) []FileChange {
+	var out []FileChange
+	var cur *FileChange
+
+	flush := func() {
+		if cur != nil && len(cur.LineRanges) > 0 {
+			out = append(out, *cur)
+		}
+		cur = nil
+	}
+
+	for line := range strings.SplitSeq(stream, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++ "):
+			flush()
+			path := strings.TrimPrefix(line, "+++ ")
+			if path == "/dev/null" {
+				cur = nil
+				continue
+			}
+			cur = &FileChange{Path: strings.TrimPrefix(path, "b/")}
+		case strings.HasPrefix(line, "@@ ") && cur != nil:
+			if start, count, ok := parseHunkHead(line); ok && count > 0 {
+				cur.LineRanges = append(cur.LineRanges, [2]int{start, start + count - 1})
+			}
+		}
+	}
+	flush()
+	return out
+}
+
+// parseHunkHead reads the head-side start line and count from `@@ -a,b +c,d @@`.
+// `+c` with no comma means count 1; `+c,0` (pure deletion) yields count 0.
+func parseHunkHead(line string) (start, count int, ok bool) {
+	// Isolate the "+c,d" token between the "+" and the closing " @@".
+	_, rest, found := strings.Cut(line, "+")
+	if !found {
+		return 0, 0, false
+	}
+	if before, _, ok := strings.Cut(rest, " "); ok {
+		rest = before
+	}
+	startStr, countStr, hasComma := strings.Cut(rest, ",")
+	start, err := strconv.Atoi(startStr)
+	if err != nil {
+		return 0, 0, false
+	}
+	count = 1
+	if hasComma {
+		if count, err = strconv.Atoi(countStr); err != nil {
+			return 0, 0, false
+		}
+	}
+	return start, count, true
+}
+
+// changedGoFiles returns the paths of changed .go files, preserving order.
+func changedGoFiles(changes []FileChange) []string {
+	var out []string
+	for _, c := range changes {
+		if strings.HasSuffix(c.Path, ".go") {
+			out = append(out, c.Path)
+		}
+	}
+	return out
+}

--- a/internal/risk/diff.go
+++ b/internal/risk/diff.go
@@ -28,11 +28,19 @@ func gitDiff(repoRoot, base, head string) (stream string, ok bool) {
 	if _, err := exec.LookPath("git"); err != nil {
 		return "", false
 	}
+	// A ref beginning with "-" would be parsed as a git option (e.g.
+	// `--output=/path`), letting a caller-supplied ref inject flags. Refs never
+	// legitimately start with "-", so reject rather than assess.
+	if strings.HasPrefix(base, "-") || strings.HasPrefix(head, "-") {
+		return "", false
+	}
 	if err := exec.Command("git", "-C", repoRoot, "rev-parse", "--is-inside-work-tree").Run(); err != nil {
 		return "", false
 	}
+	// --end-of-options fixes base/head as operands even if a future ref form
+	// looks option-like; the "--" then separates the *.go pathspec.
 	out, err := exec.Command("git", "-C", repoRoot, "diff",
-		"--unified=0", "--no-color", base, head, "--", "*.go").Output()
+		"--unified=0", "--no-color", "--end-of-options", base, head, "--", "*.go").Output()
 	if err != nil {
 		return "", false
 	}

--- a/internal/risk/diff_test.go
+++ b/internal/risk/diff_test.go
@@ -1,0 +1,81 @@
+package risk
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDiff_ExtractsHeadSideRanges_When_HunksPresent(t *testing.T) {
+	t.Parallel()
+
+	// A two-file diff: one modified file with two hunks, one added file.
+	stream := `diff --git a/internal/store/store.go b/internal/store/store.go
+index 1111111..2222222 100644
+--- a/internal/store/store.go
++++ b/internal/store/store.go
+@@ -10,0 +11,3 @@ func Open() {
++	a()
++	b()
++	c()
+@@ -40,2 +43 @@ func Close() {
++	d()
+diff --git a/cmd/new.go b/cmd/new.go
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/cmd/new.go
+@@ -0,0 +1,2 @@
++package cmd
++
+`
+
+	got := parseDiff(stream)
+	want := []FileChange{
+		{Path: "internal/store/store.go", LineRanges: [][2]int{{11, 13}, {43, 43}}},
+		{Path: "cmd/new.go", LineRanges: [][2]int{{1, 2}}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseDiff mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+func TestParseDiff_SkipsPureDeletions_When_HeadCountZero(t *testing.T) {
+	t.Parallel()
+
+	// A file deleted entirely (+++ /dev/null) and a hunk that only removes lines
+	// (+0 count) contribute no head-side ranges.
+	stream := `diff --git a/gone.go b/gone.go
+deleted file mode 100644
+--- a/gone.go
++++ /dev/null
+@@ -1,5 +0,0 @@
+-package gone
+diff --git a/trim.go b/trim.go
+--- a/trim.go
++++ b/trim.go
+@@ -5,3 +4,0 @@ func f() {
+-	old()
+`
+
+	got := parseDiff(stream)
+	// gone.go maps to /dev/null → dropped; trim.go has a hunk with +0 count → no ranges.
+	if len(got) != 0 {
+		t.Fatalf("expected no head-side changes, got %+v", got)
+	}
+}
+
+func TestChangedGoFiles_FiltersToGo(t *testing.T) {
+	t.Parallel()
+
+	changes := []FileChange{
+		{Path: "cmd/risk.go"},
+		{Path: "README.md"},
+		{Path: "internal/risk/diff.go"},
+		{Path: "go.mod"},
+	}
+	got := changedGoFiles(changes)
+	want := []string{"cmd/risk.go", "internal/risk/diff.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("changedGoFiles=%v want %v", got, want)
+	}
+}

--- a/internal/risk/risk.go
+++ b/internal/risk/risk.go
@@ -1,0 +1,93 @@
+package risk
+
+import "sort"
+
+// Verdict levels — repo-agnostic risk. The cc-plugins review-judge maps these to
+// its none|codex|full CI tier; snipe never learns the tier names.
+const (
+	VerdictLow    = "low"
+	VerdictMedium = "medium"
+	VerdictHigh   = "high"
+)
+
+// Score thresholds for the verdict level (tunable; documented in the plan).
+// Deduped signal weights sum to the score.
+const (
+	scoreHigh   = 5 // score >= scoreHigh   → high
+	scoreMedium = 2 // score >= scoreMedium → medium; else low
+)
+
+// Signal is one risk reason: a stable code, a human-legible detail, and a weight.
+type Signal struct {
+	Signal string `json:"signal"`
+	Detail string `json:"detail"`
+	Weight int    `json:"weight"`
+}
+
+// ChangeStats describes the diff's shape (observability, not scored).
+type ChangeStats struct {
+	Files   int `json:"files"`
+	GoFiles int `json:"go_files"`
+	Symbols int `json:"symbols"`
+}
+
+// Verdict is snipe's risk answer for a diff — the canonical contract consumers read.
+type Verdict struct {
+	Verdict  string      `json:"verdict"`
+	Score    int         `json:"score"`
+	Reasons  []Signal    `json:"reasons"`
+	Changed  ChangeStats `json:"changed"`
+	Degraded bool        `json:"degraded"`
+	Note     string      `json:"note,omitempty"`
+}
+
+// Fuse reduces raw signals to a verdict. It dedups by signal code (each class fires
+// at most once, keeping its highest-weight instance), sums the deduped weights, and
+// thresholds to a level. A degraded assessment is forced to low — absent signal is
+// never evidence of high risk. Reasons come out deterministically ordered.
+func Fuse(signals []Signal, changed ChangeStats, degraded bool, note string) Verdict {
+	best := make(map[string]Signal, len(signals))
+	for _, s := range signals {
+		if cur, ok := best[s.Signal]; !ok || s.Weight > cur.Weight {
+			best[s.Signal] = s
+		}
+	}
+
+	reasons := make([]Signal, 0, len(best))
+	score := 0
+	for _, s := range best {
+		reasons = append(reasons, s)
+		score += s.Weight
+	}
+	// Weight desc, then signal code asc — stable for JSON/golden output.
+	sort.Slice(reasons, func(i, j int) bool {
+		if reasons[i].Weight != reasons[j].Weight {
+			return reasons[i].Weight > reasons[j].Weight
+		}
+		return reasons[i].Signal < reasons[j].Signal
+	})
+
+	return Verdict{
+		Verdict:  level(score, degraded),
+		Score:    score,
+		Reasons:  reasons,
+		Changed:  changed,
+		Degraded: degraded,
+		Note:     note,
+	}
+}
+
+// level maps a score to a verdict, forcing low when the assessment degraded.
+func level(score int, degraded bool) string {
+	if degraded {
+		return VerdictLow
+	}
+	switch {
+	case score >= scoreHigh:
+		return VerdictHigh
+	case score >= scoreMedium:
+		return VerdictMedium
+	default:
+		return VerdictLow
+	}
+}

--- a/internal/risk/risk_test.go
+++ b/internal/risk/risk_test.go
@@ -1,0 +1,91 @@
+package risk
+
+import "testing"
+
+func TestFuse_DedupsBySignal_KeepingHighestWeight(t *testing.T) {
+	t.Parallel()
+
+	// Two `central` signals (a file in top-5, another in top-20) collapse to one
+	// reason at the higher weight — a signal class fires at most once.
+	v := Fuse([]Signal{
+		{Signal: sigCentral, Detail: "pkg A #3", Weight: 2},
+		{Signal: sigCentral, Detail: "pkg B #14", Weight: 1},
+	}, ChangeStats{}, false, "")
+
+	if len(v.Reasons) != 1 {
+		t.Fatalf("expected 1 deduped reason, got %d: %+v", len(v.Reasons), v.Reasons)
+	}
+	if v.Reasons[0].Weight != 2 || v.Reasons[0].Detail != "pkg A #3" {
+		t.Fatalf("kept wrong instance: %+v", v.Reasons[0])
+	}
+	if v.Score != 2 || v.Verdict != VerdictMedium {
+		t.Fatalf("score=%d verdict=%q, want 2/medium", v.Score, v.Verdict)
+	}
+}
+
+func TestFuse_Thresholds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		signals []Signal
+		want    string
+		score   int
+	}{
+		{"empty is low", nil, VerdictLow, 0},
+		{"score 1 is low", []Signal{{Signal: sigChurn, Weight: 1}}, VerdictLow, 1},
+		{"score 2 is medium", []Signal{{Signal: "role:api_boundary", Weight: 2}}, VerdictMedium, 2},
+		{"score 4 is medium", []Signal{
+			{Signal: sigCentral, Weight: 2}, {Signal: sigRolePrefix + "persistence", Weight: 2},
+		}, VerdictMedium, 4},
+		{"score 5 is high", []Signal{
+			{Signal: sigCentral, Weight: 2}, {Signal: sigRolePrefix + "persistence", Weight: 2},
+			{Signal: sigChurn, Weight: 1},
+		}, VerdictHigh, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v := Fuse(tt.signals, ChangeStats{}, false, "")
+			if v.Score != tt.score || v.Verdict != tt.want {
+				t.Fatalf("score=%d verdict=%q, want %d/%s", v.Score, v.Verdict, tt.score, tt.want)
+			}
+		})
+	}
+}
+
+func TestFuse_DegradedForcesLow_EvenWithSignals(t *testing.T) {
+	t.Parallel()
+
+	// A degraded assessment can't be trusted to be high — force low, keep the note.
+	v := Fuse([]Signal{
+		{Signal: sigCentral, Weight: 2}, {Signal: sigRolePrefix + "persistence", Weight: 2},
+		{Signal: sigChurn, Weight: 1},
+	}, ChangeStats{}, true, "index cold")
+
+	if v.Verdict != VerdictLow {
+		t.Fatalf("degraded verdict=%q, want low", v.Verdict)
+	}
+	if !v.Degraded || v.Note != "index cold" {
+		t.Fatalf("degraded/note not carried: %+v", v)
+	}
+}
+
+func TestFuse_ReasonsAreDeterministicallyOrdered(t *testing.T) {
+	t.Parallel()
+
+	// Reasons sort by weight desc, then signal asc — stable output for golden/JSON.
+	v := Fuse([]Signal{
+		{Signal: sigChurn, Weight: 1},
+		{Signal: "risk:concurrency", Weight: 2},
+		{Signal: sigCentral, Weight: 2},
+	}, ChangeStats{}, false, "")
+
+	got := []string{v.Reasons[0].Signal, v.Reasons[1].Signal, v.Reasons[2].Signal}
+	want := []string{sigCentral, "risk:concurrency", sigChurn}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order=%v want %v", got, want)
+		}
+	}
+}

--- a/internal/risk/signals.go
+++ b/internal/risk/signals.go
@@ -46,6 +46,9 @@ type changedSym struct {
 // git or the index can't answer, it returns a degraded low verdict so the judge can
 // call it on any repo.
 func Assess(s *store.Store, repoRoot, base, head string) Verdict {
+	if s == nil {
+		return Fuse(nil, ChangeStats{}, true, "index unavailable")
+	}
 	stream, ok := gitDiff(repoRoot, base, head)
 	if !ok {
 		return Fuse(nil, ChangeStats{}, true,
@@ -77,7 +80,10 @@ func changedSymbols(db *sql.DB, repoRoot string, changes []FileChange) []changed
 	var out []changedSym
 	seen := make(map[string]bool)
 	for _, fc := range changes {
-		if !strings.HasSuffix(fc.Path, ".go") || len(fc.LineRanges) == 0 {
+		// Symbol-derived signals (role/blast/central-pkg) mean production risk;
+		// a _test.go edit shouldn't carry a persistence role or blast radius, so it
+		// contributes no changed symbols (its churn/pkg still count elsewhere).
+		if !strings.HasSuffix(fc.Path, ".go") || strings.HasSuffix(fc.Path, "_test.go") || len(fc.LineRanges) == 0 {
 			continue
 		}
 		abs := filepath.Join(repoRoot, fc.Path)

--- a/internal/risk/signals.go
+++ b/internal/risk/signals.go
@@ -1,0 +1,279 @@
+package risk
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	snipecontext "github.com/dkoosis/snipe/internal/context"
+	"github.com/dkoosis/snipe/internal/query"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+// Signal-strength cutoffs. Centrality mirrors the ccp-1lk5 spike (top-5 → +2,
+// top-20 → +1); blast fan-out and role weights follow the plan.
+const (
+	centralTopStrong = 5
+	centralTopWeak   = 20
+	churnTopN        = 20
+	blastCallersHigh = 20
+	blastFilesHigh   = 8
+	blastCallersMed  = 5
+	blastCallerCap   = 500
+
+	weightStrong = 2
+	weightWeak   = 1
+)
+
+// Signal codes (stable identifiers in the JSON contract).
+const (
+	sigCentral    = "central"
+	sigChurn      = "churn-hotspot"
+	sigBlast      = "blast"
+	sigRolePrefix = "role:"
+	sigRiskPrefix = "risk:"
+)
+
+// changedSym is a symbol a diff touched, with the package it belongs to.
+type changedSym struct {
+	id      string
+	pkgPath string
+}
+
+// Assess runs the full pipeline for `snipe risk`: diff → changed symbols → gather
+// the code-graph signals snipe owns → Fuse into a verdict. It never errors — when
+// git or the index can't answer, it returns a degraded low verdict so the judge can
+// call it on any repo.
+func Assess(s *store.Store, repoRoot, base, head string) Verdict {
+	stream, ok := gitDiff(repoRoot, base, head)
+	if !ok {
+		return Fuse(nil, ChangeStats{}, true,
+			"git diff unavailable (not a work tree, unresolved ref, or git absent)")
+	}
+	changes := parseDiff(stream)
+	goFiles := changedGoFiles(changes)
+	stats := ChangeStats{Files: len(changes), GoFiles: len(goFiles)}
+	if len(goFiles) == 0 {
+		return Fuse(nil, stats, true, "no changed Go files")
+	}
+
+	changed := changedSymbols(s.DB(), repoRoot, changes)
+	stats.Symbols = len(changed)
+
+	var signals []Signal
+	signals = append(signals, centralSignal(s, changed)...)
+	signals = append(signals, churnSignal(s, goFiles)...)
+	signals = append(signals, roleSignals(s.DB(), repoRoot, changed)...)
+	signals = append(signals, blastSignal(s.DB(), changed)...)
+
+	return Fuse(signals, stats, false, "")
+}
+
+// changedSymbols maps changed files to the func/method/type symbols whose body
+// overlaps a changed head-side line range. Symbols the index doesn't know (e.g. a
+// brand-new file not yet reindexed) simply don't appear.
+func changedSymbols(db *sql.DB, repoRoot string, changes []FileChange) []changedSym {
+	var out []changedSym
+	seen := make(map[string]bool)
+	for _, fc := range changes {
+		if !strings.HasSuffix(fc.Path, ".go") || len(fc.LineRanges) == 0 {
+			continue
+		}
+		abs := filepath.Join(repoRoot, fc.Path)
+		rows, err := db.Query(`
+			SELECT id, pkg_path, line_start, line_end
+			FROM symbols
+			WHERE file_path = ? AND kind IN ('func', 'method', 'struct', 'interface', 'type')
+		`, abs)
+		if err != nil {
+			continue
+		}
+		for rows.Next() {
+			var id string
+			var pkg sql.NullString
+			var start, end int
+			if err := rows.Scan(&id, &pkg, &start, &end); err != nil {
+				continue
+			}
+			if seen[id] || !overlaps(start, end, fc.LineRanges) {
+				continue
+			}
+			seen[id] = true
+			out = append(out, changedSym{id: id, pkgPath: pkg.String})
+		}
+		_ = rows.Close()
+	}
+	return out
+}
+
+// overlaps reports whether [start,end] intersects any of the ranges.
+func overlaps(start, end int, ranges [][2]int) bool {
+	for _, r := range ranges {
+		if start <= r[1] && r[0] <= end {
+			return true
+		}
+	}
+	return false
+}
+
+// centralSignal fires when a changed file's package is import-central (PageRank).
+// The best (lowest) rank across all changed packages sets the weight.
+func centralSignal(s *store.Store, changed []changedSym) []Signal {
+	pkgs := distinctPkgs(changed)
+	if len(pkgs) == 0 {
+		return nil
+	}
+	rows, err := s.ReadTopN("imports", "pagerank", 0)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	rank := make(map[string]int, len(rows))
+	for _, r := range rows {
+		rank[r.NodeID] = r.Rank
+	}
+	best, bestPkg := 0, ""
+	for _, p := range pkgs {
+		if r, ok := rank[p]; ok && (best == 0 || r < best) {
+			best, bestPkg = r, p
+		}
+	}
+	weight := 0
+	switch {
+	case best == 0:
+		return nil
+	case best <= centralTopStrong:
+		weight = weightStrong
+	case best <= centralTopWeak:
+		weight = weightWeak
+	default:
+		return nil
+	}
+	return []Signal{{
+		Signal: sigCentral,
+		Detail: fmt.Sprintf("%s ranks #%d/%d by PageRank", bestPkg, best, len(rows)),
+		Weight: weight,
+	}}
+}
+
+// churnSignal fires when a changed file sits in the churn×complexity hotspot top-N.
+func churnSignal(s *store.Store, goFiles []string) []Signal {
+	rows, err := s.ReadFileChurnTopN(churnTopN)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	hot := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		hot[r.Path] = true
+	}
+	for _, f := range goFiles {
+		if hot[f] {
+			return []Signal{{
+				Signal: sigChurn,
+				Detail: fmt.Sprintf("%s in churn top-%d", f, churnTopN),
+				Weight: weightWeak,
+			}}
+		}
+	}
+	return nil
+}
+
+// roleSignals fires per distinct architectural role / risk class among the changed
+// symbols. Persistence & api_boundary weigh strong; entry_point weak; each
+// concurrency / security_boundary risk flag weighs strong. Each class fires once.
+func roleSignals(db *sql.DB, repoRoot string, changed []changedSym) []Signal {
+	ids := symbolIDs(changed)
+	if len(ids) == 0 {
+		return nil
+	}
+	roles, err := snipecontext.RolesForSymbols(db, repoRoot, ids)
+	if err != nil {
+		return nil
+	}
+	roleCount := make(map[snipecontext.Role]int)
+	riskCount := make(map[string]int)
+	for _, sr := range roles {
+		roleCount[sr.Role]++
+		for _, rf := range sr.RiskFlags {
+			riskCount[rf]++
+		}
+	}
+
+	var sigs []Signal
+	emitRole := func(role snipecontext.Role, weight int) {
+		if n := roleCount[role]; n > 0 {
+			sigs = append(sigs, Signal{
+				Signal: sigRolePrefix + string(role),
+				Detail: fmt.Sprintf("%d changed symbol(s) in a %s role", n, role),
+				Weight: weight,
+			})
+		}
+	}
+	emitRole(snipecontext.RolePersistence, weightStrong)
+	emitRole(snipecontext.RoleAPIBoundary, weightStrong)
+	emitRole(snipecontext.RoleEntryPoint, weightWeak)
+
+	for _, rf := range []string{snipecontext.RiskConcurrency, snipecontext.RiskSecurityBoundary} {
+		if n := riskCount[rf]; n > 0 {
+			sigs = append(sigs, Signal{
+				Signal: sigRiskPrefix + rf,
+				Detail: fmt.Sprintf("%d changed symbol(s) touch %s", n, rf),
+				Weight: weightStrong,
+			})
+		}
+	}
+	return sigs
+}
+
+// blastSignal fires on wide caller fan-out — a change to code many other sites call.
+func blastSignal(db *sql.DB, changed []changedSym) []Signal {
+	ids := symbolIDs(changed)
+	if len(ids) == 0 {
+		return nil
+	}
+	rows, err := query.FindImpactCallersMulti(db, ids, true, blastCallerCap, 0)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	files := make(map[string]bool)
+	for i := range rows {
+		files[rows[i].FilePathRel] = true
+	}
+	callers := len(rows)
+	weight := 0
+	switch {
+	case callers >= blastCallersHigh && len(files) >= blastFilesHigh:
+		weight = weightStrong
+	case callers >= blastCallersMed:
+		weight = weightWeak
+	default:
+		return nil
+	}
+	return []Signal{{
+		Signal: sigBlast,
+		Detail: fmt.Sprintf("%d callers across %d files", callers, len(files)),
+		Weight: weight,
+	}}
+}
+
+// distinctPkgs returns the unique, non-empty package paths among changed symbols.
+func distinctPkgs(changed []changedSym) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, c := range changed {
+		if c.pkgPath != "" && !seen[c.pkgPath] {
+			seen[c.pkgPath] = true
+			out = append(out, c.pkgPath)
+		}
+	}
+	return out
+}
+
+// symbolIDs returns the changed symbols' IDs.
+func symbolIDs(changed []changedSym) []string {
+	out := make([]string, len(changed))
+	for i, c := range changed {
+		out[i] = c.id
+	}
+	return out
+}

--- a/internal/risk/signals_test.go
+++ b/internal/risk/signals_test.go
@@ -1,0 +1,98 @@
+package risk
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+// seedStore opens a temp index and inserts one central package, one hot file, and
+// one persistence-role symbol so the store-backed gatherers have something to read.
+func seedStore(t *testing.T, repoRoot string) *store.Store {
+	t.Helper()
+	s, err := store.Open(filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	// PageRank: internal/store is #1 of two packages.
+	if err := s.WriteGraphMetrics("imports", "pagerank", map[string]float64{
+		"github.com/x/internal/store": 0.9,
+		"github.com/x/internal/util":  0.1,
+	}); err != nil {
+		t.Fatalf("write metrics: %v", err)
+	}
+	// Churn: store.go is a hotspot.
+	if err := s.WriteFileChurn([]store.FileChurn{
+		{Path: "internal/store/store.go", Commits: 40, Authors: 3, Score: 9.9},
+	}); err != nil {
+		t.Fatalf("write churn: %v", err)
+	}
+	// A persistence-role symbol: a func in a *store* package (inferRole tags store
+	// packages persistence). file_path is absolute (repoRoot-joined).
+	abs := filepath.Join(repoRoot, "internal/store/store.go")
+	_, err = s.DB().Exec(`
+		INSERT INTO symbols (id, name, kind, file_path, file_path_rel, pkg_path,
+			line_start, col_start, line_end, col_end)
+		VALUES ('sym1', 'WriteIndex', 'func', ?, 'internal/store/store.go',
+			'github.com/x/internal/store', 10, 1, 30, 1)
+	`, abs)
+	if err != nil {
+		t.Fatalf("insert symbol: %v", err)
+	}
+	return s
+}
+
+func TestCentralSignal_FiresOnTopRankedPackage(t *testing.T) {
+	t.Parallel()
+	s := seedStore(t, t.TempDir())
+	got := centralSignal(s, []changedSym{{id: "sym1", pkgPath: "github.com/x/internal/store"}})
+	if len(got) != 1 || got[0].Signal != sigCentral || got[0].Weight != weightStrong {
+		t.Fatalf("central signal = %+v, want one strong central", got)
+	}
+}
+
+func TestCentralSignal_SilentOnUnrankedPackage(t *testing.T) {
+	t.Parallel()
+	s := seedStore(t, t.TempDir())
+	if got := centralSignal(s, []changedSym{{pkgPath: "github.com/x/unknown"}}); got != nil {
+		t.Fatalf("expected no central signal, got %+v", got)
+	}
+}
+
+func TestChurnSignal_FiresOnHotFile(t *testing.T) {
+	t.Parallel()
+	s := seedStore(t, t.TempDir())
+	got := churnSignal(s, []string{"internal/store/store.go", "cmd/cold.go"})
+	if len(got) != 1 || got[0].Signal != sigChurn {
+		t.Fatalf("churn signal = %+v, want one churn-hotspot", got)
+	}
+}
+
+func TestRoleSignals_FiresPersistenceOnStorePackageSymbol(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	s := seedStore(t, repoRoot)
+	got := roleSignals(s.DB(), repoRoot, []changedSym{{id: "sym1", pkgPath: "github.com/x/internal/store"}})
+	var found bool
+	for _, sig := range got {
+		if sig.Signal == sigRolePrefix+"persistence" && sig.Weight == weightStrong {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected role:persistence signal, got %+v", got)
+	}
+}
+
+func TestAssess_DegradesWhenNotAGitWorkTree(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir() // empty dir, not a git repo
+	s := seedStore(t, repoRoot)
+	v := Assess(s, repoRoot, "HEAD~1", "HEAD")
+	if !v.Degraded || v.Verdict != VerdictLow {
+		t.Fatalf("expected degraded low verdict outside a git tree, got %+v", v)
+	}
+}

--- a/internal/risk/signals_test.go
+++ b/internal/risk/signals_test.go
@@ -87,6 +87,26 @@ func TestRoleSignals_FiresPersistenceOnStorePackageSymbol(t *testing.T) {
 	}
 }
 
+func TestChangedSymbols_ExcludesTestFiles(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	s := seedStore(t, repoRoot)
+	// Seed a symbol in a _test.go file at the same overlapping range.
+	abs := filepath.Join(repoRoot, "internal/store/store_test.go")
+	if _, err := s.DB().Exec(`
+		INSERT INTO symbols (id, name, kind, file_path, file_path_rel, pkg_path,
+			line_start, col_start, line_end, col_end)
+		VALUES ('symT', 'TestWriteIndex', 'func', ?, 'internal/store/store_test.go',
+			'github.com/x/internal/store', 10, 1, 30, 1)
+	`, abs); err != nil {
+		t.Fatalf("insert test symbol: %v", err)
+	}
+	changes := []FileChange{{Path: "internal/store/store_test.go", LineRanges: [][2]int{{10, 30}}}}
+	if got := changedSymbols(s.DB(), repoRoot, changes); len(got) != 0 {
+		t.Fatalf("expected _test.go symbols excluded, got %+v", got)
+	}
+}
+
 func TestAssess_DegradesWhenNotAGitWorkTree(t *testing.T) {
 	t.Parallel()
 	repoRoot := t.TempDir() // empty dir, not a git repo

--- a/test/blackbox/testdata/golden/TestGolden_Context_Boot.json
+++ b/test/blackbox/testdata/golden/TestGolden_Context_Boot.json
@@ -155,7 +155,7 @@
     }
   ],
   "project": "001",
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "total_pkgs": 4,
   "total_symbols": 24
 }


### PR DESCRIPTION
New `snipe risk <base> [head]` command — the code-graph core of the sn-06o epic (snipe owns the risk answer; cc-plugins review-judge becomes a thin verdict→tier consumer). dk-approved build.

## What it does
Maps a git diff → changed symbols → fuses the signals snipe already owns → one repo-agnostic `{verdict, reasons}`.

```
$ snipe risk e6df278 951bf23
risk · high (score 8)
  central                internal/store ranks #4/30 by PageRank  (+2)
  role:api_boundary      2 changed symbol(s) in a api_boundary role  (+2)
  role:persistence       5 changed symbol(s) in a persistence role  (+2)
  blast                  11 callers across 5 files  (+1)
  churn-hotspot          internal/store/write.go in churn top-20  (+1)
  changed: 5 files · 5 go · 10 symbols
```
`--format json` → the machine contract the judge parses (verdict under `.results[0]`).

## Signals (additive — beads/GitHub sources bolt on later without reshaping)
| signal | source | weight |
|---|---|---|
| central | changed pkg in PageRank top-5/top-20 | 2 / 1 |
| role:persistence \| api_boundary | changed symbol role | 2 |
| role:entry_point | " | 1 |
| risk:concurrency \| security_boundary | RiskFlags (sn-zd2) | 2 |
| churn-hotspot | changed file in churn top-20 | 1 |
| blast | caller fan-out ≥20/≥8 files, ≥5 | 2 / 1 |

Score sums deduped weights; ≥5 high, ≥2 medium, else low (tunable/documented). **Degrades silently to low (exit 0, no error envelope)** when git or the index can't answer — so the judge can call it on any repo, including prose ones.

## Design notes
- `internal/risk`: pure `Fuse` + diff parser unit-tested; store-backed gatherers have seeded integration tests; exercised end-to-end on this repo's real history.
- Added a **targeted** `context.RolesForSymbols` (only the changed symbols) instead of a whole-repo `InferRoles` pass — refactored `InferRoles` to share `classifySymbol` (behavior-preserving; roles_risk_test still green).
- **Calibration deferred to sn-tgra** (child of the epic): `score≥5→high` fires readily on core-package changes; the epic explicitly defers threshold tuning to the 20-PR replay.

## Incidental fix
Regenerates `TestGolden_Context_Boot.json`: **#185 (e2b7fad) bumped the boot schema 1.0→1.1 (risk_flags) but left the golden stale — `make audit` blackbox has been red on main since that merge.** Fixed here.

`make audit` green (vet, lint, test, race, blackbox, govulncheck).

Plan: `~/Projects/dk/Project/snipe/plans/snipe-risk-command.md`

Closes: sn-v87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `risk` command to assess diff risk from a base ref to a head ref.
  * Supports both JSON and human-readable output, including risk score, reasons, and change statistics.
  * Updated command/help text and usage docs for `risk`.
* **Bug Fixes**
  * Improved resilience when the target isn’t a valid Git work tree or when diff/index data is unavailable, returning a valid low-risk result.
* **Tests**
  * Added unit and help-output coverage for risk scoring and diff parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->