### PR TITLE
feat(risk): opportunistic bead-DAG centrality signal (sn-aa2)

### DIFF
--- a/internal/risk/beads.go
+++ b/internal/risk/beads.go
@@ -1,0 +1,228 @@
+package risk
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Signal code for the bead-DAG centrality signal (stable in the JSON contract).
+const sigBeadCentral = "bead-central"
+
+// Bead-centrality cutoffs (ported from ccp-ydmq bead-signal.sh; still uncalibrated —
+// sn-tgra tunes them). A matched bead's dependent_count — how many beads it blocks —
+// buckets the weight. We take the MAX over matched beads, never the sum: touching one
+// foundational bead is the risk story, and summing would reward bead-spam in a commit.
+const (
+	beadCentralStrong = 3 // max dependent_count >= 3 → strong
+	beadCentralWeak   = 1 // max dependent_count 1-2 → weak
+)
+
+// beadIDShape matches a bead-id-shaped token: a lowercase-led prefix, a final
+// segment, and an optional dotted child index (sn-aa2, cc-plugins-are.2).
+var beadIDShape = regexp.MustCompile(`^[a-z][a-z0-9-]*-[a-z0-9]+(\.[0-9]+)?$`)
+
+// tokenSplit breaks candidate text on any run of non-[alnum.-] characters.
+var tokenSplit = regexp.MustCompile(`[^a-zA-Z0-9.-]+`)
+
+// bead is the subset of a .beads/issues.jsonl line this signal reads.
+type bead struct {
+	ID             string `json:"id"`
+	DependentCount int    `json:"dependent_count"`
+}
+
+// beadsSignal folds bead-DAG centrality into the verdict when the repo carries a
+// git-tracked .beads/issues.jsonl export. It scans the diff's own provenance — the
+// head branch name and the base..head commit messages — for bead-id tokens, matches
+// them against the export (exact, then alias-suffix), and buckets the max
+// dependent_count of the matched beads. Every failure path returns nil silently: a
+// repo without beads, or a diff naming none, contributes no signal.
+//
+// Ported from cc-plugins ccp-ydmq bead-signal.sh. The GitHub-event-payload surface
+// (PR title/body) is intentionally dropped — snipe is a repo-agnostic CLI, and the
+// judge that consumes the verdict owns any CI-metadata folding.
+func beadsSignal(repoRoot, base, head string) []Signal {
+	beads, ok := loadBeads(beadsFile(repoRoot))
+	if !ok || len(beads) == 0 {
+		return nil
+	}
+	text := changeProvenance(repoRoot, base, head)
+	if text == "" {
+		return nil
+	}
+	matched := matchBeads(text, beads)
+	if len(matched) == 0 {
+		return nil
+	}
+
+	maxDC, ids := 0, make([]string, 0, len(matched))
+	for _, b := range matched {
+		ids = append(ids, b.ID)
+		if b.DependentCount > maxDC {
+			maxDC = b.DependentCount
+		}
+	}
+	weight := 0
+	switch {
+	case maxDC >= beadCentralStrong:
+		weight = weightStrong
+	case maxDC >= beadCentralWeak:
+		weight = weightWeak
+	default:
+		return nil
+	}
+
+	sort.Strings(ids)
+	return []Signal{{
+		Signal: sigBeadCentral,
+		Detail: fmt.Sprintf("touches bead(s) %s — one blocks %d others",
+			strings.Join(ids, ","), maxDC),
+		Weight: weight,
+	}}
+}
+
+// beadsFile resolves the issues.jsonl path — the BEADS_FILE override, else the
+// repo's default export location.
+func beadsFile(repoRoot string) string {
+	if p := os.Getenv("BEADS_FILE"); p != "" {
+		return p
+	}
+	return filepath.Join(repoRoot, ".beads", "issues.jsonl")
+}
+
+// loadBeads reads the JSONL export into an id→bead map. A missing file returns
+// (nil, false) — the caller degrades silently. Unparseable lines are skipped, not
+// fatal. ok is true whenever the file opened, even if it held no valid beads.
+func loadBeads(path string) (map[string]bead, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = f.Close() }()
+
+	out := make(map[string]bead)
+	sc := bufio.NewScanner(f)
+	// Bead lines carry full descriptions; the 64 KB default token cap is too small.
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		var b bead
+		if err := json.Unmarshal(sc.Bytes(), &b); err != nil || b.ID == "" {
+			continue
+		}
+		out[b.ID] = b
+	}
+	if err := sc.Err(); err != nil {
+		// A truncated read still yields whatever parsed — partial beads beat none.
+		return out, true
+	}
+	return out, true
+}
+
+// changeProvenance gathers the text that names the beads a diff belongs to: the head
+// branch name and the commit messages unique to base..head. Refs starting with "-"
+// are rejected (flag-injection guard, mirroring gitDiff). Any git failure yields a
+// smaller-but-valid text — the signal degrades, never errors.
+func changeProvenance(repoRoot, base, head string) string {
+	if strings.HasPrefix(base, "-") || strings.HasPrefix(head, "-") {
+		return ""
+	}
+	var sb strings.Builder
+	// Head branch name — a bead id often rides the branch (feat/sn-aa2).
+	if out, err := exec.Command("git", "-C", repoRoot, "rev-parse",
+		"--abbrev-ref", "--end-of-options", head).Output(); err == nil {
+		if br := strings.TrimSpace(string(out)); br != "" && br != "HEAD" {
+			sb.WriteString(br)
+			sb.WriteByte('\n')
+		}
+	}
+	// Commit subjects + bodies for the commits head adds over base.
+	if out, err := exec.Command("git", "-C", repoRoot, "log", "--format=%B",
+		"--end-of-options", base+".."+head).Output(); err == nil {
+		sb.Write(out)
+	}
+	return sb.String()
+}
+
+// matchBeads finds the beads named in text via two tiers: exact id match, then
+// alias-suffix match (a short routing alias like sn-aa2 shares its final segment
+// "aa2" with the canonical id snipe-aa2). The suffix tier requires the token to be
+// bead-id-shaped and its final segment to bear a letter — rejecting utf-8, sha-256.
+func matchBeads(text string, beads map[string]bead) []bead {
+	bySuffix := make(map[string][]string, len(beads))
+	for id := range beads {
+		seg := finalSeg(id)
+		bySuffix[seg] = append(bySuffix[seg], id)
+	}
+
+	seen := make(map[string]bool)
+	var out []bead
+	add := func(id string) {
+		if !seen[id] {
+			seen[id] = true
+			out = append(out, beads[id])
+		}
+	}
+
+	for _, tok := range tokenize(text) {
+		if _, ok := beads[tok]; ok { // tier 1: exact
+			add(tok)
+			continue
+		}
+		if !beadIDShape.MatchString(tok) { // tier 2: alias suffix
+			continue
+		}
+		seg := finalSeg(tok)
+		if !hasLetter(baseSeg(seg)) {
+			continue
+		}
+		for _, id := range bySuffix[seg] {
+			add(id)
+		}
+	}
+	return out
+}
+
+// tokenize splits text into unique candidate tokens, trimming trailing punctuation.
+func tokenize(text string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, raw := range tokenSplit.Split(text, -1) {
+		tok := strings.TrimRight(raw, ".,")
+		if tok == "" || seen[tok] {
+			continue
+		}
+		seen[tok] = true
+		out = append(out, tok)
+	}
+	return out
+}
+
+// finalSeg returns the segment after the last '-' (the id's alias-bearing tail).
+func finalSeg(s string) string {
+	if i := strings.LastIndex(s, "-"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+// baseSeg strips a dotted child index, leaving the letter-bearing base ("are.2"→"are").
+func baseSeg(seg string) string {
+	base, _, _ := strings.Cut(seg, ".")
+	return base
+}
+
+// hasLetter reports whether s contains an ASCII lowercase letter.
+func hasLetter(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'a' && s[i] <= 'z' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/risk/beads_test.go
+++ b/internal/risk/beads_test.go
@@ -1,0 +1,120 @@
+package risk
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMatchBeads_ExactAndAliasSuffix(t *testing.T) {
+	t.Parallel()
+	beads := map[string]bead{
+		"snipe-aa2": {ID: "snipe-aa2", DependentCount: 5},
+		"snipe-vzg": {ID: "snipe-vzg", DependentCount: 9},
+		"other-xyz": {ID: "other-xyz", DependentCount: 1},
+	}
+
+	// Exact id in a commit message; alias id (sn-vzg) on a branch → suffix match.
+	text := "feat/sn-vzg\nfix snipe-aa2: guard nil store\n"
+	got := matchBeads(text, beads)
+
+	ids := map[string]bool{}
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids["snipe-aa2"] || !ids["snipe-vzg"] || len(ids) != 2 {
+		t.Fatalf("matched = %v, want exact snipe-aa2 + alias snipe-vzg only", ids)
+	}
+}
+
+func TestMatchBeads_RejectsNonBeadTokens(t *testing.T) {
+	t.Parallel()
+	beads := map[string]bead{"snipe-256": {ID: "snipe-256", DependentCount: 4}}
+	// sha-256 / utf-8: id-shaped but the final segment bears no letter → no match.
+	if got := matchBeads("bump to sha-256 and utf-8 encoding", beads); len(got) != 0 {
+		t.Fatalf("expected no match for letterless suffixes, got %+v", got)
+	}
+}
+
+func TestBeadsSignal_MissingFileIsSilent(t *testing.T) {
+	t.Parallel()
+	// t.TempDir has no .beads/issues.jsonl → nil, no panic.
+	if got := beadsSignal(t.TempDir(), "HEAD~1", "HEAD"); got != nil {
+		t.Fatalf("expected nil signal without a beads export, got %+v", got)
+	}
+}
+
+func TestBeadsSignal_RejectsFlagLikeRefs(t *testing.T) {
+	t.Parallel()
+	if got := changeProvenance(t.TempDir(), "--output=/tmp/x", "HEAD"); got != "" {
+		t.Fatalf("expected empty provenance for a flag-like base ref, got %q", got)
+	}
+}
+
+// TestBeadsSignal_EndToEnd drives the whole signal through real git: a repo whose
+// HEAD commit message names a central bead (dependent_count 7) yields a strong signal.
+func TestBeadsSignal_EndToEnd(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("base"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-qm", "base")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("head"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-qm", "fix snipe-43i: guard the store")
+
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"id":"snipe-43i","dependent_count":7}` + "\n" +
+		`{"id":"snipe-xxx","dependent_count":0}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := beadsSignal(dir, "HEAD~1", "HEAD")
+	if len(got) != 1 || got[0].Signal != sigBeadCentral || got[0].Weight != weightStrong {
+		t.Fatalf("beadsSignal = %+v, want one strong bead-central", got)
+	}
+}
+
+func TestLoadBeads_ParsesDependentCount(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "issues.jsonl")
+	// Second line is deliberately unparseable — it must be skipped, not fatal.
+	body := `{"id":"snipe-aa2","dependent_count":3}` + "\n" +
+		`not json` + "\n" +
+		`{"id":"snipe-vzg","dependent_count":9}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	beads, ok := loadBeads(path)
+	if !ok || len(beads) != 2 {
+		t.Fatalf("loadBeads = %v (ok=%v), want 2 valid beads", beads, ok)
+	}
+	if beads["snipe-vzg"].DependentCount != 9 {
+		t.Fatalf("dependent_count = %d, want 9", beads["snipe-vzg"].DependentCount)
+	}
+}

--- a/internal/risk/signals.go
+++ b/internal/risk/signals.go
@@ -69,6 +69,7 @@ func Assess(s *store.Store, repoRoot, base, head string) Verdict {
 	signals = append(signals, churnSignal(s, goFiles)...)
 	signals = append(signals, roleSignals(s.DB(), repoRoot, changed)...)
 	signals = append(signals, blastSignal(s.DB(), changed)...)
+	signals = append(signals, beadsSignal(repoRoot, base, head)...)
 
 	return Fuse(signals, stats, false, "")
 }


### PR DESCRIPTION
## What

Adds the LEAN model's second signal source to `snipe risk`: bead-DAG centrality, when the repo carries a git-tracked `.beads/issues.jsonl`.

- Scans the diff's provenance — head branch name + `base..head` commit messages — for bead-id tokens.
- Two-tier match against the export: exact id, then **alias-suffix** (`sn-aa2` ↔ `snipe-aa2`, via shared final segment; rejects letterless suffixes like `sha-256`).
- Buckets the **max** `dependent_count` (never sum — summing rewards bead-spam): `>=3` strong, `1-2` weak.

Ported from cc-plugins `ccp-ydmq` `bead-signal.sh` — the proven passive-jsonl approach (precomputed `dependent_count`, no dolt/bd binary, no network). The GitHub-event-payload surface is intentionally dropped: snipe is a repo-agnostic CLI; the review-judge owns CI-metadata folding.

## Behavior

- Absent `.beads/issues.jsonl` → skipped silently (nil signal). Fits the degrade-silently contract.
- New file `internal/risk/beads.go`; one-line wire into `Assess`. Flag-injection guard mirrors `gitDiff`.

## Not in scope

Thresholds reuse the existing strong/weak weights and stay **uncalibrated** — that's sn-tgra (20-PR replay tuning), which now has the complete signal set to calibrate against.

## Verification

- `make audit` passes (vet, lint, race, blackbox, eval, govulncheck).
- New `internal/risk/beads_test.go`: exact/alias match, letterless-suffix rejection, missing-file silence, flag-ref rejection, jsonl parse, and an **end-to-end** test driving real git (a commit naming a central bead → strong `bead-central`).

Closes: sn-aa2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new risk signal that considers bead-related project data and recent change context when assessing repository risk.
  - Risk assessments now include this additional signal alongside existing signals for a more complete result.

- **Bug Fixes**
  - Improved handling of missing or malformed bead data so assessments continue gracefully instead of failing.
  - Added safeguards for unusual ref inputs to avoid incorrect provenance parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->