### PR TITLE
feat(risk): calibrate high cutoff 5→7 via 20-PR replay (sn-tgra)

### DIFF
--- a/internal/risk/risk.go
+++ b/internal/risk/risk.go
@@ -10,10 +10,13 @@ const (
 	VerdictHigh   = "high"
 )
 
-// Score thresholds for the verdict level (tunable; documented in the plan).
-// Deduped signal weights sum to the score.
+// Score thresholds for the verdict level. Calibrated against a 20-PR trixi replay
+// (sn-tgra): at scoreHigh=5, small changes to a central persistence symbol
+// (central+persistence+blast+churn = 6) read "high" indistinguishably from broad
+// blast-radius PRs. Raising to 7 reserves "high" (→ full review) for changes that
+// clear two strong signals AND breadth; two-strong-plus-a-weak lands "medium".
 const (
-	scoreHigh   = 5 // score >= scoreHigh   → high
+	scoreHigh   = 7 // score >= scoreHigh   → high
 	scoreMedium = 2 // score >= scoreMedium → medium; else low
 )
 

--- a/internal/risk/risk_test.go
+++ b/internal/risk/risk_test.go
@@ -38,10 +38,14 @@ func TestFuse_Thresholds(t *testing.T) {
 		{"score 4 is medium", []Signal{
 			{Signal: sigCentral, Weight: 2}, {Signal: sigRolePrefix + "persistence", Weight: 2},
 		}, VerdictMedium, 4},
-		{"score 5 is high", []Signal{
+		{"score 6 is medium (small central persistence change — sn-tgra)", []Signal{
 			{Signal: sigCentral, Weight: 2}, {Signal: sigRolePrefix + "persistence", Weight: 2},
-			{Signal: sigChurn, Weight: 1},
-		}, VerdictHigh, 5},
+			{Signal: sigBlast, Weight: 1}, {Signal: sigChurn, Weight: 1},
+		}, VerdictMedium, 6},
+		{"score 7 is high", []Signal{
+			{Signal: sigCentral, Weight: 2}, {Signal: sigRolePrefix + "persistence", Weight: 2},
+			{Signal: sigRolePrefix + "api_boundary", Weight: 2}, {Signal: sigChurn, Weight: 1},
+		}, VerdictHigh, 7},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/scripts/risk-replay.sh
+++ b/scripts/risk-replay.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# risk-replay.sh — calibrate `snipe risk` verdict tiers against a repo's merge history.
+#
+# For each of the last N merge commits M in TARGET_REPO, this replays the PR:
+#   checkout M (head) in an ISOLATED worktree → snipe index → snipe risk M^1 M
+# and tabulates the verdict-tier distribution. Reindexing at each head is REQUIRED:
+# a stale index can't map an old diff's file:line to symbols, so every historical
+# PR falsely reads 0-symbol "low" (see sn-tgra). ~15s/reindex on trixi-sized repos.
+#
+# Usage: scripts/risk-replay.sh <target-repo> [N] [snipe-bin]
+#   target-repo : path to the Go repo to replay (must have a .snipe index buildable)
+#   N           : number of recent merges to replay (default 20)
+#   snipe-bin   : path to snipe binary (default: build from this repo)
+set -euo pipefail
+
+TARGET="${1:?usage: risk-replay.sh <target-repo> [N] [snipe-bin]}"
+N="${2:-20}"
+SNIPE_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SNIPE_BIN="${3:-}"
+
+if [[ -z "$SNIPE_BIN" ]]; then
+  SNIPE_BIN="$(mktemp -t snipe-risk-replay.XXXXXX)"
+  echo "building snipe → $SNIPE_BIN" >&2
+  (cd "$SNIPE_REPO" && go build -o "$SNIPE_BIN" .)
+fi
+
+TARGET="$(cd "$TARGET" && pwd)"
+WT="$(mktemp -d -t risk-replay-wt.XXXXXX)"
+cleanup() { git -C "$TARGET" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"; }
+trap cleanup EXIT
+
+# Detached worktree so the target's live checkout (possibly dirty, on a team branch) is untouched.
+merges="$(git -C "$TARGET" log --merges -n "$N" --format='%H')"
+git -C "$TARGET" worktree add --detach "$WT" HEAD >/dev/null 2>&1
+
+# Prime the worktree's OWN index once (cold, ~2-3min). Every later checkout then
+# reindexes INCREMENTALLY against this (~15s), since the index's repo_root now matches
+# the worktree. Seeding from $TARGET/.snipe does NOT work: its baked-in repo_root points
+# at the target, so snipe treats it as foreign and rebuilds cold each time.
+echo "priming worktree index (cold, ~2-3min)…" >&2
+( cd "$WT" && "$SNIPE_BIN" index --embed-mode=off --enrich=false >/dev/null 2>&1 ) || true
+
+printf '%-10s  %-7s  %-6s  %-6s  %-6s  %s\n' MERGE VERDICT SCORE FILES SYMS REASONS
+declare -A tier_count
+i=0
+# One flaky merge (no first parent, empty diff, jq miss) must not abort the sweep —
+# every fallible step degrades to a skipped/low row instead of tripping `set -e`.
+while read -r M; do
+  [[ -z "$M" ]] && continue
+  short="$(git -C "$TARGET" rev-parse --short "$M" 2>/dev/null || echo "${M:0:8}")"
+  git -C "$WT" checkout -f "$M" >/dev/null 2>&1 || { echo "$short  SKIP (checkout failed)"; continue; }
+  ( cd "$WT" && "$SNIPE_BIN" index --embed-mode=off --enrich=false >/dev/null 2>&1 ) || true
+  json="$( (cd "$WT" && "$SNIPE_BIN" risk "${M}^1" "$M" --format json 2>/dev/null) || true )"
+  line="$(echo "$json" | jq -r '.results[0] | "\(.verdict) \(.score) \(.changed.files) \(.changed.symbols) \((.reasons // []) | map(.signal) | join(","))"' 2>/dev/null || true)"
+  read -r verdict score files syms reasons <<< "${line:-low 0 0 0 —}"
+  printf '%-10s  %-7s  %-6s  %-6s  %-6s  %s\n' "$short" "${verdict:-low}" "${score:-0}" "${files:-0}" "${syms:-0}" "${reasons:-—}"
+  tier_count[${verdict:-low}]=$(( ${tier_count[${verdict:-low}]:-0} + 1 ))
+  i=$((i+1))
+done <<< "$merges"
+
+echo
+echo "distribution over $i merges (tool's current cutoffs — high>=7 medium>=2 as of sn-tgra):"
+for t in high medium low; do
+  printf '  %-7s %s\n' "$t" "${tier_count[$t]:-0}"
+done

--- a/scripts/risk-replay.sh
+++ b/scripts/risk-replay.sh
@@ -13,21 +13,34 @@
 #   snipe-bin   : path to snipe binary (default: build from this repo)
 set -euo pipefail
 
+# jq parses every `snipe risk` verdict below; without it each merge silently
+# falls back to "low 0" and the whole calibration reads bogus. Fail loud instead.
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required but not installed" >&2; exit 1; }
+
 TARGET="${1:?usage: risk-replay.sh <target-repo> [N] [snipe-bin]}"
 N="${2:-20}"
 SNIPE_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SNIPE_BIN="${3:-}"
 
+# Register cleanup BEFORE anything mktemp's, so a failed `go build` can't orphan files.
+WT=""
+CLEANUP_BIN=""
+cleanup() {
+  [[ -n "$WT" ]] && { git -C "$TARGET" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"; }
+  [[ -n "$CLEANUP_BIN" ]] && rm -f "$CLEANUP_BIN"
+  return 0
+}
+trap cleanup EXIT
+
 if [[ -z "$SNIPE_BIN" ]]; then
   SNIPE_BIN="$(mktemp -t snipe-risk-replay.XXXXXX)"
+  CLEANUP_BIN="$SNIPE_BIN"  # we built it → we delete it (skip cleanup for a caller-supplied bin)
   echo "building snipe → $SNIPE_BIN" >&2
   (cd "$SNIPE_REPO" && go build -o "$SNIPE_BIN" .)
 fi
 
 TARGET="$(cd "$TARGET" && pwd)"
 WT="$(mktemp -d -t risk-replay-wt.XXXXXX)"
-cleanup() { git -C "$TARGET" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"; }
-trap cleanup EXIT
 
 # Detached worktree so the target's live checkout (possibly dirty, on a team branch) is untouched.
 merges="$(git -C "$TARGET" log --merges -n "$N" --format='%H')"


### PR DESCRIPTION
## What

Calibrates `snipe risk`'s high-verdict cutoff against a 20-PR trixi replay, and lands the (rebuilt) calibration harness.

## Why

At `scoreHigh=5`, the 20-PR replay read **5H / 3M / 8L** — but three *small* PRs (4-5 files) tripped **high(6)** via `central(2)+role:persistence(2)+blast(1)+churn(1)`. Any change to a central persistence symbol read "high" regardless of breadth (the sn-tgra worry, confirmed empirically).

## Change

- `scoreHigh` 5 → 7 (scoreMedium unchanged). New distribution: **2H / 6M / 8L**.
  - *high* (→ full review) now needs two strong signals **and** breadth.
  - small-but-central → *medium* (→ codex advisory), matching the review-judge's `none|codex|full` cost ladder.
- `scripts/risk-replay.sh` — the calibration harness, committed. Isolated git worktree (leaves the target's checkout untouched), cold-prime once then incremental reindex per PR. Replaces the lost/obsolete `ccp-1lk5` scratch harness. Header documents the two traps: stale-index replay reads historical diffs as 0-symbol "low", and cross-root index seeding rebuilds cold.

## Verify

`make` green (vet + lint + test). `risk_test.go` updated: score-6 central-persistence combo now asserts *medium*, added a score-7 *high* case. Harness smoke-tested end-to-end (N=3, footer + hardened skip-on-error confirmed).

Closes: sn-tgra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Risk Assessment**
  * Adjusted risk verdict thresholds: scores of **7+** are now classified as **high** (previously **5**), while **6** is **medium**.
  * Updated the mapping for “high” risk to reflect narrower vs broader diff signals for more consistent verdicts.

* **Tools**
  * Added a calibration utility to replay recent risk assessments across merge commits and summarize verdict distributions.

* **Tests**
  * Updated threshold expectations to match the new scoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->