### PR TITLE
fix(query): wrap FindOverlappingSymbols batch loop in a read tx (sn-5xen)

### DIFF
--- a/internal/query/overlap.go
+++ b/internal/query/overlap.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sort"
@@ -135,6 +136,23 @@ func FindOverlappingSymbols(db *sql.DB, repoRoot string, changes map[string][]Li
 		return nil, nil
 	}
 
+	// Wrap the whole batch loop in one read transaction so every batch reads
+	// from a single, stable snapshot. Without it each batch runs as its own
+	// implicit transaction; a concurrent writer (e.g. a reindex in WAL mode)
+	// committing between two batches would straddle the write boundary and
+	// could double-count or drop a symbol. modernc.org/sqlite honors
+	// ReadOnly:true as a plain deferred BEGIN, which takes the read snapshot on
+	// the first query and holds it until Rollback. The loop only reads, so
+	// Rollback (never Commit) is correct and cheaper — a read-only tx has
+	// nothing to commit; the deferred Rollback also runs on any early error
+	// return below. This consistency guarantee is structural — verified by
+	// construction, not by a (necessarily flaky) mid-loop-writer timing test.
+	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("query overlapping symbols: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // read-only tx: nothing to persist, rollback is cleanup-only
+
 	var allRows []SymbolRow
 	for start := 0; start < len(predSQL); start += overlapBatchPredicates {
 		end := start + overlapBatchPredicates
@@ -149,7 +167,7 @@ func FindOverlappingSymbols(db *sql.DB, repoRoot string, changes map[string][]Li
 			args = append(args, a...)
 		}
 
-		rows, err := db.Query(query, args...)
+		rows, err := tx.Query(query, args...)
 		if err != nil {
 			return nil, fmt.Errorf("query overlapping symbols: %w", err)
 		}


### PR DESCRIPTION
## What

Wrap `query.FindOverlappingSymbols`'s predicate-batch loop in a single read-only transaction (`db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})`, `defer tx.Rollback()`), and run each batch's query on the tx instead of `db` directly.

## Why

The loop issued its batches as N separate `db.Query` calls, each its own implicit transaction. On a large diff (>250 changed hunks/files, past `overlapBatchPredicates`) the query splits across multiple batches. A concurrent writer — e.g. a reindex in WAL mode — could commit **between** two batches, so the batches straddle a write boundary and could double-count or drop a symbol. Near-theoretical on snipe's static read-only index, but a real snapshot-consistency gap. The tx gives every batch one stable snapshot: modernc.org/sqlite honors `ReadOnly:true` as a plain deferred `BEGIN`, which takes the read snapshot on the first query and holds it until Rollback.

## Behavior preserved

Same predicates, same batching, same dedup, same ordering, same return. All existing `overlap` tests pass unchanged. The only observable change is transactional isolation of the batch loop.

## Scope notes

- `CheckPathStaleness` (runs before the loop, takes `db` not a tx) is deliberately left out of the tx — pulling it in would change its signature and ripple to other callers. Possible follow-up if a fully-consistent staleness+overlap snapshot is ever wanted.
- No concurrency test added: a deterministic mid-loop-writer test isn't feasible without a flaky timing hook. The guarantee is **structural** (verified by construction) and documented in a code comment. Not weakened into a CI-flaky timing test.

`make audit` green (eval repos skipped locally; eval drift reverted).

Closes: sn-5xen