### PR TITLE
sn-8f6q.7: chunk FindOverlappingSymbols into batched queries

### DIFF
--- a/internal/query/overlap.go
+++ b/internal/query/overlap.go
@@ -50,6 +50,30 @@ func mergeRanges(ranges []LineRange) []LineRange {
 	return merged
 }
 
+// overlapBatchPredicates caps the number of OR-leaf predicates per batched
+// query. Each flattened predicate binds at most 3 params (a fresh range
+// binds path+end+start; a stale file binds path alone), so a batch binds at
+// most 3 * 250 = 750 params — under the vendored SQLite host-parameter limit
+// (999) with headroom, far under the modern default (32766). The OR-spine is
+// at most 250 leaves deep plus a small constant per leaf, keeping expression
+// tree depth (~253) under MAX_EXPR_DEPTH=1000. It's a var, not a const, so
+// tests can lower it to force multi-batch behavior on small inputs.
+var overlapBatchPredicates = 250
+
+// overlapQueryPrefix and overlapQuerySuffix bracket each batch's WHERE
+// clause. Kept as a single, uninterrupted backtick literal each (not built
+// via concatenation) so orderby_guard_test.go's raw-source scan sees the
+// full "ORDER BY s.file_path, s.line_start, s.id" clause intact.
+const overlapQueryPrefix = `
+		SELECT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.pkg_path, s.line_start, s.col_start, s.line_end, s.col_end,
+		       s.signature, s.doc, s.receiver, f.hash
+		FROM symbols s
+		LEFT JOIN files f ON s.file_path = f.path
+		WHERE `
+
+const overlapQuerySuffix = `
+		ORDER BY s.file_path, s.line_start, s.id`
+
 // FindOverlappingSymbols returns the symbols whose declared range
 // [line_start, line_end] overlaps at least one changed line range, batched
 // across every file in changes with a single query. changes maps each
@@ -86,60 +110,87 @@ func FindOverlappingSymbols(db *sql.DB, repoRoot string, changes map[string][]Li
 		staleSet[rel] = struct{}{}
 	}
 
-	var clauses []string
-	var args []any
-
-	var staleAbs []string
-	for _, p := range paths {
-		if _, ok := staleSet[toRelPath(p, repoRoot)]; ok {
-			staleAbs = append(staleAbs, p)
-		}
-	}
-	if len(staleAbs) > 0 {
-		placeholders := make([]string, len(staleAbs))
-		for i, p := range staleAbs {
-			placeholders[i] = "?"
-			args = append(args, p)
-		}
-		clauses = append(clauses, "s.file_path IN ("+strings.Join(placeholders, ",")+")")
-	}
+	// Flatten every predicate — one per stale file, one per merged fresh
+	// range — into parallel slices instead of building a single combined
+	// WHERE. IN(a,b) is semantically identical to path=a OR path=b, so
+	// dropping the combined stale IN(...) clause changes nothing but shape.
+	// Flattening lets stale and fresh predicates share one uniform batching
+	// loop below, and puts a hard, countable cap on params/depth per batch.
+	var predSQL []string
+	var predArgs [][]any
 
 	for _, p := range paths {
 		if _, ok := staleSet[toRelPath(p, repoRoot)]; ok {
-			continue // already covered by the stale IN(...) clause above
-		}
-		ranges := mergeRanges(changes[p])
-		if len(ranges) == 0 {
+			predSQL = append(predSQL, "s.file_path = ?")
+			predArgs = append(predArgs, []any{p})
 			continue
 		}
-		var rangeClauses []string
-		var rangeArgs []any
-		for _, r := range ranges {
-			rangeClauses = append(rangeClauses, "(s.line_start <= ? AND s.line_end >= ?)")
-			rangeArgs = append(rangeArgs, r.End, r.Start)
+		for _, r := range mergeRanges(changes[p]) {
+			predSQL = append(predSQL, "(s.file_path = ? AND s.line_start <= ? AND s.line_end >= ?)")
+			predArgs = append(predArgs, []any{p, r.End, r.Start})
 		}
-		clauses = append(clauses, "(s.file_path = ? AND ("+strings.Join(rangeClauses, " OR ")+"))")
-		args = append(args, p)
-		args = append(args, rangeArgs...)
 	}
 
-	if len(clauses) == 0 {
+	if len(predSQL) == 0 {
 		return nil, nil
 	}
 
-	query := `
-		SELECT s.id, s.name, s.kind, s.file_path, s.file_path_rel, s.pkg_path, s.line_start, s.col_start, s.line_end, s.col_end,
-		       s.signature, s.doc, s.receiver, f.hash
-		FROM symbols s
-		LEFT JOIN files f ON s.file_path = f.path
-		WHERE ` + strings.Join(clauses, " OR ") + `
-		ORDER BY s.file_path, s.line_start, s.id`
+	var allRows []SymbolRow
+	for start := 0; start < len(predSQL); start += overlapBatchPredicates {
+		end := start + overlapBatchPredicates
+		if end > len(predSQL) {
+			end = len(predSQL)
+		}
 
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("query overlapping symbols: %w", err)
+		query := overlapQueryPrefix + strings.Join(predSQL[start:end], " OR ") + overlapQuerySuffix
+
+		var args []any
+		for _, a := range predArgs[start:end] {
+			args = append(args, a...)
+		}
+
+		rows, err := db.Query(query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("query overlapping symbols: %w", err)
+		}
+		batch, err := scanSymbolRows(rows)
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+		allRows = append(allRows, batch...)
 	}
-	defer rows.Close()
 
-	return scanSymbolRows(rows)
+	// Dedupe by ID: symbols.id is a PRIMARY KEY and files.path is a PRIMARY
+	// KEY, so the LEFT JOIN yields exactly one row per matching symbol.
+	// Batches can only re-surface the same row (e.g. a symbol spanning
+	// hunks split across two batches) — never multiply it — so a seen-set
+	// on ID is a safe, sufficient dedupe.
+	seen := make(map[string]struct{}, len(allRows))
+	result := make([]SymbolRow, 0, len(allRows))
+	for i := range allRows {
+		if _, ok := seen[allRows[i].ID]; ok {
+			continue
+		}
+		seen[allRows[i].ID] = struct{}{}
+		result = append(result, allRows[i])
+	}
+
+	// Each batch is locally ordered by the per-query ORDER BY, but the
+	// merged stream across batches is not globally ordered. Re-sort in Go
+	// by (FilePath, LineStart, ID) to reproduce the single-query
+	// ORDER BY s.file_path, s.line_start, s.id exactly. ID must stay in the
+	// comparator: two symbols can share (FilePath, LineStart) (e.g.
+	// `var a, b int`), and only ID makes this a total order matching SQL.
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].FilePath != result[j].FilePath {
+			return result[i].FilePath < result[j].FilePath
+		}
+		if result[i].LineStart != result[j].LineStart {
+			return result[i].LineStart < result[j].LineStart
+		}
+		return result[i].ID < result[j].ID
+	})
+
+	return result, nil
 }

--- a/internal/query/overlap_test.go
+++ b/internal/query/overlap_test.go
@@ -237,3 +237,139 @@ func TestFindOverlappingSymbols_HandlesMultipleHunksInOneFile_When_RangesDisjoin
 	names := []string{got[0].Name, got[1].Name}
 	require.ElementsMatch(t, []string{"First", "Second"}, names)
 }
+
+// TestFindOverlappingSymbols_ReturnsEmpty_When_RangesEmptyAfterMerge covers a
+// guard distinct from ReturnsEmpty_When_NoChanges: changes is non-empty (the
+// path is present) but its range slice is empty, so mergeRanges yields no
+// predicates and no stale file exists either. This must hit the
+// len(predSQL) == 0 early return, not the len(changes) == 0 one.
+func TestFindOverlappingSymbols_ReturnsEmpty_When_RangesEmptyAfterMerge(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.go")
+	markFresh(t, db, path)
+
+	insertOverlapSym(t, db, "s1", "Untouched", path, "empty.go", 10, 20)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		path: {},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// TestFindOverlappingSymbols_Batches_When_ManyHunks drives >1000 disjoint
+// hunks through a single fresh file, forcing the predicate count past the
+// default batch cap (250) into multiple batches. It asserts the batching
+// path returns the right symbols, deduped and correctly ordered, without
+// needing to lower overlapBatchPredicates.
+func TestFindOverlappingSymbols_Batches_When_ManyHunks(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.go")
+	markFresh(t, db, path)
+
+	// Hit spans a wide range (5-1600) that overlaps hunks from the first
+	// three of five batches (batch boundaries at indices 250/500/...).
+	insertOverlapSym(t, db, "s1", "Hit", path, "big.go", 5, 1600)
+	// Edge overlaps exactly one late hunk (index 1100, in the final batch).
+	insertOverlapSym(t, db, "s2", "Edge", path, "big.go", 3301, 3301)
+	// Miss sits in a gap between hunks that no hunk touches.
+	insertOverlapSym(t, db, "s3", "Miss", path, "big.go", 3302, 3302)
+
+	const hunkCount = 1200
+	ranges := make([]LineRange, hunkCount)
+	for i := 0; i < hunkCount; i++ {
+		line := 3*i + 1
+		ranges[i] = LineRange{Start: line, End: line}
+	}
+	require.Greater(t, hunkCount, overlapBatchPredicates,
+		"test assumes hunk count exceeds the default batch cap")
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{path: ranges})
+	require.NoError(t, err)
+
+	require.Len(t, got, 2)
+	require.Equal(t, "Hit", got[0].Name, "expected (FilePath, LineStart, ID) order: Hit (line 5) before Edge (line 3301)")
+	require.Equal(t, "Edge", got[1].Name)
+
+	seen := make(map[string]int, len(got))
+	for _, s := range got {
+		seen[s.ID]++
+	}
+	for id, count := range seen {
+		require.Equal(t, 1, count, "symbol %s returned more than once across batches", id)
+	}
+}
+
+// TestFindOverlappingSymbols_BatchedEqualsUnbatched_When_CapForcesSplit forces
+// the worst-case split (cap=1, one predicate per query) across a mixed
+// stale+fresh, multi-file, multi-range scenario, including a symbol hit by
+// two separate hunks that land in different batches. The batched result must
+// be identical to the result under the default (unbatched-in-practice) cap.
+func TestFindOverlappingSymbols_BatchedEqualsUnbatched_When_CapForcesSplit(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+	dir := t.TempDir()
+
+	freshPath := filepath.Join(dir, "fresh.go")
+	markFresh(t, db, freshPath)
+	freshPath2 := filepath.Join(dir, "fresh2.go")
+	markFresh(t, db, freshPath2)
+	stalePath := "/repo/stale-unindexed.go"
+
+	insertOverlapSym(t, db, "s1", "FreshHit", freshPath, "fresh.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "FreshMiss", freshPath, "fresh.go", 500, 520)
+	// TwoHunkHit is overlapped by two disjoint hunks below, so with cap=1 the
+	// two matching predicates land in different batches — this exercises
+	// cross-batch dedupe on the same symbol ID.
+	insertOverlapSym(t, db, "s3", "TwoHunkHit", freshPath2, "fresh2.go", 100, 110)
+	insertOverlapSym(t, db, "s4", "StaleAlwaysIncluded", stalePath, "stale-unindexed.go", 500, 520)
+
+	changes := map[string][]LineRange{
+		freshPath:  {{Start: 10, End: 15}},
+		freshPath2: {{Start: 95, End: 102}, {Start: 108, End: 115}},
+		stalePath:  {{Start: 1, End: 2}}, // irrelevant range — stale fallback ignores it
+	}
+
+	expected, err := FindOverlappingSymbols(db, "", changes)
+	require.NoError(t, err)
+	require.Len(t, expected, 3, "sanity: FreshHit, TwoHunkHit, StaleAlwaysIncluded")
+
+	orig := overlapBatchPredicates
+	overlapBatchPredicates = 1
+	defer func() { overlapBatchPredicates = orig }()
+
+	got, err := FindOverlappingSymbols(db, "", changes)
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}
+
+// TestFindOverlappingSymbols_BatchesAcrossStaleFiles_When_CapForcesSplit
+// forces several stale files' single-predicate-per-file clauses into
+// separate batches (cap=1), covering the many-stale-files batching path
+// distinct from the many-fresh-hunks path above.
+func TestFindOverlappingSymbols_BatchesAcrossStaleFiles_When_CapForcesSplit(t *testing.T) {
+	db := setupTestsDB(t)
+	defer db.Close()
+
+	orig := overlapBatchPredicates
+	overlapBatchPredicates = 1
+	defer func() { overlapBatchPredicates = orig }()
+
+	insertOverlapSym(t, db, "s1", "StaleA", "/repo/a.go", "a.go", 10, 20)
+	insertOverlapSym(t, db, "s2", "StaleB", "/repo/b.go", "b.go", 10, 20)
+	insertOverlapSym(t, db, "s3", "StaleC", "/repo/c.go", "c.go", 10, 20)
+
+	got, err := FindOverlappingSymbols(db, "", map[string][]LineRange{
+		"/repo/a.go": {{Start: 1, End: 2}},
+		"/repo/b.go": {{Start: 1, End: 2}},
+		"/repo/c.go": {{Start: 1, End: 2}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	require.ElementsMatch(t, []string{"StaleA", "StaleB", "StaleC"}, names)
+}


### PR DESCRIPTION
Batches the hunk→symbol overlap query so a pathological diff (1000+ disjoint hunks) can't exceed SQLite's vendored host-param limit (999) or MAX_EXPR_DEPTH (1000). Flatten WHERE → predicate batches of 250 → union + dedupe-by-ID + Go re-sort. Results identical to the single query on small inputs (verified: PK-uniqueness + BINARY collation).

Reviewed via dispatch-bead-agent: plan + R-A + R-B(persistence), converged 0 P0/P1. Gated on make check (make audit vuln is pre-existing CVE, sn-k9ns).

Closes sn-8f6q.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlap detection when processing large numbers of changed ranges or stale files.
  * Ensured duplicate symbol matches are removed and results remain consistently ordered.
  * Corrected handling when changed ranges become empty, preventing incorrect stale-file matches.

* **Tests**
  * Added coverage for large-range batching, split-query results, duplicate matches, and stale-file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->