### PR TITLE
snipe verify foundations: working-tree diff + hunk→symbol overlap (sn-8f6q.1, .2)

### DIFF
--- a/internal/query/overlap.go
+++ b/internal/query/overlap.go
@@ -15,6 +15,41 @@ type LineRange struct {
 	End   int
 }
 
+// mergeRanges normalizes a file's line ranges — swapping inverted bounds, then
+// sorting and coalescing overlapping or adjacent spans — so the overlap query
+// emits one predicate per distinct span instead of one per raw hunk. Fewer
+// predicates means fewer bind parameters and a shallower OR tree on large diffs.
+func mergeRanges(ranges []LineRange) []LineRange {
+	if len(ranges) == 0 {
+		return nil
+	}
+	norm := make([]LineRange, len(ranges))
+	for i, r := range ranges {
+		if r.End < r.Start {
+			r.Start, r.End = r.End, r.Start
+		}
+		norm[i] = r
+	}
+	sort.Slice(norm, func(i, j int) bool {
+		if norm[i].Start != norm[j].Start {
+			return norm[i].Start < norm[j].Start
+		}
+		return norm[i].End < norm[j].End
+	})
+	merged := norm[:1]
+	for _, r := range norm[1:] {
+		last := &merged[len(merged)-1]
+		if r.Start <= last.End+1 { // overlapping or directly adjacent
+			if r.End > last.End {
+				last.End = r.End
+			}
+			continue
+		}
+		merged = append(merged, r)
+	}
+	return merged
+}
+
 // FindOverlappingSymbols returns the symbols whose declared range
 // [line_start, line_end] overlaps at least one changed line range, batched
 // across every file in changes with a single query. changes maps each
@@ -73,19 +108,15 @@ func FindOverlappingSymbols(db *sql.DB, repoRoot string, changes map[string][]Li
 		if _, ok := staleSet[toRelPath(p, repoRoot)]; ok {
 			continue // already covered by the stale IN(...) clause above
 		}
-		ranges := changes[p]
+		ranges := mergeRanges(changes[p])
 		if len(ranges) == 0 {
 			continue
 		}
 		var rangeClauses []string
 		var rangeArgs []any
 		for _, r := range ranges {
-			start, end := r.Start, r.End
-			if end < start {
-				start, end = end, start
-			}
 			rangeClauses = append(rangeClauses, "(s.line_start <= ? AND s.line_end >= ?)")
-			rangeArgs = append(rangeArgs, end, start)
+			rangeArgs = append(rangeArgs, r.End, r.Start)
 		}
 		clauses = append(clauses, "(s.file_path = ? AND ("+strings.Join(rangeClauses, " OR ")+"))")
 		args = append(args, p)

--- a/internal/query/overlap.go
+++ b/internal/query/overlap.go
@@ -1,0 +1,114 @@
+package query
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LineRange is an inclusive [Start, End] span of changed lines within one
+// file — typically one diff hunk. Start and End are 1-based, matching the
+// symbols table's line_start/line_end.
+type LineRange struct {
+	Start int
+	End   int
+}
+
+// FindOverlappingSymbols returns the symbols whose declared range
+// [line_start, line_end] overlaps at least one changed line range, batched
+// across every file in changes with a single query. changes maps each
+// file's absolute path to the line ranges that changed in it.
+//
+// Overlap is inclusive on both ends: a hunk that only touches a symbol's
+// first or last line still counts, as does a hunk entirely inside a
+// symbol's body or a symbol entirely inside a hunk.
+//
+// Staleness fallback: for each file, CheckPathStaleness compares on-disk
+// mtime/hash against what was stored at index time. When a file comes back
+// stale, the index's line numbers may no longer line up with the working
+// tree, so hunk-precise matching isn't trustworthy — every symbol in that
+// file is returned instead. Fresh files get hunk-precise matching.
+func FindOverlappingSymbols(db *sql.DB, repoRoot string, changes map[string][]LineRange) ([]SymbolRow, error) {
+	if len(changes) == 0 {
+		return nil, nil
+	}
+
+	paths := make([]string, 0, len(changes))
+	for p := range changes {
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	sort.Strings(paths)
+
+	staleRel := CheckPathStaleness(db, repoRoot, paths)
+	staleSet := make(map[string]struct{}, len(staleRel))
+	for _, rel := range staleRel {
+		staleSet[rel] = struct{}{}
+	}
+
+	var clauses []string
+	var args []any
+
+	var staleAbs []string
+	for _, p := range paths {
+		if _, ok := staleSet[toRelPath(p, repoRoot)]; ok {
+			staleAbs = append(staleAbs, p)
+		}
+	}
+	if len(staleAbs) > 0 {
+		placeholders := make([]string, len(staleAbs))
+		for i, p := range staleAbs {
+			placeholders[i] = "?"
+			args = append(args, p)
+		}
+		clauses = append(clauses, "s.file_path IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	for _, p := range paths {
+		if _, ok := staleSet[toRelPath(p, repoRoot)]; ok {
+			continue // already covered by the stale IN(...) clause above
+		}
+		ranges := changes[p]
+		if len(ranges) == 0 {
+			continue
+		}
+		var rangeClauses []string
+		var rangeArgs []any
+		for _, r := range ranges {
+			start, end := r.Start, r.End
+			if end < start {
+				start, end = end, start
+			}
+			rangeClauses = append(rangeClauses, "(s.line_start <= ? AND s.line_end >= ?)")
+			rangeArgs = append(rangeArgs, end, start)
+		}
+		clauses = append(clauses, "(s.file_path = ? AND ("+strings.Join(rangeClauses, " OR ")+"))")
+		args = append(args, p)
+		args = append(args, rangeArgs...)
+	}
+
+	if len(clauses) == 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.pkg_path, s.line_start, s.col_start, s.line_end, s.col_end,
+		       s.signature, s.doc, s.receiver, f.hash
+		FROM symbols s
+		LEFT JOIN files f ON s.file_path = f.path
+		WHERE ` + strings.Join(clauses, " OR ") + `
+		ORDER BY s.file_path, s.line_start, s.id`
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query overlapping symbols: %w", err)
+	}
+	defer rows.Close()
+
+	return scanSymbolRows(rows)
+}

--- a/internal/query/overlap_test.go
+++ b/internal/query/overlap_test.go
@@ -10,6 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMergeRanges(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []LineRange
+		want []LineRange
+	}{
+		{"empty", nil, nil},
+		{"single", []LineRange{{5, 10}}, []LineRange{{5, 10}}},
+		{"inverted bounds swapped", []LineRange{{10, 5}}, []LineRange{{5, 10}}},
+		{"overlapping merged", []LineRange{{1, 5}, {4, 8}}, []LineRange{{1, 8}}},
+		{"adjacent merged", []LineRange{{1, 3}, {4, 6}}, []LineRange{{1, 6}}},
+		{"disjoint kept", []LineRange{{1, 3}, {10, 12}}, []LineRange{{1, 3}, {10, 12}}},
+		{"unsorted input", []LineRange{{10, 12}, {1, 3}, {2, 4}}, []LineRange{{1, 4}, {10, 12}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, mergeRanges(tt.in))
+		})
+	}
+}
+
 // insertOverlapSym inserts a symbol with an explicit line range, for overlap
 // testing where the fixed 1-10 range from insertTestSym isn't precise enough.
 func insertOverlapSym(t *testing.T, db *sql.DB, id, name, filePath, filePathRel string, lineStart, lineEnd int) {

--- a/internal/query/overlap_test.go
+++ b/internal/query/overlap_test.go
@@ -1,0 +1,218 @@
+package query
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// insertOverlapSym inserts a symbol with an explicit line range, for overlap
+// testing where the fixed 1-10 range from insertTestSym isn't precise enough.
+func insertOverlapSym(t *testing.T, db *sql.DB, id, name, filePath, filePathRel string, lineStart, lineEnd int) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO symbols (id, name, kind, file_path, file_path_rel, pkg_path,
+		line_start, col_start, line_end, col_end, signature, doc, receiver)
+		VALUES (?, ?, 'func', ?, ?, 'pkg/example', ?, 1, ?, 1, '', '', '')`,
+		id, name, filePath, filePathRel, lineStart, lineEnd)
+	require.NoError(t, err)
+}
+
+// markFresh writes a real file to disk and records it in the files table
+// with a stored mtime at or after the file's actual mtime, so
+// CheckPathStaleness sees it as fresh (hunk-precise matching applies).
+func markFresh(t *testing.T, db *sql.DB, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("package example\n"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	// Store a stored mtime comfortably ahead of the actual mtime so the
+	// comparison (`disk mtime > stored mtime`) is unambiguously false,
+	// regardless of filesystem timestamp resolution.
+	storedMtime := info.ModTime().Add(time.Hour).Unix()
+	_, err = db.Exec(`INSERT INTO files (path, mtime, hash) VALUES (?, ?, '')`, path, storedMtime)
+	require.NoError(t, err)
+}
+
+// markStaleByMtime writes a real file to disk and records a stored mtime far
+// in the past, so CheckPathStaleness reports it stale via the mtime-changed
+// path (as opposed to the "not indexed at all" path).
+func markStaleByMtime(t *testing.T, db *sql.DB, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("package example\n"), 0o600))
+	_, err := db.Exec(`INSERT INTO files (path, mtime, hash) VALUES (?, 0, '')`, path)
+	require.NoError(t, err)
+}
+
+func TestFindOverlappingSymbols_ReturnsEmpty_When_NoChanges(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+
+	got, err := FindOverlappingSymbols(db, "", nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	got, err = FindOverlappingSymbols(db, "", map[string][]LineRange{})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestFindOverlappingSymbols_ReturnsSymbol_When_HunkInsideSymbol(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "order.go")
+	markFresh(t, db, path)
+
+	insertOverlapSym(t, db, "s1", "ProcessOrder", path, "order.go", 10, 50)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {{Start: 20, End: 25}}, // hunk entirely inside the symbol's body
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "ProcessOrder", got[0].Name)
+}
+
+func TestFindOverlappingSymbols_ReturnsSymbol_When_SymbolInsideHunk(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "small.go")
+	markFresh(t, db, path)
+
+	insertOverlapSym(t, db, "s1", "Tiny", path, "small.go", 10, 15)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {{Start: 1, End: 100}}, // hunk spans well beyond the symbol
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "Tiny", got[0].Name)
+}
+
+func TestFindOverlappingSymbols_ReturnsSymbol_When_BoundaryLinesTouch(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "boundary.go")
+	markFresh(t, db, path)
+
+	// Symbol occupies lines 10-20. A hunk ending exactly at the symbol's
+	// first line, and a hunk starting exactly at the symbol's last line,
+	// both count as overlaps — boundaries are inclusive.
+	insertOverlapSym(t, db, "s1", "AtStart", path, "boundary.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "AtEnd", path, "boundary.go", 30, 40)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {
+			{Start: 1, End: 10},  // touches AtStart's first line only
+			{Start: 40, End: 45}, // touches AtEnd's last line only
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	names := []string{got[0].Name, got[1].Name}
+	require.ElementsMatch(t, []string{"AtStart", "AtEnd"}, names)
+}
+
+func TestFindOverlappingSymbols_ExcludesSymbol_When_RangeDoesNotOverlap(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "far.go")
+	markFresh(t, db, path)
+
+	insertOverlapSym(t, db, "s1", "Untouched", path, "far.go", 100, 120)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {{Start: 1, End: 99}}, // one line short of the symbol's start
+	})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestFindOverlappingSymbols_ReturnsAllFileSymbols_When_FileNotIndexed(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+
+	// No row in the files table at all — CheckPathStaleness treats an
+	// unindexed file as stale without touching disk.
+	path := "/repo/unindexed.go"
+	insertOverlapSym(t, db, "s1", "InRange", path, "unindexed.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "FarOutOfRange", path, "unindexed.go", 500, 520)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {{Start: 10, End: 12}}, // would only hit "InRange" under hunk-precise matching
+	})
+	require.NoError(t, err)
+	// Staleness fallback: both symbols come back, not just the one the hunk touches.
+	require.Len(t, got, 2)
+	names := []string{got[0].Name, got[1].Name}
+	require.ElementsMatch(t, []string{"InRange", "FarOutOfRange"}, names)
+}
+
+func TestFindOverlappingSymbols_ReturnsAllFileSymbols_When_MtimeIsStale(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stale.go")
+	markStaleByMtime(t, db, path)
+
+	insertOverlapSym(t, db, "s1", "InRange", path, "stale.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "FarOutOfRange", path, "stale.go", 500, 520)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {{Start: 10, End: 12}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func TestFindOverlappingSymbols_BatchesAcrossFiles_When_MultipleFilesChanged(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	freshPath := filepath.Join(dir, "fresh.go")
+	markFresh(t, db, freshPath)
+	stalePath := "/repo/stale-unindexed.go"
+
+	insertOverlapSym(t, db, "s1", "FreshHit", freshPath, "fresh.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "FreshMiss", freshPath, "fresh.go", 500, 520)
+	insertOverlapSym(t, db, "s3", "StaleAlwaysIncluded", stalePath, "stale-unindexed.go", 500, 520)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		freshPath: {{Start: 10, End: 15}},
+		stalePath: {{Start: 1, End: 2}}, // irrelevant range — stale fallback ignores it
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	names := []string{got[0].Name, got[1].Name}
+	require.ElementsMatch(t, []string{"FreshHit", "StaleAlwaysIncluded"}, names)
+}
+
+func TestFindOverlappingSymbols_HandlesMultipleHunksInOneFile_When_RangesDisjoint(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "multi.go")
+	markFresh(t, db, path)
+
+	insertOverlapSym(t, db, "s1", "First", path, "multi.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "Second", path, "multi.go", 100, 120)
+	insertOverlapSym(t, db, "s3", "Neither", path, "multi.go", 200, 220)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {
+			{Start: 15, End: 15},
+			{Start: 110, End: 110},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	names := []string{got[0].Name, got[1].Name}
+	require.ElementsMatch(t, []string{"First", "Second"}, names)
+}

--- a/internal/risk/diff.go
+++ b/internal/risk/diff.go
@@ -134,7 +134,8 @@ func workingTreeDiff(repoRoot string) (changes []FileChange, ok bool) {
 		"--unified=0", "--no-color", "-M", "HEAD", "--", "*.go").Output()
 	if err != nil {
 		// Most commonly an unborn HEAD (no commits yet); degrade rather than
-		// fail, same as gitDiff's unresolved-ref case.
+		// fail, same as gitDiff's unresolved-ref case. verify has nothing
+		// meaningful to say about a repo with no baseline commit.
 		return nil, false
 	}
 	changes = parseDiff(string(out))
@@ -147,13 +148,17 @@ func workingTreeDiff(repoRoot string) (changes []FileChange, ok bool) {
 // filesystem error drops the offending file rather than failing the caller —
 // this is a best-effort addition to workingTreeDiff, not a source of truth.
 func untrackedGoChanges(repoRoot string) []FileChange {
+	// -z emits NUL-separated, unquoted paths — robust against spaces, quotes,
+	// non-ASCII, and CRLF, all of which git otherwise quotes or mangles in the
+	// default newline-separated output.
 	out, err := exec.Command("git", "-C", repoRoot, "ls-files",
-		"--others", "--exclude-standard", "--", "*.go").Output()
+		"-z", "--others", "--exclude-standard", "--", "*.go").Output()
 	if err != nil {
 		return nil
 	}
 	var changes []FileChange
-	for path := range strings.SplitSeq(strings.TrimRight(string(out), "\n"), "\n") {
+	for pathBytes := range bytes.SplitSeq(out, []byte{0}) {
+		path := string(pathBytes)
 		if path == "" {
 			continue
 		}

--- a/internal/risk/diff.go
+++ b/internal/risk/diff.go
@@ -8,7 +8,10 @@
 package risk
 
 import (
+	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -105,6 +108,79 @@ func parseHunkHead(line string) (start, count int, ok bool) {
 		}
 	}
 	return start, count, true
+}
+
+// workingTreeDiff runs `git diff HEAD` (staged + unstaged combined, since both
+// are compared straight against HEAD rather than against each other) at
+// repoRoot, plus a separate untracked-file pass, and returns the same
+// []FileChange shape gitDiff/parseDiff produce for a ref-to-ref diff.
+// Untracked .go files are synthesized as whole-file changes spanning line 1
+// to their line count — git diff never reports them since they're outside
+// the index. ok is false — with no error — when git is absent or repoRoot
+// isn't a work tree, mirroring gitDiff's degrade-to-low-verdict contract.
+//
+// Rename detection (-M) is explicit here so a `git mv` + edit resolves to one
+// FileChange at the new path rather than a dropped delete plus a whole-file
+// add; a pure rename with no content change yields no hunks and so
+// contributes nothing, consistent with parseDiff dropping zero-range files.
+func workingTreeDiff(repoRoot string) (changes []FileChange, ok bool) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, false
+	}
+	if err := exec.Command("git", "-C", repoRoot, "rev-parse", "--is-inside-work-tree").Run(); err != nil {
+		return nil, false
+	}
+	out, err := exec.Command("git", "-C", repoRoot, "diff",
+		"--unified=0", "--no-color", "-M", "HEAD", "--", "*.go").Output()
+	if err != nil {
+		// Most commonly an unborn HEAD (no commits yet); degrade rather than
+		// fail, same as gitDiff's unresolved-ref case.
+		return nil, false
+	}
+	changes = parseDiff(string(out))
+	changes = append(changes, untrackedGoChanges(repoRoot)...)
+	return changes, true
+}
+
+// untrackedGoChanges lists untracked .go files at repoRoot (relative to it)
+// and synthesizes a whole-file FileChange for each non-empty one. Any git or
+// filesystem error drops the offending file rather than failing the caller —
+// this is a best-effort addition to workingTreeDiff, not a source of truth.
+func untrackedGoChanges(repoRoot string) []FileChange {
+	out, err := exec.Command("git", "-C", repoRoot, "ls-files",
+		"--others", "--exclude-standard", "--", "*.go").Output()
+	if err != nil {
+		return nil
+	}
+	var changes []FileChange
+	for path := range strings.SplitSeq(strings.TrimRight(string(out), "\n"), "\n") {
+		if path == "" {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(repoRoot, path))
+		if err != nil {
+			continue
+		}
+		n := countLines(content)
+		if n == 0 {
+			continue
+		}
+		changes = append(changes, FileChange{Path: path, LineRanges: [][2]int{{1, n}}})
+	}
+	return changes
+}
+
+// countLines counts newline-delimited lines in content, counting a final
+// unterminated line if present. An empty slice has zero lines.
+func countLines(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	n := bytes.Count(content, []byte("\n"))
+	if content[len(content)-1] != '\n' {
+		n++
+	}
+	return n
 }
 
 // changedGoFiles returns the paths of changed .go files, preserving order.

--- a/internal/risk/diff_test.go
+++ b/internal/risk/diff_test.go
@@ -123,16 +123,16 @@ func writeFile(t *testing.T, dir, name, body string) {
 }
 
 // commitAll stages every change in dir and commits it.
-func commitAll(t *testing.T, dir, msg string) {
+func commitAll(t *testing.T, dir string) {
 	t.Helper()
 	runGit(t, dir, "add", "-A")
-	runGit(t, dir, "commit", "-q", "-m", msg)
+	runGit(t, dir, "commit", "-q", "-m", "init")
 }
 
 func TestWorkingTreeDiff_CapturesStagedChanges_When_ChangeIsStagedOnly(t *testing.T) {
 	dir := gitRepo(t)
 	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n")
-	commitAll(t, dir, "init")
+	commitAll(t, dir)
 
 	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
 	runGit(t, dir, "add", "a.go")
@@ -150,7 +150,7 @@ func TestWorkingTreeDiff_CapturesStagedChanges_When_ChangeIsStagedOnly(t *testin
 func TestWorkingTreeDiff_CapturesUnstagedChanges_When_ChangeIsUnstagedOnly(t *testing.T) {
 	dir := gitRepo(t)
 	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n")
-	commitAll(t, dir, "init")
+	commitAll(t, dir)
 
 	// Modify without staging.
 	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
@@ -169,7 +169,7 @@ func TestWorkingTreeDiff_CapturesMixedChanges_When_OneFileStagedAndAnotherIsNot(
 	dir := gitRepo(t)
 	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n")
 	writeFile(t, dir, "b.go", "package p\n\nfunc C() {}\n")
-	commitAll(t, dir, "init")
+	commitAll(t, dir)
 
 	// a.go: staged change.
 	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
@@ -193,7 +193,7 @@ func TestWorkingTreeDiff_CapturesMixedChanges_When_OneFileStagedAndAnotherIsNot(
 func TestWorkingTreeDiff_SynthesizesWholeFileChange_When_FileIsUntracked(t *testing.T) {
 	dir := gitRepo(t)
 	writeFile(t, dir, "a.go", "package p\n")
-	commitAll(t, dir, "init")
+	commitAll(t, dir)
 
 	writeFile(t, dir, "new.go", "package p\n\nfunc New() {}\n")
 
@@ -210,7 +210,7 @@ func TestWorkingTreeDiff_SynthesizesWholeFileChange_When_FileIsUntracked(t *test
 func TestWorkingTreeDiff_TracksRenamedFile_When_ContentIsModified(t *testing.T) {
 	dir := gitRepo(t)
 	writeFile(t, dir, "old.go", "package p\n\nfunc A() {}\n")
-	commitAll(t, dir, "init")
+	commitAll(t, dir)
 
 	runGit(t, dir, "mv", "old.go", "new.go")
 	writeFile(t, dir, "new.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
@@ -229,7 +229,7 @@ func TestWorkingTreeDiff_TracksRenamedFile_When_ContentIsModified(t *testing.T) 
 func TestWorkingTreeDiff_ReportsNoChanges_When_TreeIsClean(t *testing.T) {
 	dir := gitRepo(t)
 	writeFile(t, dir, "a.go", "package p\n")
-	commitAll(t, dir, "init")
+	commitAll(t, dir)
 
 	changes, ok := workingTreeDiff(dir)
 	if !ok {

--- a/internal/risk/diff_test.go
+++ b/internal/risk/diff_test.go
@@ -1,6 +1,9 @@
 package risk
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -77,5 +80,174 @@ func TestChangedGoFiles_FiltersToGo(t *testing.T) {
 	want := []string{"cmd/risk.go", "internal/risk/diff.go"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("changedGoFiles=%v want %v", got, want)
+	}
+}
+
+// --- workingTreeDiff: real git repo fixtures ---
+//
+// gitDiff/parseDiff are exercised above with hand-built diff streams. The
+// working-tree path is easier to trust against a real repo, since staged vs.
+// unstaged vs. untracked state is the index/worktree's job to produce, not
+// ours to fake.
+
+// gitRepo builds a throwaway repository in a temp dir and returns its root.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Tester")
+	return dir
+}
+
+// runGit runs a git subcommand in dir, failing the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// writeFile writes body to name under dir, creating parent dirs as needed.
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// commitAll stages every change in dir and commits it.
+func commitAll(t *testing.T, dir, msg string) {
+	t.Helper()
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-q", "-m", msg)
+}
+
+func TestWorkingTreeDiff_CapturesStagedChanges_When_ChangeIsStagedOnly(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n")
+	commitAll(t, dir, "init")
+
+	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
+	runGit(t, dir, "add", "a.go")
+
+	changes, ok := workingTreeDiff(dir)
+	if !ok {
+		t.Fatal("workingTreeDiff not ok")
+	}
+	want := []FileChange{{Path: "a.go", LineRanges: [][2]int{{4, 5}}}}
+	if !reflect.DeepEqual(changes, want) {
+		t.Fatalf("got %+v want %+v", changes, want)
+	}
+}
+
+func TestWorkingTreeDiff_CapturesUnstagedChanges_When_ChangeIsUnstagedOnly(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n")
+	commitAll(t, dir, "init")
+
+	// Modify without staging.
+	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
+
+	changes, ok := workingTreeDiff(dir)
+	if !ok {
+		t.Fatal("workingTreeDiff not ok")
+	}
+	want := []FileChange{{Path: "a.go", LineRanges: [][2]int{{4, 5}}}}
+	if !reflect.DeepEqual(changes, want) {
+		t.Fatalf("got %+v want %+v", changes, want)
+	}
+}
+
+func TestWorkingTreeDiff_CapturesMixedChanges_When_OneFileStagedAndAnotherIsNot(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n")
+	writeFile(t, dir, "b.go", "package p\n\nfunc C() {}\n")
+	commitAll(t, dir, "init")
+
+	// a.go: staged change.
+	writeFile(t, dir, "a.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
+	runGit(t, dir, "add", "a.go")
+	// b.go: unstaged change.
+	writeFile(t, dir, "b.go", "package p\n\nfunc C() {}\n\nfunc D() {}\n")
+
+	changes, ok := workingTreeDiff(dir)
+	if !ok {
+		t.Fatal("workingTreeDiff not ok")
+	}
+	want := []FileChange{
+		{Path: "a.go", LineRanges: [][2]int{{4, 5}}},
+		{Path: "b.go", LineRanges: [][2]int{{4, 5}}},
+	}
+	if !reflect.DeepEqual(changes, want) {
+		t.Fatalf("got %+v want %+v", changes, want)
+	}
+}
+
+func TestWorkingTreeDiff_SynthesizesWholeFileChange_When_FileIsUntracked(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "a.go", "package p\n")
+	commitAll(t, dir, "init")
+
+	writeFile(t, dir, "new.go", "package p\n\nfunc New() {}\n")
+
+	changes, ok := workingTreeDiff(dir)
+	if !ok {
+		t.Fatal("workingTreeDiff not ok")
+	}
+	want := []FileChange{{Path: "new.go", LineRanges: [][2]int{{1, 3}}}}
+	if !reflect.DeepEqual(changes, want) {
+		t.Fatalf("got %+v want %+v", changes, want)
+	}
+}
+
+func TestWorkingTreeDiff_TracksRenamedFile_When_ContentIsModified(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "old.go", "package p\n\nfunc A() {}\n")
+	commitAll(t, dir, "init")
+
+	runGit(t, dir, "mv", "old.go", "new.go")
+	writeFile(t, dir, "new.go", "package p\n\nfunc A() {}\n\nfunc B() {}\n")
+	runGit(t, dir, "add", "new.go")
+
+	changes, ok := workingTreeDiff(dir)
+	if !ok {
+		t.Fatal("workingTreeDiff not ok")
+	}
+	want := []FileChange{{Path: "new.go", LineRanges: [][2]int{{4, 5}}}}
+	if !reflect.DeepEqual(changes, want) {
+		t.Fatalf("got %+v want %+v", changes, want)
+	}
+}
+
+func TestWorkingTreeDiff_ReportsNoChanges_When_TreeIsClean(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "a.go", "package p\n")
+	commitAll(t, dir, "init")
+
+	changes, ok := workingTreeDiff(dir)
+	if !ok {
+		t.Fatal("workingTreeDiff not ok")
+	}
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes on a clean tree, got %+v", changes)
+	}
+}
+
+func TestWorkingTreeDiff_DegradesOk_When_NotAGitRepo(t *testing.T) {
+	dir := t.TempDir() // no git init
+
+	changes, ok := workingTreeDiff(dir)
+	if ok {
+		t.Fatalf("expected ok=false for non-git dir, got changes=%+v", changes)
+	}
+	if changes != nil {
+		t.Errorf("expected nil changes, got %+v", changes)
 	}
 }


### PR DESCRIPTION
Two foundations for `snipe verify` (epic sn-8f6q) — diff-native verification.

Both are additive, TDD'd, and reuse existing infra. `make check` green.

## sn-8f6q.1 — working-tree diff mode (`internal/risk/diff.go`)
- New `workingTreeDiff(repoRoot)` — `git diff HEAD` (staged + unstaged) → `[]FileChange` via the existing `parseDiff`, plus untracked `.go` files synthesized as whole-file changes.
- Ref-to-ref path (`gitDiff`, `parseDiff`, `changedGoFiles`) byte-for-byte untouched — `snipe risk` unaffected.
- Note: `workingTreeDiff` passes `-M` (rename detection) which the ref-to-ref path does not — deliberate for deterministic tests.

## sn-8f6q.2 — hunk→symbol overlap query (`internal/query/overlap.go`, new)
- `FindOverlappingSymbols(db, repoRoot, map[string][]LineRange)` — symbols whose `[line_start, line_end]` overlaps any changed hunk, batched across files.
- Stale files (via `CheckPathStaleness`) fall back to file-granularity; fresh files get hunk precision. Inclusive overlap. Stable `ORDER BY file_path, line_start, id`.
- This is the function `snipe verify` (sn-8f6q.3) will call.

Primary applied one lint fixup (dead `msg` param in a test helper, unparam).

Closes sn-8f6q.1
Closes sn-8f6q.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Risk analysis now identifies relevant symbols affected by changed line ranges using an optimized batched lookup.
  - Working-tree change detection now accounts for staged, unstaged, renamed, and newly untracked Go files.
  - For unindexed or stale files, broadened results ensure symbols are still found.

- **Bug Fixes**
  - Improved overlap detection now treats inclusive boundary-touching ranges correctly.
  - More reliable behavior when no change ranges are available or when the environment isn’t a Git repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->