### PR TITLE
feat(index): index inline fixture-path literals for plan churn (sn-8f6q.9)

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1186,9 +1186,16 @@ func computeFileFanIn(s *store.Store) error {
 // for an ast_ctx value added after the index was built (schemaVersion is
 // unaffected — the index fingerprint excludes it, so bumping schemaVersion
 // alone would NOT trigger a reindex).
+//
+// v3 (sn-8f6q.9): inline fixture-path literals are a new string_refs extraction
+// shape. Without a bump, an index built before this change keeps the old rows —
+// change detection compares only the dependency fingerprint and unchanged
+// source, so it skips, and `plan` reports the index fresh while missing WILL
+// CHURN paths until each affected test happens to change (or --force). The bump
+// forces the one-time full reindex that backfills them.
 const (
 	metaFileMetricsVersion = "file_metrics_version"
-	fileMetricsVersion     = "2"
+	fileMetricsVersion     = "3"
 )
 
 // metricsNeedBackfill reports whether the index lacks the current generation of

--- a/internal/index/literals.go
+++ b/internal/index/literals.go
@@ -7,6 +7,7 @@ import (
 	"go/ast"
 	"go/token"
 	"strconv"
+	"strings"
 
 	"github.com/dkoosis/snipe/internal/util"
 )
@@ -16,7 +17,7 @@ type StringRef struct {
 	ID          string // 16-char hex
 	Value       string // the string value, e.g. "SNIPE_VOYAGE_API_KEY"
 	Name        string // for const refs: the declared identifier name
-	Kind        string // "env" or "const"
+	Kind        string // "env", "const", or "fixture"
 	FilePath    string
 	Line        int
 	Col         int
@@ -57,15 +58,44 @@ func ExtractLiteralsFiltered(result *LoadResult, symbols []Symbol, onlyFiles map
 	return out
 }
 
-// extractFileLiterals walks a single file's AST extracting string literals.
+// extractFileLiterals walks a single file's AST extracting string literals in
+// three shapes: os.Getenv-family args (kind=env), named string consts
+// (kind=const), and inline fixture-path literals (kind=fixture).
+//
+// The fixture pass (sn-8f6q.9) is the bounded broadening that lets `snipe plan`'s
+// churn detector fire on inline golden-path arguments — e.g.
+// golden.Assert(t, got, "testdata/x.golden") or os.ReadFile("testdata/foo.golden")
+// — which the env/const passes miss. The gate is a predicate on the VALUE:
+// contains "testdata/" or ends in ".golden" (see fixtureLikePath). That is
+// deliberately the SAME predicate FindChurnLiterals queries, so extraction and
+// query stay aligned — we index exactly what churn can consume, nothing more.
+//
+// Why this doesn't balloon the index: only fixture-shaped literals qualify. An
+// ordinary inline string (a log message, a SQL fragment, an arbitrary path)
+// never matches, so a normal repo contributes only its handful of real fixture
+// paths. Indexing every inline literal instead would multiply string_refs by
+// orders of magnitude for zero churn benefit — the predicate is the bound. (An
+// allowlist of golden-helper function names was the alternative gate, but it
+// would drift from churn's value predicate and miss os.ReadFile-style reads.)
+//
+// Dedup: ast.Inspect is pre-order, so a CallExpr/GenDecl is visited before its
+// child BasicLit. The env/const passes record each literal position they consume
+// in `claimed`; the fixture pass skips any BasicLit already claimed. A const
+// whose value happens to match the fixture predicate therefore stays a single
+// kind=const row — churn still finds it (churn keys on value, not kind).
 func extractFileLiterals(file *ast.File, filePath string, fset *token.FileSet) []StringRef {
 	var refs []StringRef
+	claimed := make(map[token.Pos]bool)
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch node := n.(type) {
 		case *ast.CallExpr:
-			refs = append(refs, extractEnvCall(node, filePath, fset)...)
+			refs = append(refs, extractEnvCall(node, filePath, fset, claimed)...)
 		case *ast.GenDecl:
-			refs = append(refs, extractConstLiterals(node, filePath, fset)...)
+			refs = append(refs, extractConstLiterals(node, filePath, fset, claimed)...)
+		case *ast.BasicLit:
+			if r, ok := extractFixtureLiteral(node, filePath, fset, claimed); ok {
+				refs = append(refs, r)
+			}
 		}
 		return true
 	})
@@ -73,7 +103,7 @@ func extractFileLiterals(file *ast.File, filePath string, fset *token.FileSet) [
 }
 
 // extractEnvCall extracts os.Getenv / os.LookupEnv / os.Setenv calls.
-func extractEnvCall(call *ast.CallExpr, filePath string, fset *token.FileSet) []StringRef {
+func extractEnvCall(call *ast.CallExpr, filePath string, fset *token.FileSet, claimed map[token.Pos]bool) []StringRef {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return nil
@@ -98,6 +128,7 @@ func extractEnvCall(call *ast.CallExpr, filePath string, fset *token.FileSet) []
 	if err != nil {
 		return nil
 	}
+	claimed[lit.Pos()] = true
 	pos := fset.Position(lit.Pos())
 	return []StringRef{{
 		Value:    value,
@@ -109,7 +140,7 @@ func extractEnvCall(call *ast.CallExpr, filePath string, fset *token.FileSet) []
 }
 
 // extractConstLiterals extracts named string constants.
-func extractConstLiterals(decl *ast.GenDecl, filePath string, fset *token.FileSet) []StringRef {
+func extractConstLiterals(decl *ast.GenDecl, filePath string, fset *token.FileSet, claimed map[token.Pos]bool) []StringRef {
 	if decl.Tok != token.CONST {
 		return nil
 	}
@@ -128,6 +159,7 @@ func extractConstLiterals(decl *ast.GenDecl, filePath string, fset *token.FileSe
 			if err != nil {
 				continue
 			}
+			claimed[lit.Pos()] = true
 			name := ""
 			if i < len(vspec.Names) {
 				name = vspec.Names[i].Name
@@ -144,6 +176,36 @@ func extractConstLiterals(decl *ast.GenDecl, filePath string, fset *token.FileSe
 		}
 	}
 	return refs
+}
+
+// fixtureLikePath reports whether a string value looks like a test fixture path.
+// This is the exact gate FindChurnLiterals queries (LIKE '%testdata/%' OR
+// '%.golden'); keeping the two in sync means the extractor indexes precisely the
+// literals churn can surface.
+func fixtureLikePath(value string) bool {
+	return strings.Contains(value, "testdata/") || strings.HasSuffix(value, ".golden")
+}
+
+// extractFixtureLiteral indexes an inline string literal that looks like a
+// fixture path, unless it was already claimed by the env/const passes. See
+// extractFileLiterals for the gate rationale.
+func extractFixtureLiteral(lit *ast.BasicLit, filePath string, fset *token.FileSet, claimed map[token.Pos]bool) (StringRef, bool) {
+	if lit.Kind != token.STRING || claimed[lit.Pos()] {
+		return StringRef{}, false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil || !fixtureLikePath(value) {
+		return StringRef{}, false
+	}
+	claimed[lit.Pos()] = true
+	pos := fset.Position(lit.Pos())
+	return StringRef{
+		Value:    value,
+		Kind:     "fixture",
+		FilePath: filePath,
+		Line:     pos.Line,
+		Col:      pos.Column,
+	}, true
 }
 
 // literalID generates a stable 16-char hex ID for a string ref.

--- a/internal/index/literals_test.go
+++ b/internal/index/literals_test.go
@@ -51,3 +51,79 @@ const (
 		t.Errorf("first const: got %+v", refs[0])
 	}
 }
+
+// TestExtractLiterals_InlineFixture covers the sn-8f6q.9 broadening: an inline
+// golden-path argument (no const, no env) is indexed as kind=fixture so `snipe
+// plan`'s churn detector fires on it. Both predicate arms are exercised — a
+// "testdata/" substring and a ".golden" suffix.
+func TestExtractLiterals_InlineFixture(t *testing.T) {
+	src := `package p
+func f(t T) {
+	golden.Assert(t, got, "testdata/x.golden")
+	os.ReadFile("fixtures/out.golden")
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "f.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := extractFileLiterals(file, "f.go", fset)
+	if len(refs) != 2 {
+		t.Fatalf("want 2 fixture refs, got %d: %+v", len(refs), refs)
+	}
+	for _, r := range refs {
+		if r.Kind != "fixture" {
+			t.Errorf("want kind=fixture, got %+v", r)
+		}
+	}
+	got := map[string]bool{refs[0].Value: true, refs[1].Value: true}
+	for _, want := range []string{"testdata/x.golden", "fixtures/out.golden"} {
+		if !got[want] {
+			t.Errorf("missing fixture value %q (got %v)", want, got)
+		}
+	}
+}
+
+// TestExtractLiterals_InlineNonFixtureIgnored is the bound: an ordinary inline
+// string literal that does NOT match the fixture predicate must NOT be indexed.
+// This is what keeps the broadening from ballooning string_refs repo-wide.
+func TestExtractLiterals_InlineNonFixtureIgnored(t *testing.T) {
+	src := `package p
+func f() {
+	fmt.Println("hello world")
+	log.Print("some/other/path.txt")
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "f.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := extractFileLiterals(file, "f.go", fset)
+	if len(refs) != 0 {
+		t.Fatalf("want 0 refs for non-fixture inline literals, got %d: %+v", len(refs), refs)
+	}
+}
+
+// TestExtractLiterals_FixtureConstNotDoubleCounted proves dedup: a const whose
+// value happens to match the fixture predicate stays a single kind=const row
+// (never also emitted as kind=fixture). Churn still finds it — churn keys on the
+// value, not the kind.
+func TestExtractLiterals_FixtureConstNotDoubleCounted(t *testing.T) {
+	src := `package p
+const golden = "testdata/x.golden"
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "f.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := extractFileLiterals(file, "f.go", fset)
+	if len(refs) != 1 {
+		t.Fatalf("want exactly 1 ref (const, not double-counted), got %d: %+v", len(refs), refs)
+	}
+	if refs[0].Kind != "const" || refs[0].Name != "golden" || refs[0].Value != "testdata/x.golden" {
+		t.Errorf("want single const ref, got %+v", refs[0])
+	}
+}

--- a/internal/query/literals.go
+++ b/internal/query/literals.go
@@ -54,12 +54,14 @@ func FindLiteralRefs(db *sql.DB, value string) ([]LiteralRef, error) {
 // dropped past the cap (0 if none). An empty testFiles returns (nil, 0, nil)
 // without querying.
 //
-// A literal churns if its value contains "testdata/" or ends in ".golden". This
-// reuses the string_refs index, which captures only two literal shapes:
-// os.Getenv-family args and named string const declarations. Inline fixture-path
-// arguments (e.g. golden.Assert(t, got, "testdata/x.golden")) are NOT indexed,
-// so churn detection fires only when the path is declared as a const — the tidy,
-// common pattern. Broadening the extractor to inline args is out of scope.
+// A literal churns if its value contains "testdata/" or ends in ".golden" — the
+// same predicate the extractor's fixture pass gates on, so churn queries exactly
+// what index.ExtractLiterals emits. The string_refs index captures three literal
+// shapes: os.Getenv-family args, named string const declarations, and inline
+// fixture-path literals (kind=fixture, sn-8f6q.9). Churn keys on the value alone
+// and never filters by kind, so all three flow through — a fixture path surfaces
+// whether it is declared as a const or passed inline (e.g.
+// golden.Assert(t, got, "testdata/x.golden") or os.ReadFile("testdata/foo.golden")).
 func FindChurnLiterals(db *sql.DB, testFiles []string, limit int) (paths []string, truncated int, err error) {
 	if len(testFiles) == 0 {
 		return nil, 0, nil

--- a/test/blackbox/plan_churn_inline_test.go
+++ b/test/blackbox/plan_churn_inline_test.go
@@ -1,0 +1,86 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeInlineChurnFixture builds a self-contained module whose covering test
+// names a fixture path as an INLINE argument (os.ReadFile("testdata/...")) with
+// no intervening const. Before sn-8f6q.9 the string_refs extractor indexed only
+// os.Getenv args and named consts, so this literal was invisible and `snipe
+// plan`'s churn detector missed it. The extractor now indexes fixture-shaped
+// inline literals (kind=fixture), so churn must surface it.
+//
+// Kept separate from writePlanFixture (which uses the const form) so the two
+// churn shapes — const and inline — are proven independently and this bead
+// touches no existing plan fixture or golden.
+func writeInlineChurnFixture(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/inlinechurn\n\ngo 1.20\n")
+
+	writeFile(t, filepath.Join(repoDir, "foo", "foo.go"), `package foo
+
+func Target(id string) string {
+	return "t:" + id
+}
+`)
+
+	// The covering test reads a golden fixture via an inline literal — no const.
+	writeFile(t, filepath.Join(repoDir, "foo", "foo_test.go"), `package foo
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTarget(t *testing.T) {
+	_, _ = os.ReadFile("testdata/inline.golden")
+	if Target("x") == "" {
+		t.Fatal("x")
+	}
+}
+`)
+	return repoDir
+}
+
+// TestPlan_WillChurnInline proves the sn-8f6q.9 broadening end-to-end: a covering
+// test with an inline golden-path arg (no const) yields a WILL CHURN entry in
+// `snipe plan` — text and JSON.
+func TestPlan_WillChurnInline(t *testing.T) {
+	repoDir := writeInlineChurnFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "WILL CHURN") {
+		t.Fatalf("expected WILL CHURN section for inline fixture arg, got:\n%s", out)
+	}
+	if !strings.Contains(out, "testdata/inline.golden") {
+		t.Fatalf("expected inline churn path testdata/inline.golden, got:\n%s", out)
+	}
+
+	// JSON: results[0].churn carries the inline path.
+	jout, _, _ := run(t, repoDir, "plan", "Target")
+	r := requireMap(t, requireSlice(t, assertEnvelope(t, jout, "plan")["results"], "results")[0], "results[0]")
+	churn := requireSlice(t, r["churn"], "churn")
+	var found bool
+	for _, c := range churn {
+		if getString(t, c, "churn[]") == "testdata/inline.golden" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("churn JSON missing testdata/inline.golden, got: %v", churn)
+	}
+}


### PR DESCRIPTION
## What

`snipe plan`'s WILL CHURN detector fired only on fixture paths declared as named consts. Inline fixture-path arguments — `golden.Assert(t, got, "testdata/x.golden")`, `os.ReadFile("testdata/foo.golden")` — were never indexed, so churn missed them.

Broaden the `string_refs` extractor to index inline fixture-path literals as a new `kind=fixture`, so churn detection fires on them too.

## How

`internal/index/literals.go` gains a third AST pass over `*ast.BasicLit` nodes (`extractFixtureLiteral`), alongside the existing env-call and const passes.

**The gate (bounded):** a predicate on the literal VALUE — contains `testdata/` or ends in `.golden` (`fixtureLikePath`). This is the exact predicate `FindChurnLiterals` queries, so extraction and query stay aligned: we index precisely what churn can consume, nothing more. An arbitrary inline string never qualifies, so a normal repo contributes only its handful of real fixture paths — the predicate is the bound, not a repo-wide index of every literal. (Alternative gate — an allowlist of golden-helper function names — was rejected: it would drift from churn's value predicate and miss `os.ReadFile`-style reads.)

**Dedup:** `ast.Inspect` is pre-order, so a `CallExpr`/`GenDecl` is visited before its child `BasicLit`. The env/const passes record each literal position they consume in a `claimed` set; the fixture pass skips any claimed position. A const whose value happens to match the predicate therefore stays a single `kind=const` row — and churn still finds it, because churn keys on the value, not the kind.

`internal/query/literals.go`: no behavior change (it already flowed any matching row through, regardless of kind); only a stale `FindChurnLiterals` doc comment was corrected — it previously claimed inline args were out of scope.

## Merge gate

`make audit` green.

## Row-growth fallout

None. Broadening extraction adds `string_refs` rows repo-wide, but no existing test needed updated counts:
- `lits`/`trace` query by exact value — fixture values don't collide with existing assertions (e.g. `SNIPE_VOYAGE_API_KEY`, which is `kind=env`).
- No test asserts a total `string_refs` count on the real repo; store write-path tests use synthetic rows.

## Tests

- `internal/index/literals_test.go`: inline-arg extraction (both predicate arms), the non-fixture bound (a `"hello"` inline literal is NOT indexed), and const non-double-counting.
- `test/blackbox/plan_churn_inline_test.go` (new, isolated): a covering test with an inline `os.ReadFile("testdata/inline.golden")` arg produces a WILL CHURN entry in `snipe plan` (text + JSON).

Closes: sn-8f6q.9