### PR TITLE
test(cli): txtar smoke suite for uncovered commands (snipe-p61)

### DIFF
--- a/test/script/script_test.go
+++ b/test/script/script_test.go
@@ -1,10 +1,35 @@
 // Package script runs testscript (.txtar) smoke tests against the snipe CLI.
 //
-// These are usage contracts: each script asserts a command's exit code plus one
-// stable human-readable line of output. They complement — and do NOT replace —
-// the JSON-envelope contract tests in test/blackbox. The blackbox suite proves
-// the --format json protocol; this suite proves the default Claude-text CLI
-// surface for commands the blackbox suite does not exercise.
+// Coexistence with test/blackbox — the two suites test DIFFERENT surfaces and
+// intentionally overlap on command names:
+//
+//   - blackbox (build tag `blackbox`, run() forces --format json) = the JSON
+//     envelope CONTRACT: field shapes, ok/error semantics, result payloads.
+//   - this suite (no build tag, plain `make`) = the DEFAULT CLI surface SMOKE:
+//     exit code + one stable line of whatever the command prints by DEFAULT
+//     (Claude-text for most; the default-JSON commands — edit/status/doctor —
+//     assert a stable envelope key). It is a cheap regression net for "does the
+//     command run and print its recognizable output on the surface Claude reads".
+//
+// Because they cover different surfaces, a command with a blackbox JSON test
+// still earns a default-surface smoke here — the two are not redundant.
+//
+// Gap note (snipe-p61): auditing the full cmd/cli.go command set against both
+// suites, only hotspots, sensitive, and guard were covered by NEITHER — those
+// are the primary contracts added here. The rest of the added scripts smoke the
+// default text surface of commands whose JSON contract lives in blackbox.
+//
+// Exemptions (a real happy-path assertion is impossible on this fixture; the
+// script smokes a documented fallback and says why, in its own header comment):
+//   - sim: zero-embedding index + no Voyage key → graceful no-key path.
+//   - risk / index: need a git work tree / would reindex per script (defeats the
+//     copy-a-prebuilt-index design) → --help fast-exit, like watch.
+//   - imports: a FILE-argument command; file lookups match the absolute path
+//     stored at index time, which no longer exists once the index is copied to a
+//     fresh $WORK path (name/package queries stay portable, file-path ones do
+//     not) → --help fast-exit (real path is blackbox TestImports).
+//   - verify / tests / show: the fixture has no diff / no _test.go / stable hex
+//     ID to assert → graceful degrade path (JSON contract is in blackbox).
 //
 // Pattern: build-and-exec. cmd.Execute() calls os.Exit internally (kong's
 // FatalIfErrorf), so the binary cannot be driven in-process. Instead the suite
@@ -97,13 +122,43 @@ func TestScripts(t *testing.T) {
 
 // writeScriptFixture writes a minimal Go module exercising the features the
 // scripted commands assert against:
-//   - cross-package refs (alpha ← beta, main → alpha/beta) for `boundary`
+//   - cross-package refs (alpha ← beta, main → alpha/beta) for `boundary`/`guard`
 //   - a named string constant for `trace`/`lits`
 //   - an unreferenced exported symbol for `deadcode`
-//   - a small call graph for `metrics`/`orient`
+//   - a small call graph for `metrics`/`orient`/`callers`/`callees`/`plan`
+//   - a self-contained `shape` package (interface + struct + implementers) so
+//     `impl`/`types` resolve real happy paths. shape imports nothing from
+//     alpha/beta and is imported by nothing, so it can't perturb the boundary,
+//     deadcode-anchor, or call-graph assertions the other scripts rely on.
 func writeScriptFixture(dir string) error {
 	files := map[string]string{
 		"go.mod": "module example.com/fixture\n\ngo 1.20\n",
+		"shape/shape.go": `package shape
+
+// Sizer is an interface — impl resolves its implementers.
+type Sizer interface {
+	Size() int
+}
+
+// Box is a struct implementing Sizer — types/lifecycle read its shape.
+type Box struct {
+	Width  int
+	Height int
+}
+
+// Size returns the box area.
+func (b Box) Size() int {
+	return b.Width * b.Height
+}
+
+// Dot is a second Sizer implementer.
+type Dot struct{}
+
+// Size is always zero.
+func (Dot) Size() int {
+	return 0
+}
+`,
 		"main.go": `package fixture
 
 import (

--- a/test/script/testdata/script/callees.txtar
+++ b/test/script/testdata/script/callees.txtar
@@ -1,0 +1,6 @@
+# callees — functions that a symbol calls.
+# Proves: `callees Run` names the two functions Run invokes (Greet, Reply).
+cd $FIXTURE
+exec snipe callees Run
+stdout '# Greet'
+stdout '# Reply'

--- a/test/script/testdata/script/callers.txtar
+++ b/test/script/testdata/script/callers.txtar
@@ -1,0 +1,6 @@
+# callers — functions that call a symbol.
+# Proves: `callers Greet` names both callers (Run and beta.Reply).
+cd $FIXTURE
+exec snipe callers Greet
+stdout '# Run'
+stdout '# Reply'

--- a/test/script/testdata/script/context.txtar
+++ b/test/script/testdata/script/context.txtar
@@ -1,0 +1,7 @@
+# context — Claude-optimized project orientation (entry points, build, packages).
+# Proves: a bare run over the indexed fixture renders the structural orientation
+# sections Claude reads first.
+cd $FIXTURE
+exec snipe context
+stdout '## build'
+stdout '## key symbols'

--- a/test/script/testdata/script/def.txtar
+++ b/test/script/testdata/script/def.txtar
@@ -1,0 +1,6 @@
+# def — jump to a symbol definition by bare name.
+# Proves: `def Run` resolves the fixture function and prints its header + body.
+cd $FIXTURE
+exec snipe def Run
+stdout '# Run'
+stdout 'func Run\(\) string'

--- a/test/script/testdata/script/deps.txtar
+++ b/test/script/testdata/script/deps.txtar
@@ -1,0 +1,6 @@
+# deps — dependency topology for the project.
+# Proves: the import edge beta -> alpha (beta.Reply calls alpha.Greet) is reported.
+# Asserts the edge, not the package/edge counts, so it survives fixture growth.
+cd $FIXTURE
+exec snipe deps
+stdout 'beta -> alpha'

--- a/test/script/testdata/script/diagram.txtar
+++ b/test/script/testdata/script/diagram.txtar
@@ -1,0 +1,8 @@
+# diagram — render snipe graphs as D2 diagram source.
+# The golden JSON for each subcommand is blackbox-covered; this smokes the
+# default text surface. Proves: `diagram arch` emits the summary header and a
+# fenced d2 block over the fixture's import graph, exit 0.
+cd $FIXTURE
+exec snipe diagram arch
+stdout 'diagram arch ·'
+stdout '```d2'

--- a/test/script/testdata/script/doctor.txtar
+++ b/test/script/testdata/script/doctor.txtar
@@ -1,0 +1,7 @@
+# doctor — check snipe installation and configuration.
+# doctor renders a JSON envelope as its default surface. Proves: the run
+# completes and reports the doctor command with its check results, exit 0.
+cd $FIXTURE
+exec snipe doctor
+stdout '"command":"doctor"'
+stdout '"name":"ripgrep"'

--- a/test/script/testdata/script/edit.txtar
+++ b/test/script/testdata/script/edit.txtar
@@ -1,0 +1,7 @@
+# edit — AST-aware code editing. Default is dry-run (no --apply), emitting the
+# edit plan as a JSON envelope without touching files.
+# Proves: a replace_body edit previews with applied=false (nothing written).
+cd $FIXTURE
+exec snipe edit Greet --operation replace_body --new-code 'return Banner'
+stdout '"operation":"replace_body"'
+stdout '"applied":false'

--- a/test/script/testdata/script/explain.txtar
+++ b/test/script/testdata/script/explain.txtar
@@ -1,0 +1,7 @@
+# explain — structured function walkthrough (purpose, mechanism, callers).
+# Proves: `explain Run` renders the purpose + mechanism sections and names a call.
+cd $FIXTURE
+exec snipe explain Run
+stdout 'purpose:'
+stdout 'mechanism:'
+stdout 'calls Greet'

--- a/test/script/testdata/script/guard.txtar
+++ b/test/script/testdata/script/guard.txtar
@@ -1,0 +1,30 @@
+# guard — assert architecture boundary rules; exit non-zero on violation.
+# Uncovered by the blackbox suite, so this is the primary contract. Two cases
+# prove both sides of the exit contract:
+#   1. a clean spec (forbids a dependency that does not exist) passes, exit 0.
+#   2. a spec forbidding the real beta -> alpha edge (beta.Reply calls
+#      alpha.Greet) is flagged, exit non-zero.
+# Specs live beside the script in $WORK; guard resolves the index from $FIXTURE.
+cd $FIXTURE
+exec snipe guard $WORK/clean.yml
+stdout 'no violations'
+
+! exec snipe guard $WORK/violation.yml
+stdout '1 violation'
+stdout 'beta/beta\.go:7'
+
+-- clean.yml --
+version: 1
+rules:
+  - name: no-alpha-to-beta
+    from: example.com/fixture/alpha
+    to: example.com/fixture/beta
+    desc: alpha must not reach into beta
+
+-- violation.yml --
+version: 1
+rules:
+  - name: no-beta-to-alpha
+    from: example.com/fixture/beta
+    to: example.com/fixture/alpha
+    desc: beta must not reach into alpha

--- a/test/script/testdata/script/hotspots.txtar
+++ b/test/script/testdata/script/hotspots.txtar
@@ -1,0 +1,9 @@
+# hotspots — files ranked by complexity x git change-frequency.
+# Uncovered by the blackbox suite, so this is the primary contract. The fixture
+# is not a git work tree, so change-frequency is unavailable; the command
+# degrades to complexity-only ranking and says so. Proves: the header renders
+# and the no-churn degrade path is announced, exit 0.
+cd $FIXTURE
+exec snipe hotspots
+stdout 'hotspots · unified risk'
+stdout 'no git churn'

--- a/test/script/testdata/script/impact.txtar
+++ b/test/script/testdata/script/impact.txtar
@@ -1,0 +1,6 @@
+# impact — blast radius for changing a symbol.
+# Proves: `impact Greet` surfaces the direct callers (Run, Reply) with hints.
+cd $FIXTURE
+exec snipe impact Greet
+stdout '# Run'
+stdout 'hints: direct_caller'

--- a/test/script/testdata/script/impl.txtar
+++ b/test/script/testdata/script/impl.txtar
@@ -1,0 +1,7 @@
+# impl — types implementing an interface.
+# Proves: `impl Sizer` resolves both implementers (Box, Dot) in the shape pkg.
+cd $FIXTURE
+exec snipe impl Sizer
+stdout '# Box'
+stdout '# Dot'
+stdout 'struct'

--- a/test/script/testdata/script/importers.txtar
+++ b/test/script/testdata/script/importers.txtar
@@ -1,0 +1,6 @@
+# importers — files that import a package.
+# Proves: `importers <alpha>` finds both import sites (main.go and beta/beta.go).
+cd $FIXTURE
+exec snipe importers example.com/fixture/alpha
+stdout 'main\.go:4 \| import'
+stdout 'beta/beta\.go:3 \| import'

--- a/test/script/testdata/script/imports.txtar
+++ b/test/script/testdata/script/imports.txtar
@@ -1,0 +1,10 @@
+# imports — packages imported by a file.
+# imports takes a FILE argument, and file lookups match the absolute path stored
+# at index time. This suite queries a prebuilt index copied to a fresh $WORK path
+# (name/package queries are portable; file-path queries are not), so no
+# script-reachable file arg resolves against it. The real file-lookup path is
+# blackbox-covered (TestImports, which indexes and queries in-place). Here we
+# smoke the --help fast-exit: usage naming the required <file> arg, exit 0.
+exec snipe imports --help
+stdout 'Usage: snipe imports <file>'
+stdout 'Show packages imported by a file'

--- a/test/script/testdata/script/index.txtar
+++ b/test/script/testdata/script/index.txtar
@@ -1,0 +1,8 @@
+# index — build or update the code index.
+# The real indexing path (go/packages walk + persistence) is blackbox-covered
+# (TestIndex). This suite copies a prebuilt index into each script rather than
+# reindexing per script — a full reindex here would defeat that design and put
+# `go` back on the script path. So we smoke the --help fast-exit: usage prints
+# and exits 0.
+exec snipe index --help
+stdout 'Usage: snipe index'

--- a/test/script/testdata/script/lifecycle.txtar
+++ b/test/script/testdata/script/lifecycle.txtar
@@ -1,0 +1,7 @@
+# lifecycle — CRUD trace for a type (Create/Mutate/Read/Delete + caller chains).
+# Proves: `lifecycle Box` renders the lifecycle header and role buckets; the
+# Box.Size method lands in the Read bucket.
+cd $FIXTURE
+exec snipe lifecycle Box
+stdout '# Lifecycle: Box'
+stdout '## Read'

--- a/test/script/testdata/script/lits.txtar
+++ b/test/script/testdata/script/lits.txtar
@@ -1,0 +1,6 @@
+# lits — locations of a string literal or env var name.
+# Proves: `lits banner-token-literal` resolves the named const Banner.
+cd $FIXTURE
+exec snipe lits banner-token-literal
+stdout '# Banner'
+stdout 'const'

--- a/test/script/testdata/script/pack.txtar
+++ b/test/script/testdata/script/pack.txtar
@@ -1,0 +1,6 @@
+# pack — deep dive on one symbol (def+refs+callers+callees+role+purpose).
+# Proves: `pack Greet` renders the role classification and the definition block.
+cd $FIXTURE
+exec snipe pack Greet
+stdout '# Greet'
+stdout 'role: api_boundary'

--- a/test/script/testdata/script/pkg.txtar
+++ b/test/script/testdata/script/pkg.txtar
@@ -1,0 +1,6 @@
+# pkg — package overview with exported symbols.
+# Proves: `pkg alpha` reports the package header and its export count (Banner, Greet).
+cd $FIXTURE
+exec snipe pkg alpha
+stdout '# package alpha'
+stdout 'exports: 2'

--- a/test/script/testdata/script/plan.txtar
+++ b/test/script/testdata/script/plan.txtar
@@ -1,0 +1,7 @@
+# plan — ordered edit worklist for a proposed symbol change.
+# Proves: `plan Greet` renders the worklist header (signature change) plus the
+# DEF line for the target definition. Exit 0 (structural, not a gate).
+cd $FIXTURE
+exec snipe plan Greet
+stdout 'plan Greet · signature change'
+stdout 'DEF  alpha/alpha\.go:7'

--- a/test/script/testdata/script/refs.txtar
+++ b/test/script/testdata/script/refs.txtar
@@ -1,0 +1,6 @@
+# refs — find all references to a symbol.
+# Proves: `refs Greet` reports the ref sites (Run's body and beta.Reply).
+cd $FIXTURE
+exec snipe refs Greet
+stdout '# Greet'
+stdout '\| ref'

--- a/test/script/testdata/script/risk.txtar
+++ b/test/script/testdata/script/risk.txtar
@@ -1,0 +1,8 @@
+# risk — assess a diff's risk (base->head) from the code graph.
+# risk requires a git work tree and a base ref, which the scripted fixture is
+# not; the real risk verdict is blackbox-covered (risk_contract_test.go). Per
+# the bead exemption for git-diff commands, we smoke the --help fast-exit path:
+# it prints usage naming the required <base> argument and exits 0.
+exec snipe risk --help
+stdout 'Usage: snipe risk <base>'
+stdout 'code-graph verdict'

--- a/test/script/testdata/script/search.txtar
+++ b/test/script/testdata/script/search.txtar
@@ -1,0 +1,6 @@
+# search — text search via ripgrep (no index required).
+# Proves: `search Greet` finds the symbol's source lines in the alpha package.
+cd $FIXTURE
+exec snipe search Greet
+stdout '# Greet'
+stdout 'alpha/alpha\.go'

--- a/test/script/testdata/script/sensitive.txtar
+++ b/test/script/testdata/script/sensitive.txtar
@@ -1,0 +1,8 @@
+# sensitive — files in security-sensitive zones (auth/crypto/migration/secret/payment).
+# Uncovered by the blackbox suite, so this is the primary contract. The fixture
+# has no sensitive files, so the command reports the empty zone. Proves: the
+# header renders and the none-detected path is announced, exit 0.
+cd $FIXTURE
+exec snipe sensitive
+stdout 'sensitive zones · 0 files'
+stdout 'none detected'

--- a/test/script/testdata/script/show.txtar
+++ b/test/script/testdata/script/show.txtar
@@ -1,0 +1,8 @@
+# show — expand a symbol by 16-char hex ID.
+# The valid-ID happy path is blackbox-covered (TestShow); asserting a real ID
+# here would hardcode a hash that drifts if indexing changes. Instead we smoke
+# the default text surface of the graceful miss: a bogus ID renders a
+# not-found error (exit 0) rather than crashing.
+cd $FIXTURE
+exec snipe show deadbeefdeadbeef
+stdout 'symbol not found: deadbeefdeadbeef'

--- a/test/script/testdata/script/sim.txtar
+++ b/test/script/testdata/script/sim.txtar
@@ -1,0 +1,8 @@
+# sim — semantic similarity search (needs embeddings).
+# The fixture index is built with --embed-mode=off (zero embeddings) and no
+# Voyage key resolves, so a real semantic hit is impossible here. Per the bead
+# exemption for embedding-backed commands, we assert the graceful no-key path:
+# sim explains embeddings are unavailable and points at doctor, exit 0.
+cd $FIXTURE
+exec snipe sim Greet
+stdout 'no API key'

--- a/test/script/testdata/script/status.txtar
+++ b/test/script/testdata/script/status.txtar
@@ -1,0 +1,7 @@
+# status — index status and statistics (the default bare-`snipe` command).
+# status renders a JSON envelope as its default surface. Proves: a run over the
+# indexed fixture reports the status command with a fresh index state, exit 0.
+cd $FIXTURE
+exec snipe status
+stdout '"command":"status"'
+stdout '"state":"fresh"'

--- a/test/script/testdata/script/sym.txtar
+++ b/test/script/testdata/script/sym.txtar
@@ -1,0 +1,6 @@
+# sym — symbol-only view (def+refs+callers+callees, no package context).
+# Proves: `sym Greet` renders the definition and its caller summary.
+cd $FIXTURE
+exec snipe sym Greet
+stdout '# Greet'
+stdout 'func Greet\(\) string'

--- a/test/script/testdata/script/tests.txtar
+++ b/test/script/testdata/script/tests.txtar
@@ -1,0 +1,7 @@
+# tests — tests that exercise a symbol.
+# The scripted fixture ships no _test.go files, so the happy "exercised" path
+# is left to the blackbox JSON contract (TestTests). Here we smoke the default
+# text surface: the command runs and renders its no-coverage sentinel, exit 0.
+cd $FIXTURE
+exec snipe tests Greet
+stdout 'No results'

--- a/test/script/testdata/script/types.txtar
+++ b/test/script/testdata/script/types.txtar
@@ -1,0 +1,7 @@
+# types — type relationships (fields, methods, interface satisfaction).
+# Proves: `types Box` renders the struct's method set (Box.Size).
+cd $FIXTURE
+exec snipe types Box
+stdout '# Box'
+stdout 'methods:'
+stdout 'Size'

--- a/test/script/testdata/script/verify.txtar
+++ b/test/script/testdata/script/verify.txtar
@@ -1,0 +1,8 @@
+# verify — map a diff to the minimal go test set covering changed symbols.
+# The scripted fixture is a plain tree, not a git work tree, so there is no diff
+# to resolve; the real diff-mapping path is blackbox-covered (verify_test.go).
+# Here we smoke the default text surface of the graceful degrade: verify reports
+# the diff is unavailable rather than crashing, exit 0.
+cd $FIXTURE
+exec snipe verify
+stdout 'diff unavailable'

--- a/test/script/testdata/script/version.txtar
+++ b/test/script/testdata/script/version.txtar
@@ -1,0 +1,4 @@
+# version — print version information. No index needed.
+# Proves: the command prints a version line and exits 0.
+exec snipe version
+stdout 'snipe version'


### PR DESCRIPTION
## What

Every command in `cmd/cli.go` now has a testscript (`.txtar`) smoke test asserting **exit code + one stable default-surface line**. 33 new scripts join the existing 11; the suite runs under plain `make` (no build tag) and `make audit`.

## Gap analysis (blackbox ∩ txtar)

Audited the full 44-command set against **both** harnesses. `run()` in the blackbox suite forces `--format json`, so blackbox tests the JSON envelope contract and never the default text surface. Cross-referencing blackbox contract tests against the existing 11 `.txtar`, only **3 commands were covered by NEITHER**: `hotspots`, `sensitive`, `guard`. Those are the primary new contracts. (The dispatcher's ~12 estimate was high — blackbox coverage is broader than assumed.) The remaining new scripts smoke the default text surface of commands whose JSON contract already lives in blackbox — a different surface, so not redundant.

## Coexistence decision

- **blackbox** (build tag `blackbox`, `--format json`) = JSON envelope **contract** (field shapes, ok/error semantics, payloads).
- **txtar** (this suite, plain `make`) = default CLI surface **smoke** (exit code + one stable line; the default-JSON commands `edit`/`status`/`doctor` assert a stable envelope key).

Recorded as a doc block atop `test/script/script_test.go`.

## Fixture change

Added a self-contained `shape` package (interface `Sizer` + struct `Box` + implementers `Box`/`Dot`) to `writeScriptFixture` so `impl`/`types`/`lifecycle` assert real happy paths. It imports nothing from `alpha`/`beta` and is imported by nothing, so it cannot perturb the existing boundary/deadcode/call-graph assertions (verified: pre-existing scripts stay green).

## Coverage

| Disposition | Commands |
|---|---|
| Happy-path smoke | context, def, refs, callers, callees, impl, impact, pack, sym, explain, pkg, search, lits, deps, importers, types, plan, hotspots, sensitive, diagram, lifecycle, guard, edit, status, doctor, version |
| Graceful-path smoke (documented) | tests (no `_test.go`), verify (not a git tree), sim (zero-embedding index / no key), show (avoids drift-prone hex ID) |
| `--help` fast-exit (documented) | risk (needs git base ref), index (per-script reindex defeats the copy-a-prebuilt-index design), imports (file-arg can't resolve against a relocated index) |

Each exemption's reason is in its script's header comment and the `script_test.go` doc block.

## Note for reviewers

`imports <file>` returns no results against a **copied** index: file-argument lookups match the absolute path stored at index time, so they don't survive index relocation (name/package queries do). This is a harness-copy artifact, not a product bug — `imports` works when index and query share a tree (blackbox `TestImports` proves it), which is normal usage. Flagging as a latent property, not fixing product code.

## Verification

`make audit` green (race, blackbox, govulncheck — 0 vulnerabilities). Test-only change; no `cmd/`, `internal/`, or `test/blackbox/` touched.

Closes: snipe-p61