### PR TITLE
feat(verify): ripple + uncovered structural warnings (sn-8f6q.4)

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/query"
@@ -25,6 +27,15 @@ const verifyTestLimit = 500
 // Claude never mistakes verify's structural mapping for a correctness gate.
 const verifyClaimNote = "note: verify maps tests to changed symbols structurally — not a correctness gate (run make audit)."
 
+// verifyRippleCallerLimit caps how many callers FindImpactCallersMulti returns
+// per changed exported symbol when counting ripple sites. Generous — the count
+// only needs to be meaningful, and a real diff rarely fans past it.
+const verifyRippleCallerLimit = 200
+
+// verifyRippleCap bounds how many ripple warnings verify emits, keeping the
+// report token-frugal (D4) even on a diff that churns many exported symbols.
+const verifyRippleCap = 20
+
 // VerifyResult is the structural test-coverage report for a diff: which
 // changed funcs/methods have covering tests, which don't, and the minimal
 // `go test` invocations exercising the covered ones. Message is set instead
@@ -36,7 +47,18 @@ type VerifyResult struct {
 	ChangedSymbols int             `json:"changed_symbols"`
 	Covered        int             `json:"covered"`
 	Uncovered      []string        `json:"uncovered,omitempty"`
+	Ripple         []VerifyRipple  `json:"ripple,omitempty"`
 	Packages       []VerifyPackage `json:"packages,omitempty"`
+}
+
+// VerifyRipple names a changed EXPORTED symbol whose callers reach past the
+// diff: Callers counts the direct call sites in files the diff never touched.
+// A cheap "this change may break un-touched code" nudge — structural, never a
+// correctness gate. Unexported symbols can't be called from outside their
+// package and diff-local churn isn't a ripple, so neither produces an entry.
+type VerifyRipple struct {
+	Symbol  string `json:"symbol"`
+	Callers int    `json:"external_callers"`
 }
 
 // VerifyPackage groups covering tests by the package that runs them, with a
@@ -93,7 +115,14 @@ func runVerify(base string) error {
 		return writeVerifyMessage(root, start, "no changed funcs/methods to verify")
 	}
 
-	v, err := verifyBuildResult(s.DB(), changedFuncs, changedTestFuncs)
+	// changedFiles: the diff's changed-file set (absolute paths), so ripple can
+	// tell a call site inside the diff from one in un-touched code.
+	changedFiles := make(map[string]bool, len(changeMap))
+	for p := range changeMap {
+		changedFiles[p] = true
+	}
+
+	v, err := verifyBuildResult(s.DB(), changedFuncs, changedTestFuncs, changedFiles)
 	if err != nil {
 		return w.WriteError(cmdNameVerify, &output.Error{Code: output.ErrInternal, Message: err.Error()})
 	}
@@ -158,7 +187,7 @@ func verifyIsTestFuncName(name string) bool {
 // a zero-coverage symbol couldn't be named. Changed test funcs are added to
 // the run set directly, without a coverage lookup (they're tests, not
 // targets).
-func verifyBuildResult(db *sql.DB, changedFuncs, changedTestFuncs []query.SymbolRow) (VerifyResult, error) {
+func verifyBuildResult(db *sql.DB, changedFuncs, changedTestFuncs []query.SymbolRow, changedFiles map[string]bool) (VerifyResult, error) {
 	testsByPkg := map[string]map[string]bool{}
 	addTest := func(dir, name string) {
 		if testsByPkg[dir] == nil {
@@ -218,12 +247,85 @@ func verifyBuildResult(db *sql.DB, changedFuncs, changedTestFuncs []query.Symbol
 		})
 	}
 
+	ripple, err := verifyBuildRipple(db, changedFuncs, changedFiles)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+
 	return VerifyResult{
 		ChangedSymbols: len(changedFuncs) + len(changedTestFuncs),
 		Covered:        covered,
 		Uncovered:      uncovered,
+		Ripple:         ripple,
 		Packages:       packages,
 	}, nil
+}
+
+// verifyBuildRipple flags changed EXPORTED funcs/methods whose callers reach
+// past the diff. For each, it counts the direct call sites (FindImpactCallersMulti
+// already drops _test.go callers) whose file is NOT in changedFiles — the
+// un-touched code a change could break. Unexported symbols can't be called from
+// outside their package, and diff-local churn isn't a ripple, so both are
+// skipped. Entries sort by symbol name (file+line tiebreak, since pkg.Name can
+// collide across receivers) and cap at verifyRippleCap for a frugal report (D4).
+func verifyBuildRipple(db *sql.DB, changedFuncs []query.SymbolRow, changedFiles map[string]bool) ([]VerifyRipple, error) {
+	type entry struct {
+		name    string
+		callers int
+		file    string
+		line    int
+	}
+	var entries []entry
+	for i := range changedFuncs {
+		sym := &changedFuncs[i]
+		if !verifyIsExported(sym.Name) {
+			continue
+		}
+		callers, err := query.FindImpactCallersMulti(db, []string{sym.ID}, true, verifyRippleCallerLimit, 0)
+		if err != nil {
+			return nil, err
+		}
+		external := 0
+		for j := range callers {
+			if !changedFiles[callers[j].FilePath] {
+				external++
+			}
+		}
+		if external == 0 {
+			continue
+		}
+		entries = append(entries, entry{
+			name:    verifyQualifiedName(sym),
+			callers: external,
+			file:    sym.FilePath,
+			line:    sym.LineStart,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].name != entries[j].name {
+			return entries[i].name < entries[j].name
+		}
+		if entries[i].file != entries[j].file {
+			return entries[i].file < entries[j].file
+		}
+		return entries[i].line < entries[j].line
+	})
+	if len(entries) > verifyRippleCap {
+		entries = entries[:verifyRippleCap]
+	}
+	ripple := make([]VerifyRipple, 0, len(entries))
+	for _, e := range entries {
+		ripple = append(ripple, VerifyRipple{Symbol: e.name, Callers: e.callers})
+	}
+	return ripple, nil
+}
+
+// verifyIsExported reports whether name begins with an upper-case rune — the Go
+// export rule. Only exported symbols can be called from outside their package,
+// so only they can ripple past the diff.
+func verifyIsExported(name string) bool {
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
 }
 
 // verifyQualifiedName renders a changed symbol as "pkg.Name" (e.g.
@@ -294,6 +396,15 @@ func writeVerifyText(v VerifyResult) error {
 		}
 		fmt.Fprintf(&b, "! %d changed symbol%s %s no covering test: %s\n",
 			len(v.Uncovered), verifyPlural(len(v.Uncovered)), verb, strings.Join(v.Uncovered, ", "))
+	}
+
+	if len(v.Ripple) > 0 {
+		parts := make([]string, len(v.Ripple))
+		for i, r := range v.Ripple {
+			parts[i] = fmt.Sprintf("%s (%d site%s)", r.Symbol, r.Callers, verifyPlural(r.Callers))
+		}
+		fmt.Fprintf(&b, "! ripple: %d changed exported symbol%s called from outside the diff — %s\n",
+			len(v.Ripple), verifyPlural(len(v.Ripple)), strings.Join(parts, ", "))
 	}
 
 	fmt.Fprintln(&b, verifyClaimNote)

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/query"
@@ -261,13 +259,16 @@ func verifyBuildResult(db *sql.DB, changedFuncs, changedTestFuncs []query.Symbol
 	}, nil
 }
 
-// verifyBuildRipple flags changed EXPORTED funcs/methods whose callers reach
-// past the diff. For each, it counts the direct call sites (FindImpactCallersMulti
+// verifyBuildRipple flags changed funcs/methods whose callers reach past the
+// diff. For each, it counts the direct call sites (FindImpactCallersMulti
 // already drops _test.go callers) whose file is NOT in changedFiles — the
-// un-touched code a change could break. Unexported symbols can't be called from
-// outside their package, and diff-local churn isn't a ripple, so both are
-// skipped. Entries sort by symbol name (file+line tiebreak, since pkg.Name can
-// collide across receivers) and cap at verifyRippleCap for a frugal report (D4).
+// un-touched code a change could break. Exported and unexported symbols both
+// qualify: "outside the diff" is not "outside the package", so an unexported
+// func changed in one file and called from an un-touched sibling file in the
+// same package is a real ripple (an exported symbol filter would miss it).
+// Diff-local churn (external == 0) is not a ripple. Entries sort by symbol name
+// (file+line tiebreak, since pkg.Name can collide across receivers) and cap at
+// verifyRippleCap for a frugal report (D4).
 func verifyBuildRipple(db *sql.DB, changedFuncs []query.SymbolRow, changedFiles map[string]bool) ([]VerifyRipple, error) {
 	type entry struct {
 		name    string
@@ -278,9 +279,6 @@ func verifyBuildRipple(db *sql.DB, changedFuncs []query.SymbolRow, changedFiles 
 	var entries []entry
 	for i := range changedFuncs {
 		sym := &changedFuncs[i]
-		if !verifyIsExported(sym.Name) {
-			continue
-		}
 		callers, err := query.FindImpactCallersMulti(db, []string{sym.ID}, true, verifyRippleCallerLimit, 0)
 		if err != nil {
 			return nil, err
@@ -318,14 +316,6 @@ func verifyBuildRipple(db *sql.DB, changedFuncs []query.SymbolRow, changedFiles 
 		ripple = append(ripple, VerifyRipple{Symbol: e.name, Callers: e.callers})
 	}
 	return ripple, nil
-}
-
-// verifyIsExported reports whether name begins with an upper-case rune — the Go
-// export rule. Only exported symbols can be called from outside their package,
-// so only they can ripple past the diff.
-func verifyIsExported(name string) bool {
-	r, _ := utf8.DecodeRuneInString(name)
-	return unicode.IsUpper(r)
 }
 
 // verifyQualifiedName renders a changed symbol as "pkg.Name" (e.g.

--- a/test/blackbox/verify_test.go
+++ b/test/blackbox/verify_test.go
@@ -230,6 +230,52 @@ func TestVerify_Ripple(t *testing.T) {
 	}
 }
 
+// TestVerify_RippleUnexported edits an unexported func (foo.helper) that an
+// un-touched sibling file in the same package calls. "Outside the diff" is not
+// "outside the package", so this must ripple — the old exported-only filter
+// wrongly stayed silent, missing un-touched code a change could break (codex
+// PR #204 P1).
+func TestVerify_RippleUnexported(t *testing.T) {
+	repoDir := t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/rip\n\ngo 1.20\n")
+	writeFile(t, filepath.Join(repoDir, "foo", "a.go"), `package foo
+
+func helper() string {
+	return "h"
+}
+`)
+	// b.go calls helper from a file the diff never touches — the ripple source.
+	writeFile(t, filepath.Join(repoDir, "foo", "b.go"), `package foo
+
+func Use() string {
+	return helper()
+}
+`)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+
+	editFile(t, filepath.Join(repoDir, "foo", "a.go"), `package foo
+
+func helper() string {
+	_ = 1
+	return "h"
+}
+`)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "verify")
+	if exit != 0 {
+		t.Fatalf("verify exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "ripple") {
+		t.Fatalf("expected a ripple warning for the unexported symbol, got:\n%s", out)
+	}
+	if !strings.Contains(out, "foo.helper") {
+		t.Fatalf("expected foo.helper named as rippling, got:\n%s", out)
+	}
+}
+
 // TestVerify_MissingIndex asserts verify degrades (exit 0 + a clear message)
 // on a git repo with no .snipe index, rather than hard-failing. verify is
 // never a gate — its doc contract promises degrade-not-fail on a missing

--- a/test/blackbox/verify_test.go
+++ b/test/blackbox/verify_test.go
@@ -81,6 +81,12 @@ func TestVerify_CorrectTestSet(t *testing.T) {
 	if strings.Contains(out, "no covering test") {
 		t.Fatalf("did not expect an uncovered-symbol warning, got:\n%s", out)
 	}
+	// Callee is exported but every caller (Caller/AnotherCaller/ThirdCaller/
+	// CallMany) lives in the edited file — all call sites are inside the diff,
+	// so nothing ripples. A fully-covered, diff-local change emits no warnings.
+	if strings.Contains(out, "ripple") {
+		t.Fatalf("did not expect a ripple warning on a diff-local change, got:\n%s", out)
+	}
 
 	// JSON envelope: same assertion, structured.
 	jout, jstderr, jexit := run(t, repoDir, "verify")
@@ -161,6 +167,66 @@ func TestVerify_NoCoveringTests(t *testing.T) {
 	}
 	if !strings.Contains(out, "UseAmbiguous") {
 		t.Fatalf("expected UseAmbiguous named as uncovered, got:\n%s", out)
+	}
+}
+
+// TestVerify_Ripple edits alpha.Ambiguous (in alpha/alpha.go), an exported
+// func whose only caller — UseAmbiguous — lives in main.go, a file the diff
+// never touches. verify must flag the ripple: a changed exported symbol called
+// from outside the diff, naming the symbol and the un-touched call-site count.
+func TestVerify_Ripple(t *testing.T) {
+	repoDir, paths := writeFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+
+	editFile(t, paths["alpha"], strings.Replace(
+		readFile(t, paths["alpha"]),
+		"func Ambiguous() string {\n\treturn \"alpha\"\n}",
+		"func Ambiguous() string {\n\t_ = 1\n\treturn \"alpha\"\n}",
+		1,
+	))
+
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := runRaw(t, repoDir, "verify")
+	if exitCode != 0 {
+		t.Fatalf("verify exit %d stderr=%s stdout=%s", exitCode, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "ripple") {
+		t.Fatalf("expected a ripple warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, "alpha.Ambiguous") {
+		t.Fatalf("expected alpha.Ambiguous named as rippling, got:\n%s", out)
+	}
+	if !strings.Contains(out, "(1 site)") {
+		t.Fatalf("expected the un-touched call-site count '(1 site)', got:\n%s", out)
+	}
+
+	// JSON envelope: the ripple section is present and structured.
+	jout, jstderr, jexit := run(t, repoDir, "verify")
+	if jexit != 0 {
+		t.Fatalf("verify --format json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	resp := assertEnvelope(t, jout, "verify")
+	results := requireSlice(t, resp["results"], "results")
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	r := requireMap(t, results[0], "results[0]")
+	rip := requireSlice(t, r["ripple"], "ripple")
+	found := false
+	for _, e := range rip {
+		em := requireMap(t, e, "ripple[]")
+		if em["symbol"] == "alpha.Ambiguous" {
+			found = true
+			if got, ok := em["external_callers"].(float64); !ok || got != 1 {
+				t.Fatalf("expected external_callers=1 for alpha.Ambiguous, got %v", em["external_callers"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected alpha.Ambiguous in the ripple array, got: %v", rip)
 	}
 }
 


### PR DESCRIPTION
## What

Extend `snipe verify` with a second cheap static warning beside the existing uncovered-symbol signal:

- **uncovered** (existing) — a changed symbol with zero covering tests.
- **ripple** (new) — a changed **exported** func/method whose direct call sites include files the diff never touched: `ripple: X called from N un-touched sites`. The "your change may break code you didn't look at" nudge.

## How

- `verifyBuildRipple` iterates the changed exported funcs/methods. For each it calls `query.FindImpactCallersMulti` (direct callers; the query already drops `_test.go` callers), filters callers whose file is in the diff's changed-file set (the same absolute-path set `verify` already builds from `changeMap`), and counts the rest.
- Unexported symbols can't be called from outside their package, and diff-local churn isn't a ripple — both are skipped.
- Entries sort by symbol name (file+line tiebreak, since `pkg.Name` can collide across receivers) and cap at 20 for a token-frugal report (D4).
- Rendered in **text** (`! ripple: N changed exported symbol(s) called from outside the diff — sym (M sites)`) and **JSON** (`ripple,omitempty` — absent when empty, mirroring `uncovered`).
- Still never a gate: every degenerate path keeps its exit-0 message.

## Tests

- `TestVerify_Ripple` — edits `alpha.Ambiguous` (caller `UseAmbiguous` lives in `main.go`, untouched); asserts the text ripple line names the symbol + `(1 site)`, and the JSON `ripple` array carries `external_callers=1`.
- `TestVerify_CorrectTestSet` extended — editing `Callee` (exported, but every caller is in the edited file) emits neither `no covering test` nor `ripple`: the fully-covered, diff-local no-warnings case.
- `make audit` green (vet, lint 0 issues, race, blackbox, govulncheck).

Closes: sn-8f6q.4