### PR TITLE
sn-v84m: classify for-range channel receives as concurrency signal

### DIFF
--- a/internal/index/refs.go
+++ b/internal/index/refs.go
@@ -3,6 +3,7 @@ package index
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,7 +34,7 @@ const (
 	CtxTypeDecl     = "typedecl" // within a type declaration (struct field, interface method)
 	CtxCallPrefix   = "call:"    // argument of a call; suffix is the callee name
 	CtxGo           = "go"       // a go statement (goroutine spawn)
-	CtxChan         = "chan"     // a channel send (ch <- x) or arrow-receive (<-ch); for-range receives and close() are not captured (see sn-v84m)
+	CtxChan         = "chan"     // a channel send (ch <- x), arrow-receive (<-ch), or for-range receive (for v := range ch)
 )
 
 // ExtractRefs extracts all references from loaded packages.
@@ -96,7 +97,7 @@ func ExtractRefsFiltered(result *LoadResult, symbols []Symbol, cache *util.FileC
 			// sends/receives, attributed to the enclosing named function. These
 			// have no Uses-map entry (a `go` keyword and `<-`/`ch <-` operators
 			// aren't identifiers), so they're generated in a separate pass.
-			refs = append(refs, extractConcurrencyRefs(file, filePath, result.Fset, enclosingMap, lines)...)
+			refs = append(refs, extractConcurrencyRefs(file, filePath, result.Fset, enclosingMap, lines, pkg.TypesInfo)...)
 
 			// Extract references from Uses map
 			for ident, obj := range pkg.TypesInfo.Uses {
@@ -152,13 +153,21 @@ func ExtractRefsFiltered(result *LoadResult, symbols []Symbol, cache *util.FileC
 }
 
 // extractConcurrencyRefs walks a file for go-statements and channel
-// sends/receives, emitting a synthetic self-attributed ref per occurrence
-// (symbol_id == enclosing_id == the enclosing named function's ID). These
-// AST nodes have no Uses-map entry (no identifier to resolve), so they're
-// generated here rather than in the main Uses-map loop. A go-stmt/channel-op
-// with no enclosing named func (e.g. inside a package-level func-literal
-// initializer) is skipped — there is no FK-valid symbol to attribute it to.
-func extractConcurrencyRefs(file *ast.File, filePath string, fset *token.FileSet, enclosingMap []enclosingFunc, lines []string) []Ref {
+// sends/receives/for-range-receives, emitting a synthetic self-attributed ref
+// per occurrence (symbol_id == enclosing_id == the enclosing named function's
+// ID). These AST nodes have no Uses-map entry (no identifier to resolve), so
+// they're generated here rather than in the main Uses-map loop. A
+// go-stmt/channel-op with no enclosing named func (e.g. inside a
+// package-level func-literal initializer) is skipped — there is no FK-valid
+// symbol to attribute it to.
+//
+// typesInfo is the enclosing package's types.Info, used to distinguish a
+// `for v := range ch` channel receive from ranging over a slice/map/array
+// (same syntax, different semantics). It may be nil (e.g. in unit tests that
+// don't run the type checker); in that case for-range receives are skipped
+// rather than guessed at — a heuristic here would false-positive on any
+// range over something merely named "ch".
+func extractConcurrencyRefs(file *ast.File, filePath string, fset *token.FileSet, enclosingMap []enclosingFunc, lines []string, typesInfo *types.Info) []Ref {
 	var out []Ref
 
 	emit := func(pos token.Pos, ctx, kind string) {
@@ -193,11 +202,26 @@ func extractConcurrencyRefs(file *ast.File, filePath string, fset *token.FileSet
 			if node.Op == token.ARROW {
 				emit(node.OpPos, CtxChan, "chanref")
 			}
+		case *ast.RangeStmt:
+			if typesInfo != nil && isChanType(typesInfo.TypeOf(node.X)) {
+				emit(node.For, CtxChan, "chanref")
+			}
 		}
 		return true
 	})
 
 	return out
+}
+
+// isChanType reports whether t is a channel type (or a named type whose
+// underlying type is a channel). nil/invalid types (e.g. unresolved
+// expressions) are not channels.
+func isChanType(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	_, ok := t.Underlying().(*types.Chan)
+	return ok
 }
 
 // SymbolPosIndex provides position-based symbol lookup with fallback for chunked loading.

--- a/internal/index/refs_test.go
+++ b/internal/index/refs_test.go
@@ -365,3 +365,84 @@ var _ = func() int {
 		}
 	}
 }
+
+// TestExtractRefs_RangeOverChannel verifies a `for v := range ch` receive is
+// classified as a chan ref (sn-v84m), while ranging over a slice or map
+// (no channel type) must NOT emit one.
+func TestExtractRefs_RangeOverChannel(t *testing.T) {
+	dir := t.TempDir()
+	src := `package rng
+
+func Drain(ch chan int) {
+	for v := range ch {
+		_ = v
+	}
+}
+
+func Walk(xs []int) {
+	for i := range xs {
+		_ = i
+	}
+}
+
+func Iter(m map[string]int) {
+	for k := range m {
+		_ = k
+	}
+}
+`
+	files := map[string]string{
+		"go.mod": "module example.com/rng\n\ngo 1.22\n",
+		"rng.go": src,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := Load(LoadConfig{Dir: dir})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	symbols, err := ExtractSymbols(result)
+	if err != nil {
+		t.Fatalf("extract symbols: %v", err)
+	}
+	refs, err := ExtractRefs(result, symbols)
+	if err != nil {
+		t.Fatalf("extract refs: %v", err)
+	}
+
+	var drainID, walkID, iterID string
+	for _, s := range symbols {
+		switch s.Name {
+		case "Drain":
+			drainID = s.ID
+		case "Walk":
+			walkID = s.ID
+		case "Iter":
+			iterID = s.ID
+		}
+	}
+	if drainID == "" || walkID == "" || iterID == "" {
+		t.Fatalf("missing symbol IDs: drainID=%q walkID=%q iterID=%q", drainID, walkID, iterID)
+	}
+
+	byEnclosing := map[string]int{}
+	for _, r := range refs {
+		if r.ASTCtx == CtxChan {
+			byEnclosing[r.EnclosingID]++
+		}
+	}
+
+	if byEnclosing[drainID] != 1 {
+		t.Errorf("Drain: chan refs = %d, want 1 (for-range over chan must classify as concurrency)", byEnclosing[drainID])
+	}
+	if byEnclosing[walkID] != 0 {
+		t.Errorf("Walk: chan refs = %d, want 0 (range over slice must not fire)", byEnclosing[walkID])
+	}
+	if byEnclosing[iterID] != 0 {
+		t.Errorf("Iter: chan refs = %d, want 0 (range over map must not fire)", byEnclosing[iterID])
+	}
+}


### PR DESCRIPTION
closes sn-v84m