### PR TITLE
sn-za8p: canonicalize project root/file paths to fix symlink query mismatch

### DIFF
--- a/cmd/imports.go
+++ b/cmd/imports.go
@@ -26,6 +26,12 @@ func runImports(args []string) error {
 	// Make path absolute if relative
 	if !filepath.IsAbs(filePath) {
 		filePath = filepath.Join(dir, filePath)
+	} else if resolved, err := filepath.EvalSymlinks(filePath); err == nil {
+		// Canonicalize an already-absolute caller-supplied path (sn-za8p):
+		// the index stores canonical file_path values (via FindProjectRoot),
+		// so a raw absolute arg through a symlink would otherwise silently
+		// match zero rows.
+		filePath = resolved
 	}
 
 	imports, err := query.FindImports(s.DB(), filePath, lim, offset)

--- a/cmd/imports.go
+++ b/cmd/imports.go
@@ -23,14 +23,16 @@ func runImports(args []string) error {
 	}
 	defer s.Close()
 
-	// Make path absolute if relative
+	// Make path absolute if relative, then canonicalize (sn-za8p): the index
+	// stores canonical file_path values (via FindProjectRoot), so a path
+	// through a symlink — an absolute arg, or a relative arg that traverses an
+	// intra-repo symlinked dir — would otherwise silently match zero rows.
+	// dir is already canonical, but the joined relative component may not be.
+	// EvalSymlinks failing (path doesn't exist) is not fatal; keep the raw value.
 	if !filepath.IsAbs(filePath) {
 		filePath = filepath.Join(dir, filePath)
-	} else if resolved, err := filepath.EvalSymlinks(filePath); err == nil {
-		// Canonicalize an already-absolute caller-supplied path (sn-za8p):
-		// the index stores canonical file_path values (via FindProjectRoot),
-		// so a raw absolute arg through a symlink would otherwise silently
-		// match zero rows.
+	}
+	if resolved, err := filepath.EvalSymlinks(filePath); err == nil {
 		filePath = resolved
 	}
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -47,6 +47,14 @@ func runIndex(args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve path: %w", err)
 	}
+	// Canonicalize an explicit path arg (sn-za8p): query commands resolve
+	// root from os.Getwd(), which macOS returns already symlink-resolved.
+	// FindProjectRoot canonicalizes too, but only when a .git/go.mod marker
+	// is found; this covers the fallback case below where none is found and
+	// absDir is used as-is.
+	if resolved, err := filepath.EvalSymlinks(absDir); err == nil {
+		absDir = resolved
+	}
 
 	// Always index relative to project root — not CWD or an arbitrary subdir (D3)
 	if root := util.FindProjectRoot(absDir); root != "" {

--- a/internal/query/position.go
+++ b/internal/query/position.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -15,8 +16,29 @@ type PositionQuery struct {
 	Col  int
 }
 
-// ParsePosition parses a position string like "file.go:42:12"
+// ParsePosition parses a position string like "file.go:42:12". If the file
+// component is already absolute, it is canonicalized via EvalSymlinks
+// (sn-za8p): relative file components get canonicalized for free when the
+// caller later joins them onto the (now-canonical, per FindProjectRoot) repo
+// root, but an absolute --at path bypasses that join entirely — without this,
+// an absolute path through a symlink (e.g. a macOS /var/folders temp dir)
+// would silently fail to match the canonical file_path values an index built
+// via FindProjectRoot stores. EvalSymlinks failing (path doesn't exist) is
+// not fatal; the original value is kept.
 func ParsePosition(s string) (*PositionQuery, error) {
+	pq, err := parsePositionRaw(s)
+	if err != nil {
+		return nil, err
+	}
+	if filepath.IsAbs(pq.File) {
+		if resolved, err := filepath.EvalSymlinks(pq.File); err == nil {
+			pq.File = resolved
+		}
+	}
+	return pq, nil
+}
+
+func parsePositionRaw(s string) (*PositionQuery, error) {
 	parts := strings.Split(s, ":")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid position format: %s (expected file:line or file:line:col)", s)

--- a/internal/util/root.go
+++ b/internal/util/root.go
@@ -8,10 +8,24 @@ import (
 // FindProjectRoot walks up from start looking for a .git directory,
 // then falls back to go.mod. Returns "" if neither is found.
 // start is resolved to an absolute path first to ensure correct termination.
+//
+// The resolved path is also canonicalized via EvalSymlinks (sn-za8p). Query
+// commands resolve project root from os.Getwd(), which on macOS the kernel
+// already returns in canonical form (/private/var/... not /var/...). Index
+// commands resolve an explicit `snipe index <path>` arg through this same
+// function; without canonicalizing here too, a symlinked start (e.g. a
+// /var/folders CI temp dir passed explicitly) would leave the returned root
+// in its unresolved form. The two sides would then disagree on file_path
+// values and every `s.file_path = ?` store lookup would silently return zero
+// rows. EvalSymlinks failing (e.g. path doesn't exist) is not fatal here —
+// fall back to the plain absolute path.
 func FindProjectRoot(start string) string {
 	abs, err := filepath.Abs(start)
 	if err != nil {
 		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
 	}
 	// First pass: look for .git
 	if root := walkUp(abs, ".git"); root != "" {

--- a/internal/util/root_test.go
+++ b/internal/util/root_test.go
@@ -23,8 +23,8 @@ func TestFindProjectRoot_FindsGitRoot_WhenRunFromSubdirectory(t *testing.T) {
 	}
 
 	got := util.FindProjectRoot(sub)
-	if got != tmp {
-		t.Fatalf("FindProjectRoot(%q) = %q, want %q", sub, got, tmp)
+	if want := canonical(t, tmp); got != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want %q", sub, got, want)
 	}
 }
 
@@ -41,8 +41,8 @@ func TestFindProjectRoot_FindsGoModRoot_WhenNoGit(t *testing.T) {
 	}
 
 	got := util.FindProjectRoot(sub)
-	if got != tmp {
-		t.Fatalf("FindProjectRoot(%q) = %q, want %q", sub, got, tmp)
+	if want := canonical(t, tmp); got != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want %q", sub, got, want)
 	}
 }
 
@@ -63,8 +63,8 @@ func TestFindProjectRoot_PrefersGitOverGoMod_WhenBothPresent(t *testing.T) {
 	}
 
 	got := util.FindProjectRoot(sub)
-	if got != sub {
-		t.Fatalf("FindProjectRoot(%q) = %q, want %q", sub, got, sub)
+	if want := canonical(t, sub); got != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want %q", sub, got, want)
 	}
 }
 
@@ -90,8 +90,8 @@ func TestFindProjectRoot_PrefersGitRoot_WhenGitIsHigherThanGoMod(t *testing.T) {
 	}
 
 	got := util.FindProjectRoot(pkg)
-	if got != tmp {
-		t.Fatalf("FindProjectRoot(%q) = %q, want %q (git root)", pkg, got, tmp)
+	if want := canonical(t, tmp); got != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want %q (git root)", pkg, got, want)
 	}
 }
 
@@ -118,8 +118,8 @@ func TestFindProjectRoot_GitWins_WhenGitIsDeeperThanGoMod(t *testing.T) {
 	}
 
 	got := util.FindProjectRoot(pkg)
-	if got != service {
-		t.Fatalf("FindProjectRoot(%q) = %q, want %q (.git wins over parent go.mod)", pkg, got, service)
+	if want := canonical(t, service); got != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want %q (.git wins over parent go.mod)", pkg, got, want)
 	}
 }
 
@@ -144,7 +144,53 @@ func TestFindProjectRoot_ReturnsStart_WhenStartIsRoot(t *testing.T) {
 	}
 
 	got := util.FindProjectRoot(tmp)
-	if got != tmp {
-		t.Fatalf("FindProjectRoot(%q) = %q, want %q", tmp, got, tmp)
+	if want := canonical(t, tmp); got != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want %q", tmp, got, want)
 	}
+}
+
+// TestFindProjectRoot_ResolvesSymlinks_WhenStartIsSymlinked guards sn-za8p:
+// query-side commands resolve project root from os.Getwd(), which macOS
+// returns already canonicalized (/private/var/... not /var/...). Index-side
+// resolved an explicit `snipe index <path>` arg with plain filepath.Abs, so a
+// symlinked start (e.g. a CI temp dir) left the returned root unresolved —
+// the two sides then disagreed on file_path and every store lookup silently
+// returned zero rows. FindProjectRoot must canonicalize regardless of which
+// side is calling it.
+func TestFindProjectRoot_ResolvesSymlinks_WhenStartIsSymlinked(t *testing.T) {
+	t.Parallel()
+
+	realDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(realDir, ".git"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	symParent := t.TempDir()
+	symDir := filepath.Join(symParent, "symlinked-repo")
+	if err := os.Symlink(realDir, symDir); err != nil {
+		t.Fatal(err)
+	}
+
+	viaSymlink := util.FindProjectRoot(symDir)
+	viaCanonical := util.FindProjectRoot(canonical(t, realDir))
+
+	if viaSymlink != viaCanonical {
+		t.Fatalf("FindProjectRoot(symlinked start) = %q, want %q (same as canonical start) — index and query sides would disagree on root", viaSymlink, viaCanonical)
+	}
+	if want := canonical(t, realDir); viaSymlink != want {
+		t.Fatalf("FindProjectRoot(%q) = %q, want canonicalized %q", symDir, viaSymlink, want)
+	}
+}
+
+// canonical resolves symlinks in p, failing the test if p doesn't exist. Used
+// to match FindProjectRoot's canonicalized return value against expectations
+// built from t.TempDir(), which on macOS is itself a symlink
+// (/var/folders -> /private/var/folders).
+func canonical(t *testing.T, p string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", p, err)
+	}
+	return resolved
 }

--- a/test/blackbox/symlink_root_test.go
+++ b/test/blackbox/symlink_root_test.go
@@ -1,0 +1,57 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIndex_SymlinkedPathArg_QueryFromCanonicalPath_FindsMatches guards
+// sn-za8p: `snipe index <path>` resolved an explicit path arg without
+// symlink resolution, while query commands (def --at, verify, risk, ...)
+// resolve project root from os.Getwd(), which macOS returns already
+// canonicalized (/private/var/... not /var/...). When index was given an
+// explicit symlinked path, the two sides disagreed on the file_path values
+// they compared against and every query silently returned zero rows. This
+// test uses an explicit symlink (rather than relying on macOS's own
+// /var -> /private/var symlink) so it exercises the same bug deterministically
+// on any platform.
+func TestIndex_SymlinkedPathArg_QueryFromCanonicalPath_FindsMatches(t *testing.T) {
+	realDir, paths := writeFixture(t)
+	if err := os.Mkdir(filepath.Join(realDir, ".git"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	symParent := t.TempDir()
+	symDir := filepath.Join(symParent, "symlinked-repo")
+	if err := os.Symlink(realDir, symDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index via the symlinked path, from an unrelated cwd — mirrors a CI
+	// runner invoking `snipe index /var/folders/.../symlinked-tmp-dir`.
+	stdout, stderr, exitCode := run(t, symParent, "index", symDir)
+	if exitCode != 0 {
+		t.Fatalf("index exit %d stderr=%s stdout=%s", exitCode, stderr, stdout)
+	}
+
+	// Query from the canonical (non-symlinked) path via a *relative* --at —
+	// cmd/def.go only joins the query-side root (os.Getwd()) onto pos.File
+	// when it's relative, so this is the exact site that silently zeroed
+	// out under the bug. (paths["callee_at"] is absolute — using it as-is
+	// would bypass root resolution entirely and test something else.)
+	relAt := strings.TrimPrefix(paths["callee_at"], realDir+string(filepath.Separator))
+	stdout, stderr, exitCode = run(t, realDir, "def", "--at", relAt)
+	if exitCode != 0 {
+		t.Fatalf("def exit %d stderr=%s stdout=%s", exitCode, stderr, stdout)
+	}
+
+	resp := parseJSON(t, stdout)
+	results := requireSlice(t, resp["results"], "results")
+	if len(results) == 0 {
+		t.Fatalf("expected Callee definition querying from canonical path after indexing via symlink, got 0 results (stdout=%s)", stdout)
+	}
+}


### PR DESCRIPTION
closes sn-za8p