### PR TITLE
Harden snipe risk JSON contract: golden guard test + doc (sn-n8re, sn-33gg)

### DIFF
--- a/cmd/risk.go
+++ b/cmd/risk.go
@@ -39,6 +39,8 @@ func writeRisk(v risk.Verdict, root string, start time.Time) error {
 
 // writeRiskJSON emits the verdict inside the standard envelope. The single verdict
 // is the sole result; consumers read `.results[0]` (e.g. `jq '.results[0].verdict'`).
+// This shape is a semver-guarded cross-repo contract — see docs/contracts/risk-json.md
+// (guard test: test/blackbox/risk_contract_test.go, sn-n8re).
 func writeRiskJSON(v risk.Verdict, root string, start time.Time) error {
 	resp := output.Response[risk.Verdict]{
 		Protocol: output.ProtocolVersion,

--- a/docs/contracts/risk-json.md
+++ b/docs/contracts/risk-json.md
@@ -1,0 +1,84 @@
+# `snipe risk --format json` — stable contract
+
+`snipe risk <base> [head] --format json` emits a code-graph risk verdict for the
+diff between two git refs. It is consumed **cross-repo** by the cc-plugins
+review-judge (ccp-1cfm), which branches CI review depth on the verdict. The
+fields and guarantees below are a **semver-guarded contract**: a rename or a
+path change is a **major** version bump. The guard test
+`test/blackbox/risk_contract_test.go` (sn-n8re) fails on any breaking change — if
+it goes red, a downstream CI judge breaks, so treat a red as intentional only
+with a major bump + a heads-up to `@cc-plugins`.
+
+## Shape
+
+Standard snipe envelope; consumers read `.results[0]`:
+
+```json
+{
+  "protocol": 1,
+  "ok": true,
+  "results": [
+    {
+      "verdict": "medium",
+      "score": 2,
+      "reasons": [
+        { "signal": "central", "detail": "…ranks #15/31 by PageRank", "weight": 1 },
+        { "signal": "churn-hotspot", "detail": "…in churn top-20", "weight": 1 }
+      ],
+      "changed": { "files": 2, "go_files": 2, "symbols": 3 },
+      "degraded": false
+    }
+  ],
+  "meta": { "command": "risk", "total": 1, "ms": 12, "…": "…" },
+  "error": null
+}
+```
+
+## Guaranteed fields — `.results[0]`
+
+| Path | Type | Meaning |
+|------|------|---------|
+| `.verdict` | string | `low` \| `medium` \| `high`. Forced `low` when `degraded`. |
+| `.score` | int | Summed signal weights (deduped per signal class). |
+| `.reasons` | array | Fired signals, each `{signal, detail, weight}`. May be `[]`. |
+| `.reasons[].signal` | string | Stable signal code (`central`, `churn-hotspot`, `blast`, `role:*`, `risk:*`, `bead-central`). |
+| `.changed` | object | `{files, go_files, symbols}` — diff shape (observability, not scored). |
+| `.degraded` | bool | See below — the load-bearing discriminator. |
+| `.note` | string | Present (omitempty) only when `degraded` or otherwise noteworthy. |
+
+## Invariants
+
+1. **Always exactly one result.** `.results` has length 1 and `.meta.total == 1`
+   on every path — clean, degraded, or unanalyzable. `risk` **never** emits
+   `results == []`. Read `.results[0]` unconditionally; **do not** branch on
+   `len(results)`.
+2. **`risk` never fails.** Exit 0 even with no index, a non-git tree, or an
+   unresolved ref — those degrade rather than erroring.
+
+## `degraded` — trust vs. fallback
+
+`degraded` is the discriminator a consumer **must** branch on. `len(reasons)`
+is **not** a safe proxy: an unanalyzable diff also carries `reasons == []`.
+
+- **`degraded: false`** — snipe analyzed a real Go diff. Trust the verdict. A
+  clean diff here reads `verdict: low` with `reasons: []` → the judge's
+  `tier:none`.
+- **`degraded: true`** — snipe **couldn't analyze**; the verdict is a safe-low
+  placeholder, not evidence of low risk. The consumer should drop to its
+  portable fallback. `.note` says why. Three cases:
+  - index absent (`"index unavailable: …"`)
+  - git diff unavailable — not a work tree, unresolved ref, or git absent
+  - no changed Go files (`"no changed Go files"`)
+
+The trap: a clean analyzed diff (`degraded:false`, `reasons:[]`) and an
+unanalyzable diff (`degraded:true`, `reasons:[]`) can look identical on
+`reasons` alone, but the judge branches on them **oppositely**. `degraded` is
+the only sound signal.
+
+## Consumer recipe (cc-plugins review-judge)
+
+```
+degraded == true                              → portable fallback (don't trust empty as safe)
+degraded == false && verdict == "low"         → tier:none  (trust the clean verdict)
+degraded == false && verdict in {medium,high} → escalate review depth
+```

--- a/test/blackbox/risk_contract_test.go
+++ b/test/blackbox/risk_contract_test.go
@@ -1,0 +1,175 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// sn-n8re — golden contract test for `snipe risk --format json`.
+//
+// cc-plugins' review-judge (ccp-1cfm) is a thin consumer that hard-couples to
+// this shape as a semver-guarded contract: it reads .results[0].{verdict,score,
+// reasons,degraded} and branches on .degraded. A rename or a shape drift here
+// silently miscalibrates their CI judge, so this test fails on any breaking
+// change. The committed field set + the always-one-result guarantee ARE the
+// contract; keep them stable or bump snipe's major version.
+//
+// The load-bearing distinction the judge needs: a clean analyzed diff
+// (degraded=false, reasons=[]) means "trust it, tier:none", whereas an
+// unanalyzable diff (degraded=true) means "drop to portable fallback, don't
+// trust empty as safe". Both can surface reasons==[], so `degraded` — not
+// len(reasons) — is the only sound discriminator. This test pins that.
+
+// gitCommitAll stages everything and commits, with ambient hooks disabled (the
+// global commit-msg conventional-commit hook otherwise rejects fixture commits).
+func gitCommitAll(t *testing.T, dir, msg string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"add", "-A"},
+		{"commit", "-m", msg},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// riskResult runs `snipe risk <args> --format json`, asserts the invariant shell
+// (exit 0, single result, meta.total==1, stable field set) that holds on EVERY
+// path — clean, degraded, or unanalyzable — and returns the sole verdict object.
+func riskResult(t *testing.T, repoDir string, args ...string) map[string]any {
+	t.Helper()
+	stdout, stderr, exitCode := run(t, repoDir, append([]string{"risk"}, args...)...)
+	if exitCode != 0 {
+		t.Fatalf("risk %v exit %d (risk must never fail — it degrades): stderr=%s stdout=%s",
+			args, exitCode, string(stderr), string(stdout))
+	}
+	resp := assertEnvelope(t, stdout, "risk")
+
+	// Always exactly one result — risk never emits results==[]. A consumer can
+	// unconditionally read .results[0]; the judge relies on this.
+	results := requireSlice(t, resp["results"], "results")
+	if len(results) != 1 {
+		t.Fatalf("risk %v: want exactly 1 result, got %d (contract: always one)", args, len(results))
+	}
+	meta := requireMap(t, resp["meta"], "meta")
+	if total, ok := meta["total"].(float64); !ok || total != 1 {
+		t.Fatalf("risk %v: meta.total = %v, want 1", args, meta["total"])
+	}
+
+	v := requireMap(t, results[0], "results[0]")
+	// Stable field names the judge hard-codes. `note` is omitempty (absent on a
+	// clean analyzed diff), so it isn't required here.
+	if _, ok := v["verdict"].(string); !ok {
+		t.Fatalf("risk %v: results[0].verdict missing/not a string: %v", args, v["verdict"])
+	}
+	if _, ok := v["score"].(float64); !ok {
+		t.Fatalf("risk %v: results[0].score missing/not a number: %v", args, v["score"])
+	}
+	if _, ok := v["reasons"]; !ok {
+		t.Fatalf("risk %v: results[0].reasons missing", args)
+	}
+	if _, ok := v["changed"].(map[string]any); !ok {
+		t.Fatalf("risk %v: results[0].changed missing/not an object: %v", args, v["changed"])
+	}
+	if _, ok := v["degraded"].(bool); !ok {
+		t.Fatalf("risk %v: results[0].degraded missing/not a bool: %v", args, v["degraded"])
+	}
+	return v
+}
+
+// reasonsLen returns the length of results[0].reasons, tolerating JSON null.
+func reasonsLen(t *testing.T, v map[string]any) int {
+	t.Helper()
+	if v["reasons"] == nil {
+		return 0
+	}
+	return len(requireSlice(t, v["reasons"], "reasons"))
+}
+
+func TestRiskJSONContract(t *testing.T) {
+	repoDir, paths := writeFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+
+	// --- unanalyzable case 1: no index -------------------------------------
+	// runRisk hits OpenStore before any diff work; a missing index degrades
+	// rather than erroring. No indexRepo call yet.
+	t.Run("missing_index_degrades", func(t *testing.T) {
+		v := riskResult(t, repoDir, "HEAD")
+		if v["degraded"] != true {
+			t.Fatalf("missing index must degrade, got degraded=%v", v["degraded"])
+		}
+		if v["verdict"] != "low" {
+			t.Fatalf("degraded verdict must be forced low, got %v", v["verdict"])
+		}
+	})
+
+	indexRepo(t, repoDir)
+
+	// --- unanalyzable case 2: no changed Go files (empty diff) --------------
+	// This is the trap the judge must not fall into: reasons==[] here, but the
+	// diff was NOT analyzed, so it must read degraded=true, never tier:none.
+	var emptyDiff map[string]any
+	t.Run("empty_diff_degrades", func(t *testing.T) {
+		emptyDiff = riskResult(t, repoDir, "HEAD", "HEAD")
+		if emptyDiff["degraded"] != true {
+			t.Fatalf("empty diff (no Go files) must degrade, got degraded=%v", emptyDiff["degraded"])
+		}
+		if n := reasonsLen(t, emptyDiff); n != 0 {
+			t.Fatalf("empty diff must carry no reasons, got %d", n)
+		}
+		if emptyDiff["verdict"] != "low" {
+			t.Fatalf("degraded verdict must be forced low, got %v", emptyDiff["verdict"])
+		}
+	})
+
+	// --- unanalyzable case 3: unresolved ref -------------------------------
+	t.Run("unresolved_ref_degrades", func(t *testing.T) {
+		v := riskResult(t, repoDir, "no-such-ref-deadbeef")
+		if v["degraded"] != true {
+			t.Fatalf("unresolved ref must degrade, got degraded=%v", v["degraded"])
+		}
+	})
+
+	// --- analyzed clean case: real Go diff, no risk signals ----------------
+	// Edit only a _test.go body: a changed Go file (so NOT degraded), but it
+	// contributes no production symbols. This is the judge's "analyzed, trust
+	// it" case; it must read degraded=false and be separable from the
+	// unanalyzable empty diff above.
+	editFile(t, paths["test"], readFile(t, paths["test"])+"\n// contract-probe touch\n")
+	gitCommitAll(t, repoDir, "edit test only")
+	indexRepo(t, repoDir)
+
+	t.Run("degraded_is_the_discriminator", func(t *testing.T) {
+		analyzed := riskResult(t, repoDir, "HEAD~1", "HEAD")
+		t.Logf("analyzed verdict: %v", analyzed)
+		if analyzed["degraded"] != false {
+			t.Fatalf("a real analyzed diff must NOT be degraded, got degraded=%v", analyzed["degraded"])
+		}
+		if emptyDiff == nil {
+			t.Fatal("empty-diff case did not run before discriminator check")
+		}
+
+		// The contract's load-bearing guarantee. The unanalyzable empty diff
+		// carries reasons==[] (the trap: a judge keying on len(reasons)==0 as
+		// "clean" would mis-score it as tier:none), yet it is degraded=true. The
+		// analyzed diff is degraded=false. So `degraded` — never len(reasons) —
+		// is the sound discriminator between "trust the clean verdict" and "drop
+		// to portable fallback". In this small fixture the analyzed diff also
+		// trips the file-level churn signal (every file lands in churn top-20),
+		// so we can't manufacture an analyzed reasons==[]; the trap we DO pin is
+		// the dangerous direction — empty-but-unanalyzable.
+		if n := reasonsLen(t, emptyDiff); n != 0 {
+			t.Fatalf("expected the unanalyzable empty diff to expose the trap (reasons==[]), got %d reasons", n)
+		}
+		if emptyDiff["degraded"] != true || analyzed["degraded"] != false {
+			t.Fatalf("degraded must separate unanalyzable (want true) from analyzed (want false): "+
+				"empty=%v analyzed=%v", emptyDiff["degraded"], analyzed["degraded"])
+		}
+	})
+}


### PR DESCRIPTION
Makes the `snipe risk --format json` contract cc-plugins' review-judge (ccp-1cfm) consumes mechanical instead of a handshake.

- **sn-n8re** — `test/blackbox/risk_contract_test.go`: golden test failing on any breaking change. Pins always-one-result (`meta.total==1`, never `results==[]`), the stable `.results[0].{verdict,score,reasons,changed,degraded}` field set, `degraded=true` in all three couldn't-analyze cases, `degraded=false` on a real diff, and `degraded` (not `len(reasons)`) as the trust/fallback discriminator.
- **sn-33gg** — `docs/contracts/risk-json.md`: the semver-guarded field paths, invariants, and degraded semantics; `cmd/risk.go` doc-comment points at both.

Per RealBison's handoff: if the guard test goes red, their CI judge is the downstream that breaks — a red is intentional only with a major bump + `@cc-plugins` heads-up.

Green on `make check` + full blackbox suite.

Closes: sn-n8re, sn-33gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a documented, stable JSON contract for `snipe risk --format json`.
  * Clarified response fields, result semantics, degraded-state handling, and consumer decision guidance.

* **Tests**
  * Added coverage validating the JSON response structure across missing, empty, unresolved, and clean analysis scenarios.
  * Confirmed consistent result counts, metadata, field types, and degraded-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->