### PR TITLE
sn-hmz: go-stmt/channel-op indexer signal + concurrency-role recall

### DIFF
--- a/cmd/deadcode.go
+++ b/cmd/deadcode.go
@@ -42,14 +42,17 @@ func runDeadcode() error {
 	defer s.Close()
 
 	// Refs count: include vs. exclude tests selected by the file_path filter.
-	refsCountExpr := `(SELECT COUNT(*) FROM refs r WHERE r.symbol_id = s.id`
+	// Exclude go/chan synthetic self-refs (sn-hmz) — symbol_id == enclosing_id
+	// for those rows, which would make a goroutine-spawning exported func look
+	// referenced and never get flagged dead.
+	refsCountExpr := `(SELECT COUNT(*) FROM refs r WHERE r.symbol_id = s.id AND (r.ast_ctx IS NULL OR r.ast_ctx NOT IN ('go','chan'))`
 	if !deadIncludeTests {
 		refsCountExpr += ` AND r.file_path NOT LIKE '%_test.go'`
 	}
 	refsCountExpr += `)`
 
 	// Also pull total (always all-files) so callers can see the gap.
-	totalCountExpr := `(SELECT COUNT(*) FROM refs r WHERE r.symbol_id = s.id)`
+	totalCountExpr := `(SELECT COUNT(*) FROM refs r WHERE r.symbol_id = s.id AND (r.ast_ctx IS NULL OR r.ast_ctx NOT IN ('go','chan')))`
 
 	q := `
 		SELECT s.id, s.name, s.kind, s.pkg_path, s.file_path_rel, s.line_start, ` + totalCountExpr + ` AS refs_all

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1162,10 +1162,15 @@ func computeFileFanIn(s *store.Store) error {
 // file-level risk metrics (file_churn + the "files" complexity/fan-in graph)
 // an index carries. fileMetricsVersion is the current generation — bump it
 // whenever a new file-level metric is added so existing indexes auto-backfill
-// on their next `snipe index`.
+// on their next `snipe index`. Repurposed (v2, sn-hmz) as the force-reindex
+// lever for the go-stmt/channel-op ast_ctx signal too: any version bump here
+// forces a one-time full reindex, which is what's needed to backfill refs
+// for an ast_ctx value added after the index was built (schemaVersion is
+// unaffected — the index fingerprint excludes it, so bumping schemaVersion
+// alone would NOT trigger a reindex).
 const (
 	metaFileMetricsVersion = "file_metrics_version"
-	fileMetricsVersion     = "1"
+	fileMetricsVersion     = "2"
 )
 
 // metricsNeedBackfill reports whether the index lacks the current generation of

--- a/internal/context/roles.go
+++ b/internal/context/roles.go
@@ -502,10 +502,13 @@ func inferRoleForType(_ *sql.DB, _, name, pkgPath string) Role {
 // its structural Role. Detection keys off signals that already exist in the index
 // (signature, imports table, refs.ast_ctx call attribution) — no indexer change.
 //
-// Recall caveat (sn-zd2 / follow-up sn-hmz): the `go func` / goroutine-spawn case
-// is NOT detectable here because `go` statements and channel ops aren't emitted as
-// refs, calls, or signature tokens. Concurrency recall is capped to channel-typed
-// signatures and sync-primitive call sites until the indexer emits a `go` signal.
+// Recall note (sn-zd2, closed by sn-hmz): the indexer now emits a synthetic
+// self-attributed ref (ast_ctx="go"/"chan") for go-statements and channel
+// sends/receives, attributed to the enclosing named function. isConcurrency
+// checks for it ungated below — no import co-signal needed, since that
+// ast_ctx is only ever emitted for a real GoStmt/channel op, unlike the
+// name-based `call:Lock` attribution which needs the sync-import gate to
+// avoid misfiring on a coincidentally-named method.
 func detectRiskFlags(db *sql.DB, imports importsCache, symbolID, signature, filePath string) []string {
 	var flags []string
 	if isConcurrency(db, imports, symbolID, signature, filePath) {
@@ -525,12 +528,25 @@ var concurrencyCallCtxs = []string{
 	"call:Store", "call:Load",
 }
 
+// goChanCtxs are the ast_ctx values the indexer emits for a real go-statement
+// or channel send/receive (self-attributed to the enclosing named func) —
+// mirrors index.CtxGo/CtxChan as literals; this package doesn't import
+// internal/index (existing convention here: concurrencyCallCtxs etc. are
+// literal "call:" strings too, not index.CtxCallPrefix-derived).
+// Unlike concurrencyCallCtxs, no import co-signal is needed: these values are
+// only ever emitted for an actual GoStmt/SendStmt/receive, never name-derived.
+var goChanCtxs = []string{"go", "chan"}
+
 // isConcurrency reports whether a symbol handles concurrency:
 //  1. its signature declares a channel type ("chan T", "chan<- T", "<-chan T"), or
-//  2. its file imports sync/sync/atomic AND an enclosed call attributes to a sync
+//  2. it encloses a go-statement or channel send/receive (ast_ctx="go"/"chan"), or
+//  3. its file imports sync/sync/atomic AND an enclosed call attributes to a sync
 //     primitive (Lock/Unlock/Wait/Do/Add/Store/Load/...).
 func isConcurrency(db *sql.DB, imports importsCache, symbolID, signature, filePath string) bool {
 	if hasChannelType(signature) {
+		return true
+	}
+	if enclosedCallCtx(db, symbolID, goChanCtxs) {
 		return true
 	}
 	if !imports.fileImportsAny(filePath, "sync", "sync/atomic") {

--- a/internal/context/roles_risk_test.go
+++ b/internal/context/roles_risk_test.go
@@ -123,11 +123,12 @@ func TestRiskClassification_Precision(t *testing.T) {
 	addImport(t, db, "/repo/counter.go", "sync")
 	addRefCtx(t, db, "r_lock", "guard", "/repo/counter.go", "call:Lock", "c.mu.Lock()")
 
-	// --- concurrency deferred-miss (plan §4.1 / sn-hmz) ---
-	// A pure `go func` spawner has no chan signature and no sync-primitive call,
-	// so it is NOT detectable until the indexer emits a go-statement signal.
-	// This asserts the documented recall gap rather than pretending it's covered.
+	// --- concurrency: pure go-func spawner (recall gap closed by sn-hmz) ---
+	// No chan signature and no sync-primitive call, but the indexer now emits
+	// a self-attributed ast_ctx="go" ref for the go-statement, enclosed by
+	// spawnWorker — detectable via the ungated goChanCtxs check.
 	addSym(t, db, "spawn", "spawnWorker", kindFunc, "func spawnWorker()", "repo/work", "/repo/worker.go")
+	addRefCtx(t, db, "r_go", "spawn", "/repo/worker.go", "go", "go worker()")
 
 	// --- security_boundary positives ---
 	// exec.Command caller: imports os/exec + encloses a Command call
@@ -155,7 +156,7 @@ func TestRiskClassification_Precision(t *testing.T) {
 		{"guardedCounter", RiskConcurrency},
 		{"runBackup", RiskSecurityBoundary},
 		{"dialTLS", RiskSecurityBoundary},
-		{"spawnWorker", ""},
+		{"spawnWorker", RiskConcurrency},
 		{"Command", ""},
 		{"plumbCtx", ""},
 	}

--- a/internal/index/refs.go
+++ b/internal/index/refs.go
@@ -33,7 +33,7 @@ const (
 	CtxTypeDecl     = "typedecl" // within a type declaration (struct field, interface method)
 	CtxCallPrefix   = "call:"    // argument of a call; suffix is the callee name
 	CtxGo           = "go"       // a go statement (goroutine spawn)
-	CtxChan         = "chan"     // a channel send (ch <- x) or receive (<-ch)
+	CtxChan         = "chan"     // a channel send (ch <- x) or arrow-receive (<-ch); for-range receives and close() are not captured (see sn-v84m)
 )
 
 // ExtractRefs extracts all references from loaded packages.

--- a/internal/index/refs.go
+++ b/internal/index/refs.go
@@ -32,6 +32,8 @@ const (
 	CtxSignature    = "sig"      // within a func declaration/literal signature
 	CtxTypeDecl     = "typedecl" // within a type declaration (struct field, interface method)
 	CtxCallPrefix   = "call:"    // argument of a call; suffix is the callee name
+	CtxGo           = "go"       // a go statement (goroutine spawn)
+	CtxChan         = "chan"     // a channel send (ch <- x) or receive (<-ch)
 )
 
 // ExtractRefs extracts all references from loaded packages.
@@ -90,6 +92,12 @@ func ExtractRefsFiltered(result *LoadResult, symbols []Symbol, cache *util.FileC
 			// Build syntactic context ranges for this file
 			ctxRanges := buildCtxRanges(file)
 
+			// Emit synthetic self-attributed refs for go-statements and channel
+			// sends/receives, attributed to the enclosing named function. These
+			// have no Uses-map entry (a `go` keyword and `<-`/`ch <-` operators
+			// aren't identifiers), so they're generated in a separate pass.
+			refs = append(refs, extractConcurrencyRefs(file, filePath, result.Fset, enclosingMap, lines)...)
+
 			// Extract references from Uses map
 			for ident, obj := range pkg.TypesInfo.Uses {
 				if obj == nil {
@@ -141,6 +149,55 @@ func ExtractRefsFiltered(result *LoadResult, symbols []Symbol, cache *util.FileC
 	}
 
 	return refs, nil
+}
+
+// extractConcurrencyRefs walks a file for go-statements and channel
+// sends/receives, emitting a synthetic self-attributed ref per occurrence
+// (symbol_id == enclosing_id == the enclosing named function's ID). These
+// AST nodes have no Uses-map entry (no identifier to resolve), so they're
+// generated here rather than in the main Uses-map loop. A go-stmt/channel-op
+// with no enclosing named func (e.g. inside a package-level func-literal
+// initializer) is skipped — there is no FK-valid symbol to attribute it to.
+func extractConcurrencyRefs(file *ast.File, filePath string, fset *token.FileSet, enclosingMap []enclosingFunc, lines []string) []Ref {
+	var out []Ref
+
+	emit := func(pos token.Pos, ctx, kind string) {
+		enclosingID := findEnclosing(pos, enclosingMap)
+		if enclosingID == "" {
+			return
+		}
+		posInfo := fset.Position(pos)
+		snippet := ""
+		if posInfo.Line > 0 && posInfo.Line <= len(lines) {
+			snippet = strings.TrimSpace(lines[posInfo.Line-1])
+		}
+		out = append(out, Ref{
+			ID:          generateID(filePath, posInfo.Line, posInfo.Column, kind),
+			SymbolID:    enclosingID,
+			FilePath:    filePath,
+			Line:        posInfo.Line,
+			Col:         posInfo.Column,
+			EnclosingID: enclosingID,
+			Snippet:     snippet,
+			ASTCtx:      ctx,
+		})
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.GoStmt:
+			emit(node.Go, CtxGo, "goref")
+		case *ast.SendStmt:
+			emit(node.Arrow, CtxChan, "chanref")
+		case *ast.UnaryExpr:
+			if node.Op == token.ARROW {
+				emit(node.OpPos, CtxChan, "chanref")
+			}
+		}
+		return true
+	})
+
+	return out
 }
 
 // SymbolPosIndex provides position-based symbol lookup with fallback for chunked loading.

--- a/internal/index/refs_test.go
+++ b/internal/index/refs_test.go
@@ -276,3 +276,92 @@ func use(n *Nug) {
 		}
 	}
 }
+
+// TestExtractRefs_ConcurrencyCtx verifies synthetic self-attributed refs are
+// emitted for go-statements and channel sends/receives, attributed to the
+// enclosing named function. A go-statement/channel-op with no enclosing
+// named func (e.g. inside a package-level IIFE) must NOT emit a ref.
+func TestExtractRefs_ConcurrencyCtx(t *testing.T) {
+	dir := t.TempDir()
+	src := `package conc
+
+func Spawn() {
+	go func() { _ = 1 }()
+}
+
+func Chan() {
+	ch := make(chan int, 1)
+	ch <- 1
+	<-ch
+}
+
+var _ = func() int {
+	go func() { _ = 1 }()
+	return 1
+}()
+`
+	files := map[string]string{
+		"go.mod":  "module example.com/conc\n\ngo 1.22\n",
+		"conc.go": src,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := Load(LoadConfig{Dir: dir})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	symbols, err := ExtractSymbols(result)
+	if err != nil {
+		t.Fatalf("extract symbols: %v", err)
+	}
+	refs, err := ExtractRefs(result, symbols)
+	if err != nil {
+		t.Fatalf("extract refs: %v", err)
+	}
+
+	var spawnID, chanID string
+	for _, s := range symbols {
+		switch s.Name {
+		case "Spawn":
+			spawnID = s.ID
+		case "Chan":
+			chanID = s.ID
+		}
+	}
+	if spawnID == "" || chanID == "" {
+		t.Fatalf("missing symbol IDs: spawnID=%q chanID=%q", spawnID, chanID)
+	}
+
+	var goRefs, chanRefs []Ref
+	for _, r := range refs {
+		switch r.ASTCtx {
+		case CtxGo:
+			goRefs = append(goRefs, r)
+		case CtxChan:
+			chanRefs = append(chanRefs, r)
+		}
+	}
+
+	// (a) exactly one go ref, self-attributed to Spawn. The package-level
+	// IIFE's go-statement has no enclosing named func and must be skipped.
+	if len(goRefs) != 1 {
+		t.Fatalf("len(goRefs) = %d, want 1 (got %+v)", len(goRefs), goRefs)
+	}
+	if goRefs[0].EnclosingID != spawnID || goRefs[0].SymbolID != spawnID {
+		t.Errorf("go ref = %+v, want EnclosingID=SymbolID=%q", goRefs[0], spawnID)
+	}
+
+	// (b) exactly two chan refs (send + receive), both self-attributed to Chan.
+	if len(chanRefs) != 2 {
+		t.Fatalf("len(chanRefs) = %d, want 2 (got %+v)", len(chanRefs), chanRefs)
+	}
+	for _, r := range chanRefs {
+		if r.EnclosingID != chanID || r.SymbolID != chanID {
+			t.Errorf("chan ref = %+v, want EnclosingID=SymbolID=%q", r, chanID)
+		}
+	}
+}

--- a/internal/query/lookup.go
+++ b/internal/query/lookup.go
@@ -462,6 +462,7 @@ func FindRefs(db *sql.DB, symbolID string, limit, offset int) ([]RefRow, error) 
 		LEFT JOIN symbols s ON r.enclosing_id = s.id
 		LEFT JOIN files f ON r.file_path = f.path
 		WHERE r.symbol_id = ?
+		  AND (r.ast_ctx IS NULL OR r.ast_ctx NOT IN ('go','chan'))
 		ORDER BY
 		  CASE WHEN r.file_path = (SELECT file_path FROM symbols WHERE id = ?) THEN 0 ELSE 1 END,
 		  r.file_path,
@@ -752,10 +753,17 @@ func countParams(paramStr string) (count int, variadic bool) {
 	return commas + 1, variadic
 }
 
-// GetRefCount returns the number of references to a symbol.
+// GetRefCount returns the number of references to a symbol. Go/chan synthetic
+// self-refs (ast_ctx="go"/"chan", symbol_id == enclosing_id, sn-hmz) are
+// excluded — they are the symbol's own go-statements/channel ops, not
+// references TO it, and would otherwise inflate the count (and diverge from
+// `snipe deadcode`, which applies the same filter).
 func GetRefCount(db *sql.DB, symbolID string) (int, error) {
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM refs WHERE symbol_id = ?`, symbolID).Scan(&count)
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM refs WHERE symbol_id = ? AND (ast_ctx IS NULL OR ast_ctx NOT IN ('go','chan'))`,
+		symbolID,
+	).Scan(&count)
 	return count, err
 }
 

--- a/internal/query/lookup_test.go
+++ b/internal/query/lookup_test.go
@@ -280,3 +280,72 @@ func TestLookupByName_QualifiedMethodForms(t *testing.T) {
 		}
 	}
 }
+
+// TestRefQueries_ExcludeGoChanSelfRefs verifies FindRefs and GetRefCount drop
+// the synthetic go/chan self-refs (ast_ctx="go"/"chan", symbol_id ==
+// enclosing_id, sn-hmz). Those rows are a function's own go-statements and
+// channel ops, not references TO it; counting them would inflate GetRefCount
+// and surface a "go worker()" statement as a reference row in `snipe refs`.
+func TestRefQueries_ExcludeGoChanSelfRefs(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE symbols (
+			id TEXT PRIMARY KEY, name TEXT, kind TEXT,
+			file_path TEXT, file_path_rel TEXT, pkg_path TEXT,
+			line_start INT, col_start INT, line_end INT, col_end INT,
+			signature TEXT, doc TEXT, receiver TEXT
+		);
+		CREATE TABLE files (path TEXT PRIMARY KEY, mtime INT, hash TEXT);
+		CREATE TABLE refs (
+			id TEXT PRIMARY KEY, symbol_id TEXT NOT NULL,
+			file_path TEXT NOT NULL, file_path_rel TEXT,
+			line INT, col INT, enclosing_id TEXT, snippet TEXT, ast_ctx TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+
+	// Serve encloses `go worker()` and a channel op; caller genuinely refs Serve.
+	execOrFatal(t, db, `INSERT INTO symbols VALUES ('serve','Serve','func','/srv.go','srv.go','pkg',1,1,10,1,NULL,NULL,NULL)`)
+	execOrFatal(t, db, `INSERT INTO symbols VALUES ('caller','callSite','func','/main.go','main.go','pkg',1,1,5,1,NULL,NULL,NULL)`)
+	execOrFatal(t, db, `INSERT INTO files VALUES ('/srv.go',0,'h1')`)
+	execOrFatal(t, db, `INSERT INTO files VALUES ('/main.go',0,'h2')`)
+
+	// One genuine reference TO Serve (from callSite, no ast_ctx).
+	execOrFatal(t, db, `INSERT INTO refs VALUES ('r_real','serve','/main.go','main.go',3,5,'caller','Serve()',NULL)`)
+	// Serve's own go-statement + channel op: synthetic self-refs.
+	execOrFatal(t, db, `INSERT INTO refs VALUES ('r_go','serve','/srv.go','srv.go',4,2,'serve','go worker()','go')`)
+	execOrFatal(t, db, `INSERT INTO refs VALUES ('r_chan','serve','/srv.go','srv.go',5,2,'serve','ch <- 1','chan')`)
+
+	// GetRefCount: 1 real reference, not 3 (the two self-refs excluded).
+	count, err := GetRefCount(db, "serve")
+	if err != nil {
+		t.Fatalf("GetRefCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("GetRefCount(Serve) = %d, want 1 (go/chan self-refs must be excluded)", count)
+	}
+
+	// FindRefs: only the genuine reference, no go/chan self-ref rows.
+	refs, err := FindRefs(db, "serve", 50, 0)
+	if err != nil {
+		t.Fatalf("FindRefs: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("FindRefs(Serve) = %d rows, want 1", len(refs))
+	}
+	if refs[0].ID != "r_real" {
+		t.Errorf("FindRefs(Serve) returned %q, want the genuine ref r_real", refs[0].ID)
+	}
+	for _, r := range refs {
+		if r.ASTCtx == "go" || r.ASTCtx == "chan" {
+			t.Errorf("FindRefs returned a go/chan self-ref row: id=%s ast_ctx=%s snippet=%q", r.ID, r.ASTCtx, r.Snippet)
+		}
+	}
+}


### PR DESCRIPTION
Emits a go/chan ast_ctx signal from the AST walk (self-ref attributed to the enclosing func) so the concurrency-role classifier can see `go func(){}()` spawns; wires isConcurrency to consume it. Reindex forced via fileMetricsVersion (NOT schemaVersion — fingerprint excludes it).

Reviewed via dispatch-bead-agent: plan + R-A + R-B(correctness). R-B caught a self-ref wrong-data leak into snipe refs/pack — fixed + query-level test. Converged. Gated on make check.

Closes sn-hmz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency risk detection for goroutines and channel operations, including cases without synchronization imports.
  * Corrected dead-code and reference counts so internal concurrency markers do not make symbols appear used.
  * Added clearer unused-symbol results and hints based on accurate reference counts.

* **Maintenance**
  * Existing indexes may be rebuilt once to generate updated file-level risk metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->