### PR TITLE
chore(embed): drop deprecated plaintext credentials-file fallback (sn-nduv)

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -269,16 +269,16 @@ func checkEmbeddings() DoctorCheck {
 		check.OK = true
 		check.Message = "embedding credentials available"
 	case has && probeErr != nil:
-		// Keychain is locked/unreadable but env or the credentials file
+		// Keychain is locked/unreadable but the SNIPE_VOYAGE_API_KEY env var
 		// covers it — say so instead of a false "credentials available".
 		check.OK = true
-		check.Message = "keychain locked or unreadable — using env/file credentials"
+		check.Message = "keychain locked or unreadable — using env credentials"
 		check.Details = probeErr.Error()
 		check.Remediation = "security unlock-keychain"
 	case probeErr != nil:
 		check.OK = true // Not a failure, just informational
 		check.Code = DoctorEmbedAuthMissing
-		check.Message = "keychain locked or unreadable and no env/file credentials (embeddings disabled)"
+		check.Message = "keychain locked or unreadable and no env credentials (embeddings disabled)"
 		check.Details = probeErr.Error()
 		check.Remediation = "security unlock-keychain; or export SNIPE_VOYAGE_API_KEY=your-key"
 	default:
@@ -293,12 +293,12 @@ func checkEmbeddings() DoctorCheck {
 
 // embedAuthRemediation orders the credential recipes by platform: the macOS
 // keychain recipe leads only on darwin; elsewhere there is no keychain
-// backend, so env/file guidance comes first.
+// backend, so the env-var recipe is the only one.
 func embedAuthRemediation() string {
 	if runtime.GOOS == "darwin" {
-		return "store the key in the macOS keychain: security add-generic-password -U -s snipe -a voyage -w YOUR-KEY (preferred); or export SNIPE_VOYAGE_API_KEY=your-key; the plaintext ~/.config/snipe/credentials file still works but is deprecated"
+		return "store the key in the macOS keychain: security add-generic-password -U -s snipe -a voyage -w YOUR-KEY (preferred); or export SNIPE_VOYAGE_API_KEY=your-key"
 	}
-	return "export SNIPE_VOYAGE_API_KEY=your-key; or create ~/.config/snipe/credentials with SNIPE_VOYAGE_API_KEY=your-key (no keychain backend on this platform)"
+	return "export SNIPE_VOYAGE_API_KEY=your-key (no keychain backend on this platform)"
 }
 
 func checkOrphans() DoctorCheck {

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -141,12 +141,12 @@ func resolveCredentials() (string, string, string, error) {
 	case keyErr == nil:
 	case errors.Is(keyErr, keyring.ErrNotFound), errors.Is(keyErr, keyring.ErrUnsupported):
 		// Confirmed absent, or no keychain backend: GetOrEnv already
-		// consulted the env var; fall through to the credentials file.
+		// consulted the env var; nothing left to try.
 	case errors.Is(keyErr, keyring.ErrUnreadable):
 		// Locked or denied keychain. snipe index can run headless or in the
 		// background, so a hard error here would be wrong — but a silent
 		// downgrade violates the keyring contract. Warn LOUDLY once per
-		// process, then consult env/file explicitly (GetOrEnv does not fall
+		// process, then consult the env var explicitly (GetOrEnv does not fall
 		// through on ErrUnreadable). If nothing else exists, embeddings
 		// switch off via the caller's existing Warning path.
 		recordProbe(keyErr)

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -58,7 +56,7 @@ func recordProbe(err error) {
 }
 
 // warnUnreadableOnce logs one prominent warning per account per process when
-// the keychain is unreadable and we downgrade to env/file. The keyring
+// the keychain is unreadable and we downgrade to the env var. The keyring
 // contract forbids a SILENT downgrade; for a consumer that can run headless or
 // in the background (snipe index), a LOUD one-time downgrade is the correct
 // behavior — name the locked keychain, the account, and the fallback, then
@@ -71,7 +69,7 @@ func warnUnreadableOnce(account string, err error) {
 	}
 	warnedAccounts[account] = true
 	fmt.Fprintf(os.Stderr,
-		"WARNING: keychain item %s/%s is unreadable (keychain locked or access denied): %v — falling back to SNIPE_VOYAGE_API_KEY / ~/.config/snipe/credentials\n",
+		"WARNING: keychain item %s/%s is unreadable (keychain locked or access denied): %v — falling back to SNIPE_VOYAGE_API_KEY\n",
 		keyringService, account, err)
 }
 
@@ -108,22 +106,12 @@ type EmbeddingResponse struct {
 	} `json:"usage"`
 }
 
-// credentialsPath returns the path to snipe's credentials file.
-func credentialsPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".config", "snipe", "credentials")
-}
-
 // HasCredentials checks if embedding credentials are available.
-// Returns true if the keychain holds a voyage key, the SNIPE_VOYAGE_API_KEY
-// env var is set, or the credentials file exists. An unreadable keychain
-// (locked/denied — keyring.ErrUnreadable) is NOT treated as "credentials
-// available": the probe falls through to env/file and records the locked
-// state in LastProbeErr so doctor can name it, keeping this probe in
-// agreement with resolveCredentials.
+// Returns true if the keychain holds a voyage key or the SNIPE_VOYAGE_API_KEY
+// env var is set. An unreadable keychain (locked/denied — keyring.ErrUnreadable)
+// is NOT treated as "credentials available": the probe falls through to the env
+// var and records the locked state in LastProbeErr so doctor can name it,
+// keeping this probe in agreement with resolveCredentials.
 func HasCredentials() bool {
 	recordProbe(nil)
 	if store, err := credStore(); err == nil {
@@ -133,28 +121,16 @@ func HasCredentials() bool {
 		}
 		if hasErr != nil && errors.Is(hasErr, keyring.ErrUnreadable) {
 			// Locked or denied keychain — not confirmation of absence.
-			// Record it and consult env/file below.
+			// Record it and consult the env var below.
 			recordProbe(hasErr)
 		}
 	}
-	if envAPIKey() != "" {
-		return true
-	}
-	path := credentialsPath()
-	if path == "" {
-		return false
-	}
-	data, err := os.ReadFile(path) // #nosec G304 -- path from credentialsPath() (user config)
-	if err != nil {
-		return false
-	}
-	return strings.Contains(string(data), "SNIPE_VOYAGE_API_KEY=")
+	return envAPIKey() != ""
 }
 
 // resolveCredentials reads the API key keychain-first, then the
-// SNIPE_VOYAGE_API_KEY env var, then the credentials file (Linux + existing
-// installs). Model and endpoint are config, not secrets — plain env only.
-// Returns (apiKey, model, endpoint, error).
+// SNIPE_VOYAGE_API_KEY env var. Model and endpoint are config, not secrets —
+// plain env only. Returns (apiKey, model, endpoint, error).
 func resolveCredentials() (string, string, string, error) {
 	store, err := credStore()
 	if err != nil {
@@ -182,23 +158,8 @@ func resolveCredentials() (string, string, string, error) {
 	model := os.Getenv("VOYAGE_MODEL")
 	endpoint := os.Getenv("VOYAGE_API_URL")
 
-	// Last fallback: credentials file
 	if apiKey == "" {
-		creds, err := loadCredentials()
-		if err != nil {
-			return "", "", "", fmt.Errorf("no API key: store one in the keychain (security add-generic-password -U -s snipe -a voyage -w KEY), set SNIPE_VOYAGE_API_KEY, or create ~/.config/snipe/credentials: %w", err)
-		}
-		apiKey = creds["SNIPE_VOYAGE_API_KEY"]
-		if model == "" {
-			model = creds["VOYAGE_MODEL"]
-		}
-		if endpoint == "" {
-			endpoint = creds["VOYAGE_API_URL"]
-		}
-	}
-
-	if apiKey == "" {
-		return "", "", "", fmt.Errorf("SNIPE_VOYAGE_API_KEY not set")
+		return "", "", "", fmt.Errorf("no API key: store one in the keychain (security add-generic-password -U -s snipe -a voyage -w KEY) or set SNIPE_VOYAGE_API_KEY")
 	}
 	if model == "" {
 		model = "voyage-code-3"
@@ -207,7 +168,7 @@ func resolveCredentials() (string, string, string, error) {
 }
 
 // NewClient creates a new embedding client.
-// It reads credentials from ~/.config/snipe/credentials if not provided.
+// It reads the API key keychain-first, falling back to SNIPE_VOYAGE_API_KEY.
 func NewClient() (*Client, error) {
 	apiKey, model, endpoint, err := resolveCredentials()
 	if err != nil {
@@ -225,33 +186,6 @@ func NewClient() (*Client, error) {
 			Timeout: 30 * time.Second,
 		},
 	}, nil
-}
-
-// loadCredentials reads the credentials file.
-func loadCredentials() (map[string]string, error) {
-	path := credentialsPath()
-	if path == "" {
-		return nil, fmt.Errorf("cannot determine home directory")
-	}
-
-	data, err := os.ReadFile(path) // #nosec G304 -- path from credentialsPath() (user config)
-	if err != nil {
-		return nil, err
-	}
-
-	creds := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			creds[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-		}
-	}
-
-	return creds, nil
 }
 
 // Embed generates embeddings for the given texts.

--- a/internal/embed/client_test.go
+++ b/internal/embed/client_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -147,6 +149,33 @@ func TestEmbed_RespectsContextCancellation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "deadline") {
 		t.Fatalf("expected context/deadline error, got: %v", err)
+	}
+}
+
+// TestCredentials_IgnoresPlaintextFile guards the sn-nduv removal: the
+// deprecated ~/.config/snipe/credentials fallback is gone, so a planted file
+// must never satisfy HasCredentials or resolveCredentials. Keychain is disabled
+// and the env var cleared, leaving the file as the only possible source — and
+// it must be ignored.
+func TestCredentials_IgnoresPlaintextFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KEYRING_DISABLE", "1")
+	t.Setenv("SNIPE_VOYAGE_API_KEY", "")
+
+	credDir := filepath.Join(home, ".config", "snipe")
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(credDir, "credentials"), []byte("SNIPE_VOYAGE_API_KEY=planted-key\n"), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	if HasCredentials() {
+		t.Error("HasCredentials returned true from a plaintext file — the file fallback must be gone")
+	}
+	if _, _, _, err := resolveCredentials(); err == nil {
+		t.Error("resolveCredentials succeeded from a plaintext file — the file fallback must be gone")
 	}
 }
 


### PR DESCRIPTION
## What

Removes the deprecated `~/.config/snipe/credentials` plaintext fallback. After keychain-first resolution landed in #200, the file was the last of three credential legs; now keychain + `SNIPE_VOYAGE_API_KEY` env are the only paths.

## Changes

- **internal/embed/client.go** — delete `credentialsPath()` and `loadCredentials()`; drop the file-read leg in `HasCredentials()` and the file fallback in `resolveCredentials()`. Drop unused `path/filepath` + `strings` imports. Update the unreadable-keychain warning and doc comments.
- **cmd/doctor.go** — remediation text no longer mentions the plaintext file.
- **internal/embed/client_test.go** — regression guard `TestCredentials_IgnoresPlaintextFile`: a planted `~/.config/snipe/credentials` (keychain disabled, env cleared) must not satisfy `HasCredentials`/`resolveCredentials`.

## Verify

`make audit` green (vet, lint, test, race, blackbox, govulncheck: 0 called vulnerabilities).

Closes: sn-nduv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Embedding credentials are now accepted from the system keychain or `SNIPE_VOYAGE_API_KEY`.
  * Deprecated plaintext credentials files are no longer recognized.
  * Updated credential status messages and setup guidance to reflect the supported authentication methods.
  * Improved handling and reporting when keychain access is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->