### PR TITLE
feat(plan): golden/testdata churn detection for snipe plan (sn-8f6q.6)

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -24,9 +24,11 @@ const planTestLimit = 500
 // never mistakes plan's structural worklist for a correctness gate.
 const planClaimNote = "note: plan maps the edit worklist structurally — not a correctness gate (run make audit)."
 
-// planGoldenPlaceholder is the neutral golden/testdata stub. Churn detection is
-// a follow-up; for now plan only flags that fixtures may need a hand scan.
-const planGoldenPlaceholder = "churn not analyzed here; scan fixtures by hand if this symbol shapes golden output"
+// planChurnLimit caps the "will churn" list. Churn is an advisory heads-up, not
+// an exhaustive worklist — one symbol's covering tests rarely name more than a
+// handful of fixtures, and the cap bounds a pathological const block while the
+// "+N more" footer tells Claude to hand-scan the rest.
+const planChurnLimit = 20
 
 // Change modes for `snipe plan --change`.
 const (
@@ -47,18 +49,19 @@ var (
 // (no index, symbol not found, ambiguous, zero callers on delete uses the
 // SafeToDelete fields) — plan is never a gate, so every such path exits 0.
 type PlanResult struct {
-	Message      string         `json:"message,omitempty"`
-	Symbol       string         `json:"symbol,omitempty"`
-	ID           string         `json:"id,omitempty"`
-	Change       string         `json:"change"`
-	Def          *PlanDef       `json:"def,omitempty"`
-	CallSites    []PlanPkgGroup `json:"call_sites,omitempty"`
-	MustRemove   bool           `json:"must_remove,omitempty"`
-	SafeToDelete bool           `json:"safe_to_delete,omitempty"`
-	TestOnlyRefs int            `json:"test_only_refs,omitempty"`
-	Tests        PlanTests      `json:"tests"`
-	Golden       string         `json:"golden_placeholder,omitempty"`
-	Truncated    int            `json:"truncated_call_sites,omitempty"`
+	Message        string         `json:"message,omitempty"`
+	Symbol         string         `json:"symbol,omitempty"`
+	ID             string         `json:"id,omitempty"`
+	Change         string         `json:"change"`
+	Def            *PlanDef       `json:"def,omitempty"`
+	CallSites      []PlanPkgGroup `json:"call_sites,omitempty"`
+	MustRemove     bool           `json:"must_remove,omitempty"`
+	SafeToDelete   bool           `json:"safe_to_delete,omitempty"`
+	TestOnlyRefs   int            `json:"test_only_refs,omitempty"`
+	Tests          PlanTests      `json:"tests"`
+	Churn          []string       `json:"churn,omitempty"`
+	ChurnTruncated int            `json:"churn_truncated,omitempty"`
+	Truncated      int            `json:"truncated_call_sites,omitempty"`
 
 	// TotalCallSites/TotalPkgs are the pre-truncation totals the header
 	// reports ("def + N call sites in K pkgs"); CallSites may hold fewer once
@@ -156,7 +159,6 @@ func runPlan(change string, args []string) error {
 			ID:        symbolID,
 			Signature: defSym.Signature.String,
 		},
-		Golden: planGoldenPlaceholder,
 	}
 
 	// Tests: direct + transitive covering tests. Skipped for the delete
@@ -180,6 +182,29 @@ func runPlan(change string, args []string) error {
 				result.Tests.Direct = append(result.Tests.Direct, pt)
 			}
 		}
+
+		// Churn: golden/testdata fixture paths named in the covering test files,
+		// which this change is likely to force a regen of. Scope to the distinct
+		// absolute paths of the tests just collected.
+		testFiles := make([]string, 0, len(testRows))
+		seenFile := make(map[string]struct{})
+		for i := range testRows {
+			fp := testRows[i].FilePath
+			if fp == "" {
+				continue
+			}
+			if _, ok := seenFile[fp]; ok {
+				continue
+			}
+			seenFile[fp] = struct{}{}
+			testFiles = append(testFiles, fp)
+		}
+		churn, churnTrunc, err := query.FindChurnLiterals(s.DB(), testFiles, planChurnLimit)
+		if err != nil {
+			return err
+		}
+		result.Churn = churn
+		result.ChurnTruncated = churnTrunc
 		return nil
 	}
 
@@ -436,14 +461,14 @@ func writePlanText(p PlanResult) error {
 	case p.Change == planChangeDelete:
 		writePlanCallSites(&b, p, "MUST REMOVE — every ref below, else the build breaks")
 		writePlanTests(&b, p, "TESTS — drop or rewrite")
-		writePlanGolden(&b, p)
+		writePlanChurn(&b, p)
 	case p.Change == planChangeBehavior:
 		writePlanTests(&b, p, "TESTS — no signature change; verify these still pass / add cases for new behavior")
-		writePlanGolden(&b, p)
+		writePlanChurn(&b, p)
 	default: // signature
 		writePlanCallSites(&b, p, "CALL SITES — edit every one to match the new signature")
 		writePlanTests(&b, p, "TESTS — update/verify after editing")
-		writePlanGolden(&b, p)
+		writePlanChurn(&b, p)
 	}
 
 	fmt.Fprintln(&b, planClaimNote)
@@ -559,11 +584,25 @@ func writePlanTests(b *strings.Builder, p PlanResult, header string) {
 	}
 }
 
-func writePlanGolden(b *strings.Builder, p PlanResult) {
-	if p.Golden == "" {
+// writePlanChurn renders the golden/testdata fixtures the change is likely to
+// force a regen of. Emitted only when non-empty (D4: earn the bytes) — an empty
+// churn list says nothing.
+func writePlanChurn(b *strings.Builder, p PlanResult) {
+	if len(p.Churn) == 0 {
 		return
 	}
-	fmt.Fprintf(b, "GOLDEN / TESTDATA — %s\n", p.Golden)
+	plural := ""
+	if len(p.Churn) != 1 {
+		plural = "s"
+	}
+	fmt.Fprintf(b, "WILL CHURN — %d testdata/golden path%s referenced by covering tests (regenerate this pass):\n",
+		len(p.Churn), plural)
+	for _, path := range p.Churn {
+		fmt.Fprintf(b, "  %s\n", path)
+	}
+	if p.ChurnTruncated > 0 {
+		fmt.Fprintf(b, "  +%d more\n", p.ChurnTruncated)
+	}
 }
 
 // planCountSites returns the number of emitted sites and distinct packages.

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -591,12 +591,15 @@ func writePlanChurn(b *strings.Builder, p PlanResult) {
 	if len(p.Churn) == 0 {
 		return
 	}
+	// Header carries the pre-truncation total (like the plan header's call-site
+	// count); the list below shows the capped subset + a "+N more" footer.
+	total := len(p.Churn) + p.ChurnTruncated
 	plural := ""
-	if len(p.Churn) != 1 {
+	if total != 1 {
 		plural = "s"
 	}
 	fmt.Fprintf(b, "WILL CHURN — %d testdata/golden path%s referenced by covering tests (regenerate this pass):\n",
-		len(p.Churn), plural)
+		total, plural)
 	for _, path := range p.Churn {
 		fmt.Fprintf(b, "  %s\n", path)
 	}

--- a/internal/query/literals.go
+++ b/internal/query/literals.go
@@ -3,6 +3,7 @@ package query
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 // LiteralRef is a resolved string_ref row returned by queries.
@@ -44,4 +45,67 @@ func FindLiteralRefs(db *sql.DB, value string) ([]LiteralRef, error) {
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// FindChurnLiterals returns the distinct golden/testdata fixture paths named as
+// string literals in the given test files — the fixtures a symbol change is
+// likely to force Claude to regenerate. Results are deduped by value, sorted by
+// value, and capped at limit; the returned count is how many distinct paths were
+// dropped past the cap (0 if none). An empty testFiles returns (nil, 0, nil)
+// without querying.
+//
+// A literal churns if its value contains "testdata/" or ends in ".golden". This
+// reuses the string_refs index, which captures only two literal shapes:
+// os.Getenv-family args and named string const declarations. Inline fixture-path
+// arguments (e.g. golden.Assert(t, got, "testdata/x.golden")) are NOT indexed,
+// so churn detection fires only when the path is declared as a const — the tidy,
+// common pattern. Broadening the extractor to inline args is out of scope.
+func FindChurnLiterals(db *sql.DB, testFiles []string, limit int) (paths []string, truncated int, err error) {
+	if len(testFiles) == 0 {
+		return nil, 0, nil
+	}
+
+	placeholders := strings.Repeat("?,", len(testFiles))
+	placeholders = placeholders[:len(placeholders)-1]
+
+	args := make([]any, 0, len(testFiles)+2)
+	for _, f := range testFiles {
+		args = append(args, f)
+	}
+	// Neither pattern contains a LIKE metacharacter, so no ESCAPE is needed.
+	args = append(args, "%testdata/%", "%.golden")
+
+	// DISTINCT collapses the same path referenced by two covering tests; ORDER BY
+	// value (a plain column) both sorts the output and satisfies the ORDER BY
+	// guard test.
+	q := fmt.Sprintf(`
+		SELECT DISTINCT value
+		FROM string_refs
+		WHERE file_path IN (%s)
+		  AND (value LIKE ? OR value LIKE ?)
+		ORDER BY value
+	`, placeholders)
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query churn literals: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			return nil, 0, fmt.Errorf("scan churn literal: %w", err)
+		}
+		paths = append(paths, value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	if limit > 0 && len(paths) > limit {
+		truncated = len(paths) - limit
+		paths = paths[:limit]
+	}
+	return paths, truncated, nil
 }

--- a/internal/query/literals.go
+++ b/internal/query/literals.go
@@ -75,9 +75,30 @@ func FindChurnLiterals(db *sql.DB, testFiles []string, limit int) (paths []strin
 	// Neither pattern contains a LIKE metacharacter, so no ESCAPE is needed.
 	args = append(args, "%testdata/%", "%.golden")
 
+	// Count the full distinct match set first so "+N more" stays exact while the
+	// SELECT below caps what it materializes. Without this, a pathological test
+	// file (thousands of testdata/ consts) would stream every row into Go before
+	// the cap applied — the cap would bound the output but not the work, defeating
+	// the point of limit for exactly the const registries this feature targets.
+	countQ := fmt.Sprintf(`
+		SELECT COUNT(*) FROM (
+			SELECT DISTINCT value
+			FROM string_refs
+			WHERE file_path IN (%s)
+			  AND (value LIKE ? OR value LIKE ?)
+		)
+	`, placeholders)
+	var total int
+	if err := db.QueryRow(countQ, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count churn literals: %w", err)
+	}
+	if total == 0 {
+		return nil, 0, nil
+	}
+
 	// DISTINCT collapses the same path referenced by two covering tests; ORDER BY
 	// value (a plain column) both sorts the output and satisfies the ORDER BY
-	// guard test.
+	// guard test. LIMIT bounds the rows SQLite streams back, not just the slice.
 	q := fmt.Sprintf(`
 		SELECT DISTINCT value
 		FROM string_refs
@@ -85,6 +106,10 @@ func FindChurnLiterals(db *sql.DB, testFiles []string, limit int) (paths []strin
 		  AND (value LIKE ? OR value LIKE ?)
 		ORDER BY value
 	`, placeholders)
+	if limit > 0 {
+		q += "\t\tLIMIT ?\n"
+		args = append(args, limit)
+	}
 
 	rows, err := db.Query(q, args...)
 	if err != nil {
@@ -103,9 +128,5 @@ func FindChurnLiterals(db *sql.DB, testFiles []string, limit int) (paths []strin
 		return nil, 0, err
 	}
 
-	if limit > 0 && len(paths) > limit {
-		truncated = len(paths) - limit
-		paths = paths[:limit]
-	}
-	return paths, truncated, nil
+	return paths, total - len(paths), nil
 }

--- a/internal/query/literals_test.go
+++ b/internal/query/literals_test.go
@@ -54,3 +54,78 @@ func TestFindLiteralRefs_Missing(t *testing.T) {
 		t.Errorf("want 0, got %d", len(got))
 	}
 }
+
+// churnFixture seeds string_refs covering both predicate arms (testdata/ and
+// .golden), a dup across two covering test files, a non-matching literal, and a
+// match in a NON-covering file — so a single fixture exercises scoping, the two
+// arms, dedup, and exclusion.
+func churnFixture(t *testing.T) *store.Store {
+	t.Helper()
+	s := openLitTestStore(t)
+	refs := []index.StringRef{
+		{ID: "aa00000000000001", Value: "testdata/foo.golden", Kind: "const", FilePath: "/pkg/foo_test.go", Line: 3, Col: 2},
+		{ID: "aa00000000000002", Value: "snapshots/out.golden", Kind: "const", FilePath: "/pkg/foo_test.go", Line: 4, Col: 2},
+		{ID: "aa00000000000003", Value: "testdata/shared.golden", Kind: "const", FilePath: "/pkg/foo_test.go", Line: 5, Col: 2},
+		{ID: "aa00000000000004", Value: "testdata/shared.golden", Kind: "const", FilePath: "/pkg/a_test.go", Line: 9, Col: 2},
+		{ID: "aa00000000000005", Value: "SOME_ENV", Kind: "env", FilePath: "/pkg/foo_test.go", Line: 6, Col: 2},
+		{ID: "aa00000000000006", Value: "testdata/other.golden", Kind: "const", FilePath: "/pkg/bar_test.go", Line: 2, Col: 2},
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestFindChurnLiterals(t *testing.T) {
+	s := churnFixture(t)
+	got, truncated, err := query.FindChurnLiterals(s.DB(), []string{"/pkg/foo_test.go", "/pkg/a_test.go"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// value-sorted, deduped across the two covering files; the non-covering
+	// bar_test.go match and the env literal are excluded.
+	want := []string{"snapshots/out.golden", "testdata/foo.golden", "testdata/shared.golden"}
+	if len(got) != len(want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: want %q, got %q (full: %v)", i, want[i], got[i], got)
+		}
+	}
+	if truncated != 0 {
+		t.Errorf("want truncated 0, got %d", truncated)
+	}
+}
+
+func TestFindChurnLiterals_Cap(t *testing.T) {
+	s := churnFixture(t)
+	got, truncated, err := query.FindChurnLiterals(s.DB(), []string{"/pkg/foo_test.go", "/pkg/a_test.go"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cap keeps the first two by sort order; the third is dropped and counted.
+	want := []string{"snapshots/out.golden", "testdata/foo.golden"}
+	if len(got) != len(want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: want %q, got %q", i, want[i], got[i])
+		}
+	}
+	if truncated != 1 {
+		t.Errorf("want truncated 1, got %d", truncated)
+	}
+}
+
+func TestFindChurnLiterals_Empty(t *testing.T) {
+	s := churnFixture(t)
+	got, truncated, err := query.FindChurnLiterals(s.DB(), nil, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil || truncated != 0 {
+		t.Errorf("want (nil,0), got (%v,%d)", got, truncated)
+	}
+}

--- a/test/blackbox/plan_test.go
+++ b/test/blackbox/plan_test.go
@@ -49,6 +49,10 @@ func Orphan() string {
 
 import "testing"
 
+// targetGolden is a fixture path declared as a const so the string_refs
+// extractor indexes it — the churn detector should surface it for Target.
+const targetGolden = "testdata/target.golden"
+
 func TestTarget(t *testing.T) {
 	if Target("x") == "" {
 		t.Fatal("x")
@@ -270,6 +274,57 @@ func TestPlan_DeleteZeroCallerFastPath(t *testing.T) {
 	}
 	if n := int(getFloat(t, r["test_only_refs"], "test_only_refs")); n != 1 {
 		t.Fatalf("want 1 test-only ref, got %d", n)
+	}
+}
+
+// TestPlan_WillChurn proves the golden/testdata churn section: it appears (text
+// + JSON) when a covering test names a fixture-path const, and is omitted on the
+// delete fast path (which skips test collection, so no churn is scanned).
+func TestPlan_WillChurn(t *testing.T) {
+	repoDir, _ := writePlanFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	// Positive (text): Target's covering test declares targetGolden.
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "WILL CHURN") {
+		t.Fatalf("expected WILL CHURN section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "testdata/target.golden") {
+		t.Fatalf("expected churn path testdata/target.golden, got:\n%s", out)
+	}
+
+	// Positive (JSON): results[0].churn carries the path.
+	jout, _, _ := run(t, repoDir, "plan", "Target")
+	r := requireMap(t, requireSlice(t, assertEnvelope(t, jout, "plan")["results"], "results")[0], "results[0]")
+	churn := requireSlice(t, r["churn"], "churn")
+	var found bool
+	for _, c := range churn {
+		if getString(t, c, "churn[]") == "testdata/target.golden" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("churn JSON missing testdata/target.golden, got: %v", churn)
+	}
+
+	// Negative: the delete zero-caller fast path skips test collection entirely,
+	// so no churn section — even though Orphan's covering test shares the file.
+	dstdout, _, _ := runRaw(t, repoDir, "plan", "Orphan", "--change=delete")
+	if strings.Contains(string(dstdout), "WILL CHURN") {
+		t.Fatalf("delete fast path must omit WILL CHURN, got:\n%s", string(dstdout))
+	}
+	djson, _, _ := run(t, repoDir, "plan", "Orphan", "--change=delete")
+	dr := requireMap(t, requireSlice(t, assertEnvelope(t, djson, "plan")["results"], "results")[0], "results[0]")
+	if c, ok := dr["churn"]; ok && c != nil {
+		if len(requireSlice(t, c, "churn")) != 0 {
+			t.Fatalf("delete fast path JSON should have empty/absent churn, got: %v", c)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`snipe plan` now surfaces a **WILL CHURN** section: for each covering test file in the worklist, it lists the `testdata/` / `.golden` fixture paths those tests reference — the fixtures a symbol change is likely to force Claude to regenerate in the same pass, instead of after CI reddens.

Replaces the neutral `planGoldenPlaceholder` stub (always printed) with real detection.

## How

- **`internal/query/literals.go`** — new `FindChurnLiterals(db, testFiles, limit)`: a file-scoped `string_refs` query (`WHERE file_path IN (…) AND (value LIKE '%testdata/%' OR value LIKE '%.golden')`), reusing the existing lits infra. SQL-side `DISTINCT value` + `ORDER BY value` dedup and stable-sort; Go-side cap returning the dropped count. All inputs bound params.
- **`cmd/plan.go`** — dropped `Golden`/`planGoldenPlaceholder`; added `Churn []string` + `ChurnTruncated int` (`omitempty` → section only when non-empty, D1/D4), `planChurnLimit=20`. Collects distinct covering-test file paths in `buildTests`; renders via `writePlanChurn` (list + `+N more`). Delete zero-caller fast path skips test collection → no churn, as before.

## Scope / limitation

Const-only by design: `string_refs` indexes `const`/`env` literal shapes, not inline call args, so churn fires on **const-declared** fixture paths (documented in the `FindChurnLiterals` doc comment). Broadening the extractor to inline golden-helper args is deferred to **sn-8f6q.9**.

## Tests

- `internal/query/literals_test.go` — `TestFindChurnLiterals` (scoping, both predicate arms, dedup across files, value-sort), `_Cap` (cap + truncated count), `_Empty` (nil input → no query).
- `test/blackbox/plan_test.go` — `TestPlan_WillChurn` (text + JSON positive; delete-fast-path omits, both surfaces).
- `make audit` green (vet, lint, race, blackbox, govulncheck).

## Reviews

Dispatched via dispatch-bead-agent. R-A plan-adherence: ADHERES. R-B query/sqlite: SOUND-WITH-NITS (no P0/P1). Triage applied SQL-side dedup simplification, deferred extractor-broadening to sn-8f6q.9. Audit trail: `~/Projects/dk/Project/snipe/plans/reviews/sn-8f6q.6-*`.

Closes: sn-8f6q.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added churn detection to plan results, identifying affected test fixtures and golden files.
  * Plan output now shows a “WILL CHURN” section when applicable.
  * JSON plans include churn paths and indicate when results are truncated.

* **Bug Fixes**
  * Removed obsolete golden/testdata placeholder output.
  * Prevented churn reporting when using the delete fast path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->