### PR TITLE
feat(plan): snipe plan — ordered edit worklist (sn-8f6q.5)

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -45,6 +45,7 @@ type CLI struct {
 	Hotspots  HotspotsCmd  `cmd:"" group:"Graph & Structure:" help:"Rank files by complexity × git change-frequency (Tornhill hotspot model)"`
 	Risk      RiskCmd      `cmd:"" group:"Graph & Structure:" help:"Assess a diff's risk (base→head): code-graph verdict (roles, centrality, blast, churn)"`
 	Verify    VerifyCmd    `cmd:"" group:"Graph & Structure:" help:"Map a diff to the minimal go test set covering changed symbols (structural, not a gate)"`
+	Plan      PlanCmd      `cmd:"" group:"Graph & Structure:" help:"Ordered edit worklist for a proposed symbol change (def + call sites + tests; structural, not a gate)"`
 	Sensitive SensitiveCmd `cmd:"" group:"Graph & Structure:" help:"List files in security-sensitive zones (auth/crypto/migration/secret/payment)"`
 	Diagram   DiagramCmd   `cmd:"" group:"Graph & Structure:" help:"Render snipe graphs as D2 diagram source"`
 	Lifecycle LifecycleCmd `cmd:"" group:"Graph & Structure:" help:"Trace every function creating, mutating, reading, or deleting a type"`

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -356,6 +356,22 @@ func (c *VerifyCmd) Run() error {
 	return runVerify(c.Base)
 }
 
+type PlanCmd struct {
+	Symbol string `arg:"" optional:"" help:"Symbol name or id"`
+
+	Change     string `enum:"signature,behavior,delete" default:"signature" help:"Which worklist to emit: signature (full), behavior (tests only), or delete (must-remove refs)"`
+	At         string `help:"Position to look up (file:line:col)"`
+	ID         string `name:"id" help:"Symbol ID to look up"`
+	MaxCallers int    `default:"50" help:"Cap total call sites emitted (token budget)"`
+}
+
+func (c *PlanCmd) Run() error {
+	planAt = c.At
+	planID = c.ID
+	planMaxCallers = c.MaxCallers
+	return runPlan(c.Change, argsOf(c.Symbol))
+}
+
 type SensitiveCmd struct{}
 
 func (c *SensitiveCmd) Run() error {

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -368,7 +368,13 @@ type PlanCmd struct {
 func (c *PlanCmd) Run() error {
 	planAt = c.At
 	planID = c.ID
+	// Clamp negatives to 0 (most restrictive cap). A negative value must never
+	// reach planBuildCallSites, where <0 is the internal unlimited sentinel —
+	// a --max-callers=-1 typo would otherwise dump every site.
 	planMaxCallers = c.MaxCallers
+	if planMaxCallers < 0 {
+		planMaxCallers = 0
+	}
 	return runPlan(c.Change, argsOf(c.Symbol))
 }
 

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -22,6 +22,7 @@ const (
 	cmdNameTests       = "tests"
 	cmdNameTypes       = "types"
 	cmdNameVerify      = "verify"
+	cmdNamePlan        = "plan"
 	cmdNamePack        = "pack"
 	cmdNamePkg         = "pkg"
 	cmdNameImports     = "imports"

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/query"
@@ -196,13 +198,19 @@ func runPlan(change string, args []string) error {
 		}
 
 	case planChangeDelete:
-		nonTest, testOnly, err := query.CountCallSites(s.DB(), symbolID)
-		if err != nil {
-			return internalErr(err)
-		}
 		refs, err := query.FindCallSites(s.DB(), symbolID)
 		if err != nil {
 			return internalErr(err)
+		}
+		// FindCallSites already carries IsTest per row, so count in Go rather
+		// than firing a second scan via CountCallSites.
+		var nonTest, testOnly int
+		for i := range refs {
+			if refs[i].IsTest {
+				testOnly++
+			} else {
+				nonTest++
+			}
 		}
 		if nonTest == 0 {
 			// Safe-to-delete fast path: list the test-only refs and stop.
@@ -301,7 +309,9 @@ func planAmbiguousMessage(name string, symbols []query.SymbolRow) string {
 // planFilterRefs splits FindCallSites rows on IsTest. wantTest=true keeps only
 // test-file refs (delete fast path); false keeps only production call sites.
 func planFilterRefs(refs []query.RefRow, wantTest bool) []query.RefRow {
-	out := refs[:0:0]
+	// Reuse refs' backing array — callers pass refs once and discard it, and
+	// the filter only ever shrinks (out never overtakes the read index).
+	out := refs[:0]
 	for i := range refs {
 		if refs[i].IsTest == wantTest {
 			out = append(out, refs[i])
@@ -320,7 +330,7 @@ func planBuildCallSites(refs []query.RefRow, maxSites int) (groups []PlanPkgGrou
 	totalSites = len(refs)
 	seenPkg := map[string]struct{}{}
 	for i := range refs {
-		seenPkg[filepath.Dir(refs[i].FilePathRel)] = struct{}{}
+		seenPkg[filepath.Dir(planRelFile(refs[i].FilePathRel, refs[i].FilePath))] = struct{}{}
 	}
 	totalPkgs = len(seenPkg)
 
@@ -331,7 +341,8 @@ func planBuildCallSites(refs []query.RefRow, maxSites int) (groups []PlanPkgGrou
 	idx := map[string]int{}
 	for i := range refs {
 		r := &refs[i]
-		pkg := filepath.Dir(r.FilePathRel)
+		file := planRelFile(r.FilePathRel, r.FilePath)
+		pkg := filepath.Dir(file)
 		gi, ok := idx[pkg]
 		if !ok {
 			gi = len(groups)
@@ -339,7 +350,7 @@ func planBuildCallSites(refs []query.RefRow, maxSites int) (groups []PlanPkgGrou
 			groups = append(groups, PlanPkgGroup{Pkg: pkg})
 		}
 		groups[gi].Sites = append(groups[gi].Sites, PlanSite{
-			File:      r.FilePathRel,
+			File:      file,
 			Line:      r.Line,
 			Col:       r.Col,
 			ID:        r.EnclosingID.String,
@@ -350,6 +361,20 @@ func planBuildCallSites(refs []query.RefRow, maxSites int) (groups []PlanPkgGrou
 		})
 	}
 	return groups, truncated, totalSites, totalPkgs
+}
+
+// planExportedName reports whether name is a Go-exported identifier (leading
+// upper-case rune). Method names may arrive as "Recv.Method" — the final
+// segment decides exportedness.
+func planExportedName(name string) bool {
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	if name == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
 }
 
 // planRelFile prefers the relative path for output, falling back to absolute.
@@ -433,8 +458,14 @@ func writePlanHeader(b *strings.Builder, p PlanResult) {
 
 	switch {
 	case p.Change == planChangeDelete && p.SafeToDelete:
-		fmt.Fprintf(b, "plan %s · delete · safe to delete — 0 non-test callers, %d test-only ref%s\n",
-			p.Symbol, p.TestOnlyRefs, verifyPlural(p.TestOnlyRefs))
+		// "safe to delete" is index-scoped: an exported symbol may still have
+		// consumers outside this repo that the index can't see. Say so.
+		safe := "safe to delete"
+		if planExportedName(p.Symbol) {
+			safe = "no indexed non-test callers (exported — external consumers not visible to the index)"
+		}
+		fmt.Fprintf(b, "plan %s · delete · %s, %d test-only ref%s\n",
+			p.Symbol, safe, p.TestOnlyRefs, verifyPlural(p.TestOnlyRefs))
 	case p.Change == planChangeDelete:
 		fmt.Fprintf(b, "plan %s · delete · MUST remove %d ref%s in %d pkg%s before deleting def\n",
 			p.Symbol, sites, verifyPlural(sites), pkgs, verifyPlural(pkgs))
@@ -460,7 +491,9 @@ func writePlanDef(b *strings.Builder, p PlanResult) {
 }
 
 func writePlanCallSites(b *strings.Builder, p PlanResult, header string) {
-	if len(p.CallSites) == 0 {
+	// Truncated>0 with zero emitted sites is the --max-callers=0 case: still
+	// print the header + "+N more" so the count in the header isn't orphaned.
+	if len(p.CallSites) == 0 && p.Truncated == 0 {
 		return
 	}
 	fmt.Fprintln(b, header)
@@ -492,6 +525,7 @@ func writePlanTestOnlyRefs(b *strings.Builder, p PlanResult) {
 	n, _ := planCountSites(p.CallSites)
 	fmt.Fprintf(b, "test-only refs (%d)\n", n)
 	for _, g := range p.CallSites {
+		fmt.Fprintf(b, "%s (%d)\n", g.Pkg, len(g.Sites))
 		for _, s := range g.Sites {
 			id := s.ID
 			if id == "" {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,0 +1,542 @@
+package cmd
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+)
+
+// planTestLimit caps how many covering tests plan lists. Generous on purpose —
+// plan's worklist should name every covering test, not paginate them.
+const planTestLimit = 500
+
+// planClaimNote is appended to every non-degenerate text response so Claude
+// never mistakes plan's structural worklist for a correctness gate.
+const planClaimNote = "note: plan maps the edit worklist structurally — not a correctness gate (run make audit)."
+
+// planGoldenPlaceholder is the neutral golden/testdata stub. Churn detection is
+// a follow-up; for now plan only flags that fixtures may need a hand scan.
+const planGoldenPlaceholder = "churn not analyzed here; scan fixtures by hand if this symbol shapes golden output"
+
+// Change modes for `snipe plan --change`.
+const (
+	planChangeSignature = "signature"
+	planChangeBehavior  = "behavior"
+	planChangeDelete    = "delete"
+)
+
+var (
+	planAt         string
+	planID         string
+	planMaxCallers int
+)
+
+// PlanResult is the ordered edit worklist for a proposed symbol change: the def
+// site (with signature), the call sites grouped by package, and the covering
+// tests. Message is set instead of the rest of the fields for degenerate paths
+// (no index, symbol not found, ambiguous, zero callers on delete uses the
+// SafeToDelete fields) — plan is never a gate, so every such path exits 0.
+type PlanResult struct {
+	Message      string         `json:"message,omitempty"`
+	Symbol       string         `json:"symbol,omitempty"`
+	ID           string         `json:"id,omitempty"`
+	Change       string         `json:"change"`
+	Def          *PlanDef       `json:"def,omitempty"`
+	CallSites    []PlanPkgGroup `json:"call_sites,omitempty"`
+	MustRemove   bool           `json:"must_remove,omitempty"`
+	SafeToDelete bool           `json:"safe_to_delete,omitempty"`
+	TestOnlyRefs int            `json:"test_only_refs,omitempty"`
+	Tests        PlanTests      `json:"tests"`
+	Golden       string         `json:"golden_placeholder,omitempty"`
+	Truncated    int            `json:"truncated_call_sites,omitempty"`
+
+	// TotalCallSites/TotalPkgs are the pre-truncation totals the header
+	// reports ("def + N call sites in K pkgs"); CallSites may hold fewer once
+	// --max-callers truncates. Kept out of the header's job in the text path.
+	TotalCallSites int `json:"total_call_sites,omitempty"`
+	TotalPkgs      int `json:"total_pkgs,omitempty"`
+}
+
+// PlanDef is the definition site of the symbol under change.
+type PlanDef struct {
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	ID        string `json:"id"`
+	Signature string `json:"signature"`
+}
+
+// PlanPkgGroup is a set of call sites sharing a package (the ref file's
+// directory). The single-footer truncation rule reports the global dropped
+// count via PlanResult.Truncated, so no per-group count is carried here.
+type PlanPkgGroup struct {
+	Pkg   string     `json:"pkg"`
+	Sites []PlanSite `json:"sites"`
+}
+
+// PlanSite is one call site. ID chains to the enclosing symbol's def (empty for
+// a package-level initializer); RefID is always present so the site stays
+// addressable even when ID is empty.
+type PlanSite struct {
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	Col       int    `json:"col"`
+	ID        string `json:"id"`
+	RefID     string `json:"ref_id"`
+	Enclosing string `json:"enclosing"`
+	Snippet   string `json:"snippet"`
+	ASTCtx    string `json:"ast_ctx,omitempty"`
+}
+
+// PlanTests groups covering tests by hop distance.
+type PlanTests struct {
+	Direct     []PlanTest `json:"direct"`
+	Transitive []PlanTest `json:"transitive"`
+}
+
+// PlanTest is one covering test function.
+type PlanTest struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// runPlan builds the ordered edit worklist for a symbol Claude is about to
+// change. Like verify, every degenerate path (no index, symbol not found,
+// ambiguous, malformed --at, unknown --id, no input) exits 0 with a plain
+// message via writePlanMessage — never an error envelope.
+func runPlan(change string, args []string) error {
+	start := time.Now()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+
+	// nil writer: suppress OpenStore's missing-index error envelope. plan
+	// degrades to an "index unavailable" message and exits 0 (a USER
+	// condition). root is still populated on error, so the message-writer has
+	// what it needs.
+	s, root, err := OpenStore(nil, cmdNamePlan)
+	if err != nil {
+		return writePlanMessage(root, start, change, "index unavailable: "+err.Error())
+	}
+	defer s.Close()
+
+	symbolID, msg, err := resolvePlanSymbol(s.DB(), root, args)
+	if err != nil {
+		return w.WriteError(cmdNamePlan, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	if msg != "" {
+		return writePlanMessage(root, start, change, msg)
+	}
+
+	defSym, err := query.LookupByID(s.DB(), symbolID)
+	if err != nil {
+		return w.WriteError(cmdNamePlan, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	if defSym == nil {
+		return writePlanMessage(root, start, change, "no symbol with id "+symbolID)
+	}
+	recordSessionQuery(root, defSym.Name, defSym.FilePathRel, defSym.LineStart, defSym.Kind, cmdNamePlan)
+
+	result := PlanResult{
+		Symbol: defSym.Name,
+		ID:     symbolID,
+		Change: change,
+		Def: &PlanDef{
+			File:      planRelFile(defSym.FilePathRel, defSym.FilePath),
+			Line:      defSym.LineStart,
+			ID:        symbolID,
+			Signature: defSym.Signature.String,
+		},
+		Golden: planGoldenPlaceholder,
+	}
+
+	// Tests: direct + transitive covering tests. Skipped for the delete
+	// zero-caller fast path (which lists test-only refs instead).
+	buildTests := func() error {
+		testRows, err := query.FindTestsMulti(s.DB(), []string{symbolID}, false, planTestLimit, 0)
+		if err != nil {
+			return err
+		}
+		for i := range testRows {
+			tr := &testRows[i]
+			pt := PlanTest{
+				File: planRelFile(tr.FilePathRel, tr.FilePath),
+				Line: tr.LineStart,
+				ID:   tr.ID,
+				Name: tr.Name,
+			}
+			if tr.Hop == 2 {
+				result.Tests.Transitive = append(result.Tests.Transitive, pt)
+			} else {
+				result.Tests.Direct = append(result.Tests.Direct, pt)
+			}
+		}
+		return nil
+	}
+
+	// internalErr escalates a genuine query/SQL failure to a non-zero error
+	// envelope (mirrors verify.go), distinct from the USER conditions that
+	// degrade to an exit-0 message.
+	internalErr := func(err error) error {
+		return w.WriteError(cmdNamePlan, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+
+	switch change {
+	case planChangeBehavior:
+		// No signature change: skip call sites entirely, keep tests.
+		if err := buildTests(); err != nil {
+			return internalErr(err)
+		}
+
+	case planChangeDelete:
+		nonTest, testOnly, err := query.CountCallSites(s.DB(), symbolID)
+		if err != nil {
+			return internalErr(err)
+		}
+		refs, err := query.FindCallSites(s.DB(), symbolID)
+		if err != nil {
+			return internalErr(err)
+		}
+		if nonTest == 0 {
+			// Safe-to-delete fast path: list the test-only refs and stop.
+			result.SafeToDelete = true
+			result.TestOnlyRefs = testOnly
+			result.CallSites, _, _, _ = planBuildCallSites(planFilterRefs(refs, true), -1)
+			break
+		}
+		result.MustRemove = true
+		result.CallSites, result.Truncated, result.TotalCallSites, result.TotalPkgs =
+			planBuildCallSites(planFilterRefs(refs, false), planMaxCallers)
+		if err := buildTests(); err != nil {
+			return internalErr(err)
+		}
+
+	default: // "signature"
+		refs, err := query.FindCallSites(s.DB(), symbolID)
+		if err != nil {
+			return internalErr(err)
+		}
+		result.CallSites, result.Truncated, result.TotalCallSites, result.TotalPkgs =
+			planBuildCallSites(planFilterRefs(refs, false), planMaxCallers)
+		if err := buildTests(); err != nil {
+			return internalErr(err)
+		}
+	}
+
+	return writePlan(result, root, start)
+}
+
+// resolvePlanSymbol mirrors impact.go's resolution structure. USER conditions
+// (malformed --at, symbol not found, ambiguous, no input) route through a
+// returned message (exit 0); a genuine query failure returns a non-nil error
+// so the caller can escalate it to a non-zero INTERNAL envelope. Returns
+// (symbolID, "", nil) on success, ("", message, nil) to degrade, or
+// ("", "", err) on an internal failure.
+func resolvePlanSymbol(db *sql.DB, root string, args []string) (symbolID, msg string, err error) {
+	switch {
+	case planID != "":
+		return planID, "", nil
+
+	case planAt != "":
+		pos, perr := query.ParsePosition(planAt)
+		if perr != nil {
+			return "", "invalid --at: " + perr.Error(), nil //nolint:nilerr // malformed --at is a USER condition — degrade to an exit-0 message, not an INTERNAL error
+		}
+		filePath := pos.File
+		if filepath.IsAbs(filePath) {
+			if rel, err := filepath.Rel(root, filePath); err == nil {
+				filePath = rel
+			}
+		}
+		sym := query.FindSymbolAtPosition(db, filePath, pos.Line)
+		if sym == nil {
+			return "", "no symbol found at " + planAt, nil
+		}
+		return sym.ID, "", nil
+
+	default:
+		if len(args) == 0 {
+			return "", "provide a symbol name, --at position, or --id", nil
+		}
+		name := args[0]
+		if len(name) == 16 {
+			if _, err := hex.DecodeString(name); err == nil {
+				return name, "", nil
+			}
+		}
+		symbols, err := query.LookupByName(db, name)
+		if err != nil {
+			return "", "", err
+		}
+		if len(symbols) == 0 {
+			return "", "no symbol named " + name, nil
+		}
+		if len(symbols) > 1 {
+			return "", planAmbiguousMessage(name, symbols), nil
+		}
+		return symbols[0].ID, "", nil
+	}
+}
+
+// planAmbiguousMessage renders a candidate list for an ambiguous name (D2:
+// disambiguate rather than error out).
+func planAmbiguousMessage(name string, symbols []query.SymbolRow) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "ambiguous: %d symbols named %q — disambiguate with --id or --at:", len(symbols), name)
+	for i := range symbols {
+		sym := &symbols[i]
+		fmt.Fprintf(&b, "\n  %s:%d  %s  %s.%s",
+			planRelFile(sym.FilePathRel, sym.FilePath), sym.LineStart, sym.ID, sym.PkgPath, sym.Name)
+	}
+	return b.String()
+}
+
+// planFilterRefs splits FindCallSites rows on IsTest. wantTest=true keeps only
+// test-file refs (delete fast path); false keeps only production call sites.
+func planFilterRefs(refs []query.RefRow, wantTest bool) []query.RefRow {
+	out := refs[:0:0]
+	for i := range refs {
+		if refs[i].IsTest == wantTest {
+			out = append(out, refs[i])
+		}
+	}
+	return out
+}
+
+// planBuildCallSites groups ordered refs by the ref file's package directory,
+// preserving order (refs arrive sorted by file_path_rel, so packages are
+// contiguous). When maxSites >= 0 it truncates the flattened ordered list to
+// the first maxSites; maxSites < 0 means no cap. Returns the display groups,
+// the number of sites dropped, and the PRE-truncation totals (total sites and
+// distinct packages) the header reports.
+func planBuildCallSites(refs []query.RefRow, maxSites int) (groups []PlanPkgGroup, truncated, totalSites, totalPkgs int) {
+	totalSites = len(refs)
+	seenPkg := map[string]struct{}{}
+	for i := range refs {
+		seenPkg[filepath.Dir(refs[i].FilePathRel)] = struct{}{}
+	}
+	totalPkgs = len(seenPkg)
+
+	if maxSites >= 0 && len(refs) > maxSites {
+		truncated = len(refs) - maxSites
+		refs = refs[:maxSites]
+	}
+	idx := map[string]int{}
+	for i := range refs {
+		r := &refs[i]
+		pkg := filepath.Dir(r.FilePathRel)
+		gi, ok := idx[pkg]
+		if !ok {
+			gi = len(groups)
+			idx[pkg] = gi
+			groups = append(groups, PlanPkgGroup{Pkg: pkg})
+		}
+		groups[gi].Sites = append(groups[gi].Sites, PlanSite{
+			File:      r.FilePathRel,
+			Line:      r.Line,
+			Col:       r.Col,
+			ID:        r.EnclosingID.String,
+			RefID:     r.ID,
+			Enclosing: r.EnclosingName,
+			Snippet:   strings.TrimSpace(r.Snippet),
+			ASTCtx:    r.ASTCtx,
+		})
+	}
+	return groups, truncated, totalSites, totalPkgs
+}
+
+// planRelFile prefers the relative path for output, falling back to absolute.
+func planRelFile(rel, abs string) string {
+	if rel != "" {
+		return rel
+	}
+	return abs
+}
+
+// writePlan dispatches to the JSON envelope or the terse Claude-default text
+// renderer per the global --format flag.
+func writePlan(p PlanResult, root string, start time.Time) error {
+	if GetOutputFormat() == output.OutputJSON {
+		return writePlanJSON(p, root, start)
+	}
+	return writePlanText(p)
+}
+
+// writePlanMessage renders a degenerate-path result — always exit 0, never a gate.
+func writePlanMessage(root string, start time.Time, change, msg string) error {
+	return writePlan(PlanResult{Message: msg, Change: change}, root, start)
+}
+
+// writePlanJSON emits the result inside the standard envelope; the single
+// result is the sole entry, consumers read `.results[0]` (mirrors writeVerifyJSON).
+func writePlanJSON(p PlanResult, root string, start time.Time) error {
+	resp := output.Response[PlanResult]{
+		Protocol: output.ProtocolVersion,
+		Ok:       true,
+		Results:  []PlanResult{p},
+		Meta: output.Meta{
+			Command:  cmdNamePlan,
+			RepoRoot: root,
+			Ms:       time.Since(start).Milliseconds(),
+			Total:    1,
+		},
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+func writePlanText(p PlanResult) error {
+	var b strings.Builder
+
+	if p.Message != "" {
+		fmt.Fprintln(&b, p.Message)
+		_, err := os.Stdout.WriteString(b.String())
+		return err
+	}
+
+	writePlanHeader(&b, p)
+	writePlanDef(&b, p)
+
+	switch {
+	case p.Change == planChangeDelete && p.SafeToDelete:
+		writePlanTestOnlyRefs(&b, p)
+	case p.Change == planChangeDelete:
+		writePlanCallSites(&b, p, "MUST REMOVE — every ref below, else the build breaks")
+		writePlanTests(&b, p, "TESTS — drop or rewrite")
+		writePlanGolden(&b, p)
+	case p.Change == planChangeBehavior:
+		writePlanTests(&b, p, "TESTS — no signature change; verify these still pass / add cases for new behavior")
+		writePlanGolden(&b, p)
+	default: // signature
+		writePlanCallSites(&b, p, "CALL SITES — edit every one to match the new signature")
+		writePlanTests(&b, p, "TESTS — update/verify after editing")
+		writePlanGolden(&b, p)
+	}
+
+	fmt.Fprintln(&b, planClaimNote)
+
+	_, err := os.Stdout.WriteString(b.String())
+	return err
+}
+
+func writePlanHeader(b *strings.Builder, p PlanResult) {
+	sites, pkgs := p.TotalCallSites, p.TotalPkgs
+	ntests := len(p.Tests.Direct) + len(p.Tests.Transitive)
+
+	switch {
+	case p.Change == planChangeDelete && p.SafeToDelete:
+		fmt.Fprintf(b, "plan %s · delete · safe to delete — 0 non-test callers, %d test-only ref%s\n",
+			p.Symbol, p.TestOnlyRefs, verifyPlural(p.TestOnlyRefs))
+	case p.Change == planChangeDelete:
+		fmt.Fprintf(b, "plan %s · delete · MUST remove %d ref%s in %d pkg%s before deleting def\n",
+			p.Symbol, sites, verifyPlural(sites), pkgs, verifyPlural(pkgs))
+	case p.Change == planChangeBehavior:
+		fmt.Fprintf(b, "plan %s · behavior change · no signature change — verify these %d test%s\n",
+			p.Symbol, ntests, verifyPlural(ntests))
+	default: // signature
+		fmt.Fprintf(b, "plan %s · signature change · def + %d call site%s in %d pkg%s · %d test%s\n",
+			p.Symbol, sites, verifyPlural(sites), pkgs, verifyPlural(pkgs), ntests, verifyPlural(ntests))
+	}
+	fmt.Fprintln(b)
+}
+
+func writePlanDef(b *strings.Builder, p PlanResult) {
+	label := "DEF"
+	if p.Change == planChangeDelete {
+		label = "DEF (remove)"
+	}
+	fmt.Fprintf(b, "%s  %s:%d  %s\n", label, p.Def.File, p.Def.Line, p.Def.ID)
+	if p.Def.Signature != "" {
+		fmt.Fprintf(b, "  %s\n", p.Def.Signature)
+	}
+}
+
+func writePlanCallSites(b *strings.Builder, p PlanResult, header string) {
+	if len(p.CallSites) == 0 {
+		return
+	}
+	fmt.Fprintln(b, header)
+	for _, g := range p.CallSites {
+		fmt.Fprintf(b, "%s (%d)\n", g.Pkg, len(g.Sites))
+		for _, s := range g.Sites {
+			id := s.ID
+			if id == "" {
+				id = s.RefID
+			}
+			enc := s.Enclosing
+			if enc == "" {
+				enc = "(pkg-init)"
+			}
+			line := fmt.Sprintf("  %s:%d  %s  %s  %s",
+				filepath.Base(s.File), s.Line, id, enc, s.Snippet)
+			if s.ASTCtx != "" {
+				line += "  [" + s.ASTCtx + "]"
+			}
+			fmt.Fprintln(b, line)
+		}
+	}
+	if p.Truncated > 0 {
+		fmt.Fprintf(b, "  +%d more call sites (raise --max-callers)\n", p.Truncated)
+	}
+}
+
+func writePlanTestOnlyRefs(b *strings.Builder, p PlanResult) {
+	n, _ := planCountSites(p.CallSites)
+	fmt.Fprintf(b, "test-only refs (%d)\n", n)
+	for _, g := range p.CallSites {
+		for _, s := range g.Sites {
+			id := s.ID
+			if id == "" {
+				id = s.RefID
+			}
+			enc := s.Enclosing
+			if enc == "" {
+				enc = "(pkg-init)"
+			}
+			fmt.Fprintf(b, "  %s:%d  %s  %s\n", filepath.Base(s.File), s.Line, id, enc)
+		}
+	}
+}
+
+func writePlanTests(b *strings.Builder, p PlanResult, header string) {
+	if len(p.Tests.Direct) == 0 && len(p.Tests.Transitive) == 0 {
+		return
+	}
+	fmt.Fprintln(b, header)
+	if len(p.Tests.Direct) > 0 {
+		fmt.Fprintf(b, "direct (%d)\n", len(p.Tests.Direct))
+		for _, t := range p.Tests.Direct {
+			fmt.Fprintf(b, "  %s:%d  %s  %s\n", t.File, t.Line, t.ID, t.Name)
+		}
+	}
+	if len(p.Tests.Transitive) > 0 {
+		fmt.Fprintf(b, "transitive (%d)\n", len(p.Tests.Transitive))
+		for _, t := range p.Tests.Transitive {
+			fmt.Fprintf(b, "  %s:%d  %s  %s  (2-hop)\n", t.File, t.Line, t.ID, t.Name)
+		}
+	}
+}
+
+func writePlanGolden(b *strings.Builder, p PlanResult) {
+	if p.Golden == "" {
+		return
+	}
+	fmt.Fprintf(b, "GOLDEN / TESTDATA — %s\n", p.Golden)
+}
+
+// planCountSites returns the number of emitted sites and distinct packages.
+func planCountSites(groups []PlanPkgGroup) (sites, pkgs int) {
+	pkgs = len(groups)
+	for _, g := range groups {
+		sites += len(g.Sites)
+	}
+	return sites, pkgs
+}

--- a/cmd/testdata/help/plan.golden
+++ b/cmd/testdata/help/plan.golden
@@ -1,0 +1,30 @@
+Usage: snipe plan [<symbol>] [flags]
+
+Ordered edit worklist for a proposed symbol change (def + call sites + tests;
+structural, not a gate)
+
+Arguments:
+  [<symbol>]    Symbol name or id
+
+Flags:
+  -h, --help                  Show context-sensitive help.
+      --limit=10              Cap results returned (applied after --select)
+      --offset=0              Pagination offset
+      --context=2             Context lines around match
+      --no-body               Exclude function body
+      --no-siblings           Exclude sibling declarations
+      --signature-only        Return only signature (no body, no context)
+      --max-tokens=0          Token budget (0 = unlimited)
+      --format="concise"      concise (LLM default) | detailed | summary | json
+                              (stable, for tooling) | human (TTY)
+      --kg-hints              Include Orca KG hints
+      --suggestions           Include next-step suggestions in Claude output
+      --timeout=DURATION      Timeout for command (e.g., 30s, 5m)
+      --select="all"          Pick top candidates by score: all, best, top3,
+                              top5 (applied before --limit)
+
+      --change="signature"    Which worklist to emit: signature (full), behavior
+                              (tests only), or delete (must-remove refs)
+      --at=STRING             Position to look up (file:line:col)
+      --id=STRING             Symbol ID to look up
+      --max-callers=50        Cap total call sites emitted (token budget)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -134,6 +134,10 @@ Graph & Structure:
     Map a diff to the minimal go test set covering changed symbols (structural,
     not a gate)
 
+  plan [<symbol>] [flags]
+    Ordered edit worklist for a proposed symbol change (def + call sites +
+    tests; structural, not a gate)
+
   sensitive [flags]
     List files in security-sensitive zones
     (auth/crypto/migration/secret/payment)

--- a/internal/query/callsites.go
+++ b/internal/query/callsites.go
@@ -1,0 +1,75 @@
+package query
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// FindCallSites returns every non-def, non-concurrency reference to symbolID
+// (call sites and func-value uses), each with its enclosing symbol, source
+// snippet, and refs.ast_ctx. ASTCtx is "" when the column is NULL (pre-v18
+// index) — callers degrade to plain sites. NO SQL LIMIT: returns the full set
+// so the caller can group-then-truncate deterministically in Go and report an
+// accurate "+N more" footer. Grouping key = the ref file's package (from
+// file_path_rel dir), stable for package-level-init refs where enclosing is NULL.
+// Ordered by (ref-file relative path, line, col) — plain columns, ORDER-BY-guard
+// safe; sorting by file_path_rel keeps every package's refs contiguous.
+//
+// The `ast_ctx NOT IN ('go','chan')` filter mirrors FindRefs/GetRefCount so
+// goroutine/channel self-attributed rows don't masquerade as call sites.
+func FindCallSites(db *sql.DB, symbolID string) ([]RefRow, error) {
+	rows, err := db.Query(`
+		SELECT r.id, r.symbol_id, r.file_path, r.file_path_rel, r.line, r.col, r.enclosing_id, r.snippet, r.ast_ctx,
+		       s.name, s.kind, s.signature,
+		       (r.file_path GLOB '*_test.go') AS is_test
+		FROM refs r
+		LEFT JOIN symbols s ON r.enclosing_id = s.id
+		WHERE r.symbol_id = ?
+		  AND (r.ast_ctx IS NULL OR r.ast_ctx NOT IN ('go','chan'))
+		ORDER BY r.file_path_rel, r.line, r.col
+	`, symbolID)
+	if err != nil {
+		return nil, fmt.Errorf("query call sites: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []RefRow
+	for rows.Next() {
+		var r RefRow
+		var encName, encKind, encSig, filePathRel, astCtx sql.NullString
+		var isTest int
+		err := rows.Scan(&r.ID, &r.SymbolID, &r.FilePath, &filePathRel, &r.Line, &r.Col, &r.EnclosingID, &r.Snippet, &astCtx,
+			&encName, &encKind, &encSig, &isTest)
+		if err != nil {
+			return nil, fmt.Errorf("scan call site row: %w", err)
+		}
+		r.FilePathRel = filePathRel.String
+		r.ASTCtx = astCtx.String
+		r.EnclosingName = encName.String
+		r.EnclosingKind = encKind.String
+		r.EnclosingSignature = encSig.String
+		r.IsTest = isTest != 0
+		refs = append(refs, r)
+	}
+
+	return refs, rows.Err()
+}
+
+// CountCallSites returns (nonTest, testOnly) reference counts, splitting on
+// whether the ref's file is *_test.go. Drives the delete zero-caller fast path.
+// Applies the same go/chan concurrency filter as FindCallSites so the counts
+// match what FindCallSites would render.
+func CountCallSites(db *sql.DB, symbolID string) (nonTest, testOnly int, err error) {
+	err = db.QueryRow(`
+		SELECT
+		  COALESCE(SUM(CASE WHEN r.file_path GLOB '*_test.go' THEN 0 ELSE 1 END), 0) AS non_test,
+		  COALESCE(SUM(CASE WHEN r.file_path GLOB '*_test.go' THEN 1 ELSE 0 END), 0) AS test_only
+		FROM refs r
+		WHERE r.symbol_id = ?
+		  AND (r.ast_ctx IS NULL OR r.ast_ctx NOT IN ('go','chan'))
+	`, symbolID).Scan(&nonTest, &testOnly)
+	if err != nil {
+		return 0, 0, fmt.Errorf("count call sites: %w", err)
+	}
+	return nonTest, testOnly, nil
+}

--- a/internal/query/callsites.go
+++ b/internal/query/callsites.go
@@ -21,7 +21,7 @@ func FindCallSites(db *sql.DB, symbolID string) ([]RefRow, error) {
 	rows, err := db.Query(`
 		SELECT r.id, r.symbol_id, r.file_path, r.file_path_rel, r.line, r.col, r.enclosing_id, r.snippet, r.ast_ctx,
 		       s.name, s.kind, s.signature,
-		       (r.file_path GLOB '*_test.go') AS is_test
+		       (r.file_path LIKE '%_test.go') AS is_test
 		FROM refs r
 		LEFT JOIN symbols s ON r.enclosing_id = s.id
 		WHERE r.symbol_id = ?
@@ -62,8 +62,8 @@ func FindCallSites(db *sql.DB, symbolID string) ([]RefRow, error) {
 func CountCallSites(db *sql.DB, symbolID string) (nonTest, testOnly int, err error) {
 	err = db.QueryRow(`
 		SELECT
-		  COALESCE(SUM(CASE WHEN r.file_path GLOB '*_test.go' THEN 0 ELSE 1 END), 0) AS non_test,
-		  COALESCE(SUM(CASE WHEN r.file_path GLOB '*_test.go' THEN 1 ELSE 0 END), 0) AS test_only
+		  COALESCE(SUM(CASE WHEN r.file_path LIKE '%_test.go' THEN 0 ELSE 1 END), 0) AS non_test,
+		  COALESCE(SUM(CASE WHEN r.file_path LIKE '%_test.go' THEN 1 ELSE 0 END), 0) AS test_only
 		FROM refs r
 		WHERE r.symbol_id = ?
 		  AND (r.ast_ctx IS NULL OR r.ast_ctx NOT IN ('go','chan'))

--- a/internal/query/callsites_test.go
+++ b/internal/query/callsites_test.go
@@ -1,0 +1,213 @@
+package query
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupCallSitesDB builds an in-memory schema that includes refs.ast_ctx (the
+// column FindCallSites/CountCallSites read) plus the enclosing-symbol join.
+func setupCallSitesDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE symbols (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			kind TEXT,
+			file_path TEXT,
+			file_path_rel TEXT,
+			pkg_path TEXT,
+			line_start INTEGER,
+			col_start INTEGER,
+			line_end INTEGER,
+			col_end INTEGER,
+			signature TEXT,
+			doc TEXT,
+			receiver TEXT
+		);
+		CREATE TABLE refs (
+			id TEXT PRIMARY KEY,
+			symbol_id TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			file_path_rel TEXT,
+			line INTEGER,
+			col INTEGER,
+			enclosing_id TEXT,
+			snippet TEXT,
+			ast_ctx TEXT
+		);
+		CREATE TABLE files (
+			path TEXT PRIMARY KEY,
+			mtime INTEGER NOT NULL,
+			hash TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+	return db
+}
+
+func insertCSSym(t *testing.T, db *sql.DB, id, name, filePathRel, pkgPath string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO symbols (id, name, kind, file_path, file_path_rel, pkg_path,
+		line_start, col_start, line_end, col_end, signature, doc, receiver)
+		VALUES (?, ?, 'func', ?, ?, ?, 1, 1, 10, 1, '', '', '')`,
+		id, name, "/repo/"+filePathRel, filePathRel, pkgPath)
+	if err != nil {
+		t.Fatalf("insert symbol %s: %v", id, err)
+	}
+}
+
+// insertCSRef inserts a ref. Pass astCtx="" to store SQL NULL (simulates a
+// pre-v18 / not-backfilled index); any other value is stored literally.
+func insertCSRef(t *testing.T, db *sql.DB, id, filePathRel string, line, col int, enclosingID, snippet, astCtx string) {
+	t.Helper()
+	var enc any
+	if enclosingID == "" {
+		enc = nil
+	} else {
+		enc = enclosingID
+	}
+	var ctx any
+	if astCtx == "" {
+		ctx = nil
+	} else {
+		ctx = astCtx
+	}
+	_, err := db.Exec(`INSERT INTO refs (id, symbol_id, file_path, file_path_rel, line, col, enclosing_id, snippet, ast_ctx)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, "tgt", "/repo/"+filePathRel, filePathRel, line, col, enc, snippet, ctx)
+	if err != nil {
+		t.Fatalf("insert ref %s: %v", id, err)
+	}
+}
+
+func TestFindCallSites_GroupOrderAndFields(t *testing.T) {
+	db := setupCallSitesDB(t)
+	defer db.Close()
+
+	insertCSSym(t, db, "tgt", "Target", "foo/foo.go", "example.com/p/foo")
+	insertCSSym(t, db, "serve", "Serve", "api/api.go", "example.com/p/api")
+	insertCSSym(t, db, "run", "Run", "worker/worker.go", "example.com/p/worker")
+
+	// worker ref inserted first, but ORDER BY file_path_rel must put api before worker.
+	insertCSRef(t, db, "r1", "worker/worker.go", 5, 9, "run", "foo.Target(id)", "")
+	insertCSRef(t, db, "r2", "api/api.go", 8, 9, "serve", "foo.Target(id)", "")
+	insertCSRef(t, db, "r3", "api/api.go", 12, 9, "serve", "wire(foo.Target)", "call:wire")
+
+	rows, err := FindCallSites(db, "tgt")
+	if err != nil {
+		t.Fatalf("FindCallSites: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("want 3 call sites, got %d", len(rows))
+	}
+	// api rows (r2, r3) must come before the worker row (r1) — sorted by file_path_rel.
+	if rows[0].FilePathRel != "api/api.go" || rows[1].FilePathRel != "api/api.go" || rows[2].FilePathRel != "worker/worker.go" {
+		t.Fatalf("unexpected order: %s, %s, %s", rows[0].FilePathRel, rows[1].FilePathRel, rows[2].FilePathRel)
+	}
+	if rows[0].EnclosingName != "Serve" {
+		t.Fatalf("enclosing name not populated: name=%q", rows[0].EnclosingName)
+	}
+	if rows[1].ASTCtx != "call:wire" {
+		t.Fatalf("want ast_ctx call:wire on r3, got %q", rows[1].ASTCtx)
+	}
+	for i := range rows {
+		if rows[i].IsTest {
+			t.Fatalf("row %d unexpectedly flagged IsTest", i)
+		}
+	}
+}
+
+func TestFindCallSites_NullASTCtxDegrades(t *testing.T) {
+	db := setupCallSitesDB(t)
+	defer db.Close()
+
+	insertCSSym(t, db, "tgt", "Target", "foo/foo.go", "example.com/p/foo")
+	insertCSSym(t, db, "serve", "Serve", "api/api.go", "example.com/p/api")
+	insertCSRef(t, db, "r1", "api/api.go", 8, 9, "serve", "foo.Target(id)", "") // NULL ast_ctx
+
+	rows, err := FindCallSites(db, "tgt")
+	if err != nil {
+		t.Fatalf("FindCallSites: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 call site, got %d", len(rows))
+	}
+	if rows[0].ASTCtx != "" {
+		t.Fatalf("NULL ast_ctx should scan as empty string, got %q", rows[0].ASTCtx)
+	}
+}
+
+func TestFindCallSites_PackageLevelEnclosingNull(t *testing.T) {
+	db := setupCallSitesDB(t)
+	defer db.Close()
+
+	insertCSSym(t, db, "tgt", "Target", "foo/foo.go", "example.com/p/foo")
+	insertCSRef(t, db, "r1", "api/api.go", 3, 9, "", "var _ = foo.Target(\"init\")", "") // package-level init
+
+	rows, err := FindCallSites(db, "tgt")
+	if err != nil {
+		t.Fatalf("FindCallSites: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 call site, got %d", len(rows))
+	}
+	if rows[0].EnclosingID.Valid {
+		t.Fatalf("expected NULL enclosing_id, got %q", rows[0].EnclosingID.String)
+	}
+	if rows[0].ID != "r1" {
+		t.Fatalf("ref id should stay addressable, got %q", rows[0].ID)
+	}
+}
+
+func TestFindCallSites_FiltersGoChan(t *testing.T) {
+	db := setupCallSitesDB(t)
+	defer db.Close()
+
+	insertCSSym(t, db, "tgt", "Target", "foo/foo.go", "example.com/p/foo")
+	insertCSRef(t, db, "r1", "api/api.go", 8, 9, "", "foo.Target(id)", "")
+	insertCSRef(t, db, "r2", "api/api.go", 9, 9, "", "go foo.Target()", "go")
+	insertCSRef(t, db, "r3", "api/api.go", 10, 9, "", "ch <- foo.Target()", "chan")
+
+	rows, err := FindCallSites(db, "tgt")
+	if err != nil {
+		t.Fatalf("FindCallSites: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("go/chan self-refs should be filtered; want 1, got %d", len(rows))
+	}
+	if rows[0].ID != "r1" {
+		t.Fatalf("wrong row survived: %q", rows[0].ID)
+	}
+}
+
+func TestCountCallSites_NonTestVsTestSplit(t *testing.T) {
+	db := setupCallSitesDB(t)
+	defer db.Close()
+
+	insertCSSym(t, db, "tgt", "Orphan", "foo/foo.go", "example.com/p/foo")
+	// Two test-file refs, zero production refs — the delete fast path shape.
+	insertCSRef(t, db, "r1", "foo/foo_test.go", 9, 3, "t1", "Orphan()", "")
+	insertCSRef(t, db, "r2", "foo/foo_test.go", 31, 3, "t2", "Orphan()", "")
+	// A go-self-ref must not be counted.
+	insertCSRef(t, db, "r3", "foo/foo.go", 40, 3, "", "go Orphan()", "go")
+
+	nonTest, testOnly, err := CountCallSites(db, "tgt")
+	if err != nil {
+		t.Fatalf("CountCallSites: %v", err)
+	}
+	if nonTest != 0 {
+		t.Fatalf("want 0 non-test refs, got %d", nonTest)
+	}
+	if testOnly != 2 {
+		t.Fatalf("want 2 test-only refs, got %d", testOnly)
+	}
+}

--- a/internal/query/lookup.go
+++ b/internal/query/lookup.go
@@ -511,6 +511,10 @@ type RefRow struct {
 	EnclosingKind      string
 	EnclosingSignature string
 	FileHash           string // Content hash for change detection
+
+	// IsTest is true when the ref lives in a *_test.go file. Populated only by
+	// FindCallSites (false from FindRefs).
+	IsTest bool
 }
 
 // ToResult converts a SymbolRow to an output.Result

--- a/test/blackbox/plan_test.go
+++ b/test/blackbox/plan_test.go
@@ -250,8 +250,10 @@ func TestPlan_DeleteZeroCallerFastPath(t *testing.T) {
 		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
 	}
 	out := string(stdout)
-	if !strings.Contains(out, "safe to delete") {
-		t.Fatalf("expected safe-to-delete fast path, got:\n%s", out)
+	// Orphan is exported, so the header must NOT claim a bare "safe to delete"
+	// — it scopes the claim to the index and flags unseen external consumers.
+	if !strings.Contains(out, "no indexed non-test callers") {
+		t.Fatalf("expected index-scoped delete claim for exported symbol, got:\n%s", out)
 	}
 	if !strings.Contains(out, "test-only ref") {
 		t.Fatalf("expected test-only refs mention, got:\n%s", out)

--- a/test/blackbox/plan_test.go
+++ b/test/blackbox/plan_test.go
@@ -1,0 +1,472 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// writePlanFixture builds a self-contained module for the `plan` command's
+// acceptance cases: a target func (foo.Target) called from two packages (api,
+// worker) with a package-level-init call site (NULL enclosing) and a
+// func-value use (ast_ctx call:...), a direct + transitive covering test, and
+// an orphan func referenced only by a test (delete fast path).
+//
+// Deliberately NOT an extension of the shared writeFixture: that fixture is
+// pinned by ~40 behavioral goldens (context/pkg/deps/diagram are repo-wide),
+// none of which are in this bead's edit scope. A private fixture keeps every
+// change inside plan_test.go and touches no existing golden.
+func writePlanFixture(t *testing.T) (repoDir string, atTarget string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/planfix\n\ngo 1.20\n")
+
+	fooContent := `package foo
+
+// PLAN_TARGET
+func Target(id string) string {
+	return "t:" + id
+}
+
+func helper() string {
+	return Target("h")
+}
+
+func Orphan() string {
+	return "orphan"
+}
+`
+	writeFile(t, filepath.Join(repoDir, "foo", "foo.go"), fooContent)
+
+	writeFile(t, filepath.Join(repoDir, "foo", "foo_test.go"), `package foo
+
+import "testing"
+
+func TestTarget(t *testing.T) {
+	if Target("x") == "" {
+		t.Fatal("x")
+	}
+}
+
+func TestViaHelper(t *testing.T) {
+	if helper() == "" {
+		t.Fatal("h")
+	}
+}
+
+func TestOrphan(t *testing.T) {
+	if Orphan() == "" {
+		t.Fatal("o")
+	}
+}
+`)
+
+	writeFile(t, filepath.Join(repoDir, "api", "api.go"), `package api
+
+import "example.com/planfix/foo"
+
+var _ = foo.Target("init")
+
+func Serve(id string) string {
+	return foo.Target(id)
+}
+
+func Handle(id string) string {
+	v := foo.Target(id)
+	return v
+}
+
+func Wire() string {
+	return callWith(foo.Target)
+}
+
+func callWith(f func(string) string) string {
+	return f("w")
+}
+
+func Dup() {}
+`)
+
+	writeFile(t, filepath.Join(repoDir, "worker", "worker.go"), `package worker
+
+import "example.com/planfix/foo"
+
+func Run(id string) string {
+	return foo.Target(id)
+}
+
+func Dup() {}
+`)
+
+	line, col := positionAfterMarker(t, fooContent, "PLAN_TARGET", "Target")
+	atTarget = fmt.Sprintf("%s:%d:%d", filepath.Join(repoDir, "foo", "foo.go"), line, col)
+	return repoDir, atTarget
+}
+
+func planDefID(t *testing.T, repoDir string) string {
+	t.Helper()
+	jout, jstderr, jexit := run(t, repoDir, "plan", "Target")
+	if jexit != 0 {
+		t.Fatalf("plan Target --format json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	resp := assertEnvelope(t, jout, "plan")
+	results := requireSlice(t, resp["results"], "results")
+	r := requireMap(t, results[0], "results[0]")
+	def := requireMap(t, r["def"], "def")
+	return getString(t, def["id"], "def.id")
+}
+
+func isHex16(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPlan_SignatureWorklist(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	for _, want := range []string{"DEF", "func Target(id string) string", "CALL SITES", "TESTS", "(2-hop)", planNoteFragment} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("signature output missing %q, got:\n%s", want, out)
+		}
+	}
+	// PRESENT-case ast_ctx: the func-value use `callWith(foo.Target)` yields a
+	// populated ast_ctx, which the text renderer must surface as a `[call:...]`
+	// tag (complements TestPlan_ASTCtxNullDegrade, which asserts its ABSENCE
+	// once ast_ctx is NULLed).
+	if !strings.Contains(out, "[call:") {
+		t.Fatalf("expected a populated ast_ctx to render a [call:...] tag, got:\n%s", out)
+	}
+
+	// JSON: def.id is 16 hex, call_sites non-empty, direct + transitive tests.
+	jout, jstderr, jexit := run(t, repoDir, "plan", "Target")
+	if jexit != 0 {
+		t.Fatalf("plan json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	resp := assertEnvelope(t, jout, "plan")
+	r := requireMap(t, requireSlice(t, resp["results"], "results")[0], "results[0]")
+	def := requireMap(t, r["def"], "def")
+	if id := getString(t, def["id"], "def.id"); !isHex16(id) {
+		t.Fatalf("def.id not 16 hex: %q", id)
+	}
+	if cs := requireSlice(t, r["call_sites"], "call_sites"); len(cs) == 0 {
+		t.Fatalf("expected non-empty call_sites")
+	}
+	tests := requireMap(t, r["tests"], "tests")
+	if len(requireSlice(t, tests["direct"], "tests.direct")) == 0 {
+		t.Fatalf("expected direct tests")
+	}
+	if len(requireSlice(t, tests["transitive"], "tests.transitive")) == 0 {
+		t.Fatalf("expected transitive tests")
+	}
+}
+
+func TestPlan_BehaviorSkipsCallSites(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target", "--change=behavior")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if strings.Contains(out, "CALL SITES") {
+		t.Fatalf("behavior must omit CALL SITES, got:\n%s", out)
+	}
+	if !strings.Contains(out, "no signature change") {
+		t.Fatalf("behavior framing missing, got:\n%s", out)
+	}
+	if !strings.Contains(out, "TESTS") {
+		t.Fatalf("behavior should still list tests, got:\n%s", out)
+	}
+
+	jout, _, _ := run(t, repoDir, "plan", "Target", "--change=behavior")
+	resp := assertEnvelope(t, jout, "plan")
+	r := requireMap(t, requireSlice(t, resp["results"], "results")[0], "results[0]")
+	if cs, ok := r["call_sites"]; ok && cs != nil {
+		if len(requireSlice(t, cs, "call_sites")) != 0 {
+			t.Fatalf("behavior JSON should have empty/absent call_sites, got: %v", cs)
+		}
+	}
+}
+
+func TestPlan_DeleteMustRemove(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target", "--change=delete")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "MUST REMOVE") {
+		t.Fatalf("delete must show MUST REMOVE, got:\n%s", out)
+	}
+	if !strings.Contains(out, "DEF (remove)") {
+		t.Fatalf("delete def label missing, got:\n%s", out)
+	}
+
+	jout, _, _ := run(t, repoDir, "plan", "Target", "--change=delete")
+	resp := assertEnvelope(t, jout, "plan")
+	r := requireMap(t, requireSlice(t, resp["results"], "results")[0], "results[0]")
+	if !getBool(t, r["must_remove"], "must_remove") {
+		t.Fatalf("must_remove should be true")
+	}
+}
+
+func TestPlan_DeleteZeroCallerFastPath(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Orphan", "--change=delete")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "safe to delete") {
+		t.Fatalf("expected safe-to-delete fast path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "test-only ref") {
+		t.Fatalf("expected test-only refs mention, got:\n%s", out)
+	}
+	if strings.Contains(out, "MUST REMOVE") {
+		t.Fatalf("fast path must not list MUST REMOVE, got:\n%s", out)
+	}
+
+	jout, _, _ := run(t, repoDir, "plan", "Orphan", "--change=delete")
+	resp := assertEnvelope(t, jout, "plan")
+	r := requireMap(t, requireSlice(t, resp["results"], "results")[0], "results[0]")
+	if !getBool(t, r["safe_to_delete"], "safe_to_delete") {
+		t.Fatalf("safe_to_delete should be true")
+	}
+	if n := int(getFloat(t, r["test_only_refs"], "test_only_refs")); n != 1 {
+		t.Fatalf("want 1 test-only ref, got %d", n)
+	}
+}
+
+func TestPlan_ASTCtxNullDegrade(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	// Simulate a pre-v18 / not-backfilled index: NULL out every ast_ctx.
+	dbPath := filepath.Join(repoDir, ".snipe", "index.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open index db: %v", err)
+	}
+	if _, err := db.Exec("UPDATE refs SET ast_ctx = NULL"); err != nil {
+		db.Close()
+		t.Fatalf("null ast_ctx: %v", err)
+	}
+	db.Close()
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "CALL SITES") {
+		t.Fatalf("call sites should still render with NULL ast_ctx, got:\n%s", out)
+	}
+	if strings.Contains(out, "[call:") {
+		t.Fatalf("no bracket tag expected when ast_ctx is NULL, got:\n%s", out)
+	}
+}
+
+func TestPlan_Truncation(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	// Target has 6 production call sites (foo.helper, api ×4, worker); cap at
+	// 2 → footer "+4 more". Derive total from a full run to stay robust.
+	jfull, _, _ := run(t, repoDir, "plan", "Target", "--max-callers=100")
+	rf := requireMap(t, requireSlice(t, assertEnvelope(t, jfull, "plan")["results"], "results")[0], "results[0]")
+	total := int(getFloat(t, rf["total_call_sites"], "total_call_sites"))
+	if total <= 2 {
+		t.Fatalf("fixture must have >2 call sites for a truncation test, got %d", total)
+	}
+	wantMore := total - 2
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target", "--max-callers=2")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	wantFooter := fmt.Sprintf("+%d more call sites (raise --max-callers)", wantMore)
+	if !strings.Contains(out, wantFooter) {
+		t.Fatalf("expected single truncation footer %q, got:\n%s", wantFooter, out)
+	}
+
+	jout, _, _ := run(t, repoDir, "plan", "Target", "--max-callers=2")
+	resp := assertEnvelope(t, jout, "plan")
+	r := requireMap(t, requireSlice(t, resp["results"], "results")[0], "results[0]")
+	if n := int(getFloat(t, r["truncated_call_sites"], "truncated_call_sites")); n != wantMore {
+		t.Fatalf("want truncated_call_sites=%d, got %d", wantMore, n)
+	}
+	// Exactly 2 sites emitted across all groups.
+	emitted := 0
+	for _, g := range requireSlice(t, r["call_sites"], "call_sites") {
+		gm := requireMap(t, g, "group")
+		emitted += len(requireSlice(t, gm["sites"], "sites"))
+	}
+	if emitted != 2 {
+		t.Fatalf("want 2 emitted sites, got %d", emitted)
+	}
+}
+
+func TestPlan_PackageLevelCallSite(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	jout, jstderr, jexit := run(t, repoDir, "plan", "Target")
+	if jexit != 0 {
+		t.Fatalf("plan json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	resp := assertEnvelope(t, jout, "plan")
+	r := requireMap(t, requireSlice(t, resp["results"], "results")[0], "results[0]")
+
+	foundPkgInit := false
+	for _, g := range requireSlice(t, r["call_sites"], "call_sites") {
+		gm := requireMap(t, g, "group")
+		for _, s := range requireSlice(t, gm["sites"], "sites") {
+			sm := requireMap(t, s, "site")
+			id, _ := sm["id"].(string)
+			refID, _ := sm["ref_id"].(string)
+			if id == "" && refID != "" {
+				foundPkgInit = true
+				if !isHex16(refID) {
+					t.Fatalf("package-level ref_id not 16 hex: %q", refID)
+				}
+			}
+		}
+	}
+	if !foundPkgInit {
+		t.Fatalf("expected a package-level call site with empty enclosing id but present ref_id, resp:\n%s", string(jout))
+	}
+}
+
+func TestPlan_ResolveByAtAndID(t *testing.T) {
+	repoDir, atTarget := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	// --at resolution (ParsePosition EvalSymlinks the abs path, so the
+	// pre-canonical path still resolves under the canonical root).
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "--at", atTarget)
+	if exit != 0 {
+		t.Fatalf("plan --at exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	if !strings.Contains(string(stdout), "Target") {
+		t.Fatalf("plan --at should resolve Target, got:\n%s", string(stdout))
+	}
+
+	// --id resolution.
+	id := planDefID(t, repoDir)
+	stdout, stderr, exit = runRaw(t, repoDir, "plan", "--id", id)
+	if exit != 0 {
+		t.Fatalf("plan --id exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	if !strings.Contains(string(stdout), "DEF") {
+		t.Fatalf("plan --id should emit a worklist, got:\n%s", string(stdout))
+	}
+
+	// Malformed --at degrades (exit 0, plain message).
+	stdout, _, exit = runRaw(t, repoDir, "plan", "--at", "not-a-position")
+	if exit != 0 {
+		t.Fatalf("malformed --at should exit 0, got %d:\n%s", exit, string(stdout))
+	}
+	if !strings.Contains(string(stdout), "invalid --at") {
+		t.Fatalf("expected invalid --at message, got:\n%s", string(stdout))
+	}
+
+	// Unknown --id degrades (exit 0, plain message).
+	stdout, _, exit = runRaw(t, repoDir, "plan", "--id", "0000000000000000")
+	if exit != 0 {
+		t.Fatalf("unknown --id should exit 0, got %d:\n%s", exit, string(stdout))
+	}
+	if !strings.Contains(string(stdout), "no symbol with id") {
+		t.Fatalf("expected no-symbol-with-id message, got:\n%s", string(stdout))
+	}
+}
+
+func TestPlan_AmbiguousName(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, _, exit := runRaw(t, repoDir, "plan", "Dup")
+	if exit != 0 {
+		t.Fatalf("ambiguous name should exit 0, got %d:\n%s", exit, string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "ambiguous") {
+		t.Fatalf("expected ambiguous message, got:\n%s", out)
+	}
+}
+
+func TestPlan_MissingIndex(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	// No indexRepo.
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target")
+	if exit != 0 {
+		t.Fatalf("missing index should exit 0, got %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	if !strings.Contains(string(stdout), "index unavailable") {
+		t.Fatalf("expected index-unavailable message, got:\n%s", string(stdout))
+	}
+}
+
+func TestPlan_SymbolNotFound(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, _, exit := runRaw(t, repoDir, "plan", "NoSuchSymbol")
+	if exit != 0 {
+		t.Fatalf("unknown symbol should exit 0, got %d:\n%s", exit, string(stdout))
+	}
+	if !strings.Contains(string(stdout), "no symbol named NoSuchSymbol") {
+		t.Fatalf("expected no-symbol-named message, got:\n%s", string(stdout))
+	}
+}
+
+const planNoteFragment = "not a correctness gate"


### PR DESCRIPTION
## What

New command `snipe plan <sym> --change=signature|behavior|delete` — the forward-looking twin of `snipe verify`. Given a symbol you're *about to* change, it emits the ordered edit worklist: def site (with signature) → call sites grouped by package (with `refs.ast_ctx` call-expression context) → covering tests (direct then transitive) → golden/testdata placeholder. Not a gate; `make audit` stays the merge gate.

## Variants

- **signature** (default): full worklist — edit every call site to match the new signature.
- **behavior**: skip call sites, keep tests ("no signature change; verify these").
- **delete**: call sites become a must-remove list; zero-caller fast path emits "safe to delete; N test-only refs".

## Design

- Reuses `FindRefs`' scan (`RefRow` gains `IsTest`); new `FindCallSites` / `CountCallSites` in `internal/query/callsites.go`.
- `ast_ctx` degrades gracefully to plain call sites when NULL (pre-v18 index).
- Deterministic single-global-footer truncation via `--max-callers` (default 50) — fetch all, truncate in Go.
- Genuine internal query errors escalate via `WriteError` (a broken index is not silently reported as "nothing to do"); user conditions (no index, not found, ambiguous, malformed `--at`/`--id`) still exit 0.
- Every line carries `file:line` + 16-char hex ID (D5). Claude-optimized text default; full envelope under `--format json` (D1/D4).

## Review & verify

Dispatched through the full pipeline (high band): design plan → 2 plan-review gates → session-model TDD implementer → 3 review passes (plan-adherence, Go/SQL bug hunt, arch+strategic) → triage. Zero P0/P1. 5 findings folded, 1 deferred to sn-8f6q.8 (test-file refs beyond `FindTests`' 2-hop reach), 2 rejected. `make audit` green (vet, lint, race, blackbox, govulncheck).

Audit trail: `~/Projects/dk/Project/snipe/plans/snipe-plan-command-v1.md` + `plans/reviews/sn-8f6q.5-*`.

Closes sn-8f6q.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `snipe plan` command for generating ordered edit worklists for symbol changes.
  * Supports signature, behavior, and deletion planning modes.
  * Includes definition sites, call sites, related tests, deletion guidance, and configurable caller limits.
  * Supports text and JSON output, symbol lookup by name, source position, or identifier.
  * Added clear handling for ambiguous, missing, or incomplete symbol information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->