### PR TITLE
fix(plan): surface test-file call sites beyond FindTests' 2-hop reach (sn-8f6q.8)

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -259,7 +259,7 @@ func runPlan(change string, args []string) error {
 		result.CallSites, result.Truncated, result.TotalCallSites, result.TotalPkgs =
 			planBuildCallSites(prodRefs, planMaxCallers)
 		result.TestCallSites, result.TestCallSitesTruncated, _, _ =
-			planBuildCallSites(testRefs, planMaxCallers)
+			planBuildCallSites(testRefs, planTestBudget(planMaxCallers, result.TotalCallSites, result.Truncated))
 		if err := buildTests(); err != nil {
 			return internalErr(err)
 		}
@@ -273,7 +273,7 @@ func runPlan(change string, args []string) error {
 		result.CallSites, result.Truncated, result.TotalCallSites, result.TotalPkgs =
 			planBuildCallSites(prodRefs, planMaxCallers)
 		result.TestCallSites, result.TestCallSitesTruncated, _, _ =
-			planBuildCallSites(testRefs, planMaxCallers)
+			planBuildCallSites(testRefs, planTestBudget(planMaxCallers, result.TotalCallSites, result.Truncated))
 		if err := buildTests(); err != nil {
 			return internalErr(err)
 		}
@@ -361,6 +361,24 @@ func planPartitionRefs(refs []query.RefRow) (prod, test []query.RefRow) {
 		}
 	}
 	return prod, test
+}
+
+// planTestBudget splits the single --max-callers cap across the production and
+// test-ref sections so the COMBINED emitted count honors the flag's documented
+// "cap total call sites emitted" contract (cmd/commands.go) — applying the cap
+// to each partition independently would let --max-callers=N emit up to 2N. It
+// returns what's left of the cap after the production section: the cap minus
+// the sites prod actually emitted (its pre-truncation total minus what it
+// dropped), floored at 0. The unlimited sentinel (<0) passes through so an
+// explicit no-cap request stays uncapped.
+func planTestBudget(maxCallers, prodTotal, prodTruncated int) int {
+	if maxCallers < 0 {
+		return maxCallers
+	}
+	if rem := maxCallers - (prodTotal - prodTruncated); rem > 0 {
+		return rem
+	}
+	return 0
 }
 
 // planBuildCallSites groups ordered refs by the ref file's package directory,

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -49,19 +49,28 @@ var (
 // (no index, symbol not found, ambiguous, zero callers on delete uses the
 // SafeToDelete fields) — plan is never a gate, so every such path exits 0.
 type PlanResult struct {
-	Message        string         `json:"message,omitempty"`
-	Symbol         string         `json:"symbol,omitempty"`
-	ID             string         `json:"id,omitempty"`
-	Change         string         `json:"change"`
-	Def            *PlanDef       `json:"def,omitempty"`
-	CallSites      []PlanPkgGroup `json:"call_sites,omitempty"`
-	MustRemove     bool           `json:"must_remove,omitempty"`
-	SafeToDelete   bool           `json:"safe_to_delete,omitempty"`
-	TestOnlyRefs   int            `json:"test_only_refs,omitempty"`
-	Tests          PlanTests      `json:"tests"`
-	Churn          []string       `json:"churn,omitempty"`
-	ChurnTruncated int            `json:"churn_truncated,omitempty"`
-	Truncated      int            `json:"truncated_call_sites,omitempty"`
+	Message   string         `json:"message,omitempty"`
+	Symbol    string         `json:"symbol,omitempty"`
+	ID        string         `json:"id,omitempty"`
+	Change    string         `json:"change"`
+	Def       *PlanDef       `json:"def,omitempty"`
+	CallSites []PlanPkgGroup `json:"call_sites,omitempty"`
+
+	// TestCallSites is the _test.go call sites on the signature/delete paths —
+	// the raw ref-location view that catches test helpers and >=3-hop chains
+	// FindTests' 2-hop, Test*-named TESTS list can't reach. Superset-safe: it
+	// may overlap TESTS (which lists test *functions*, not ref locations).
+	// Absent on the behavior path and the delete fast path (D4: earn the bytes).
+	TestCallSites          []PlanPkgGroup `json:"test_call_sites,omitempty"`
+	TestCallSitesTruncated int            `json:"test_call_sites_truncated,omitempty"`
+
+	MustRemove     bool      `json:"must_remove,omitempty"`
+	SafeToDelete   bool      `json:"safe_to_delete,omitempty"`
+	TestOnlyRefs   int       `json:"test_only_refs,omitempty"`
+	Tests          PlanTests `json:"tests"`
+	Churn          []string  `json:"churn,omitempty"`
+	ChurnTruncated int       `json:"churn_truncated,omitempty"`
+	Truncated      int       `json:"truncated_call_sites,omitempty"`
 
 	// TotalCallSites/TotalPkgs are the pre-truncation totals the header
 	// reports ("def + N call sites in K pkgs"); CallSites may hold fewer once
@@ -241,12 +250,16 @@ func runPlan(change string, args []string) error {
 			// Safe-to-delete fast path: list the test-only refs and stop.
 			result.SafeToDelete = true
 			result.TestOnlyRefs = testOnly
-			result.CallSites, _, _, _ = planBuildCallSites(planFilterRefs(refs, true), -1)
+			_, testRefs := planPartitionRefs(refs)
+			result.CallSites, _, _, _ = planBuildCallSites(testRefs, -1)
 			break
 		}
 		result.MustRemove = true
+		prodRefs, testRefs := planPartitionRefs(refs)
 		result.CallSites, result.Truncated, result.TotalCallSites, result.TotalPkgs =
-			planBuildCallSites(planFilterRefs(refs, false), planMaxCallers)
+			planBuildCallSites(prodRefs, planMaxCallers)
+		result.TestCallSites, result.TestCallSitesTruncated, _, _ =
+			planBuildCallSites(testRefs, planMaxCallers)
 		if err := buildTests(); err != nil {
 			return internalErr(err)
 		}
@@ -256,8 +269,11 @@ func runPlan(change string, args []string) error {
 		if err != nil {
 			return internalErr(err)
 		}
+		prodRefs, testRefs := planPartitionRefs(refs)
 		result.CallSites, result.Truncated, result.TotalCallSites, result.TotalPkgs =
-			planBuildCallSites(planFilterRefs(refs, false), planMaxCallers)
+			planBuildCallSites(prodRefs, planMaxCallers)
+		result.TestCallSites, result.TestCallSitesTruncated, _, _ =
+			planBuildCallSites(testRefs, planMaxCallers)
 		if err := buildTests(); err != nil {
 			return internalErr(err)
 		}
@@ -331,18 +347,20 @@ func planAmbiguousMessage(name string, symbols []query.SymbolRow) string {
 	return b.String()
 }
 
-// planFilterRefs splits FindCallSites rows on IsTest. wantTest=true keeps only
-// test-file refs (delete fast path); false keeps only production call sites.
-func planFilterRefs(refs []query.RefRow, wantTest bool) []query.RefRow {
-	// Reuse refs' backing array — callers pass refs once and discard it, and
-	// the filter only ever shrinks (out never overtakes the read index).
-	out := refs[:0]
+// planPartitionRefs splits FindCallSites rows on IsTest in one pass into two
+// fresh slices, so BOTH partitions survive: the signature/delete paths render
+// production sites AND, separately, the _test.go refs the TESTS list can't reach
+// (helpers, >=3-hop chains). Fresh slices — neither partition aliases refs'
+// backing array, so callers may keep and render both.
+func planPartitionRefs(refs []query.RefRow) (prod, test []query.RefRow) {
 	for i := range refs {
-		if refs[i].IsTest == wantTest {
-			out = append(out, refs[i])
+		if refs[i].IsTest {
+			test = append(test, refs[i])
+		} else {
+			prod = append(prod, refs[i])
 		}
 	}
-	return out
+	return prod, test
 }
 
 // planBuildCallSites groups ordered refs by the ref file's package directory,
@@ -461,6 +479,7 @@ func writePlanText(p PlanResult) error {
 	case p.Change == planChangeDelete:
 		writePlanCallSites(&b, p, "MUST REMOVE — every ref below, else the build breaks")
 		writePlanTests(&b, p, "TESTS — drop or rewrite")
+		writePlanTestCallSites(&b, p, "TEST-FILE REFS — remove these too (ref-level view; catches helpers/≥3-hop the TESTS list misses)")
 		writePlanChurn(&b, p)
 	case p.Change == planChangeBehavior:
 		writePlanTests(&b, p, "TESTS — no signature change; verify these still pass / add cases for new behavior")
@@ -468,6 +487,7 @@ func writePlanText(p PlanResult) error {
 	default: // signature
 		writePlanCallSites(&b, p, "CALL SITES — edit every one to match the new signature")
 		writePlanTests(&b, p, "TESTS — update/verify after editing")
+		writePlanTestCallSites(&b, p, "TEST-FILE REFS — edit these too (ref-level view; catches helpers/≥3-hop the TESTS list misses)")
 		writePlanChurn(&b, p)
 	}
 
@@ -522,7 +542,32 @@ func writePlanCallSites(b *strings.Builder, p PlanResult, header string) {
 		return
 	}
 	fmt.Fprintln(b, header)
-	for _, g := range p.CallSites {
+	writePlanSiteGroups(b, p.CallSites)
+	if p.Truncated > 0 {
+		fmt.Fprintf(b, "  +%d more call sites (raise --max-callers)\n", p.Truncated)
+	}
+}
+
+// writePlanTestCallSites renders the _test.go call sites the TESTS list can't
+// reach — test helpers and >=3-hop chains past FindTests' 2-hop, Test*-named
+// cap. A ref-location view (distinct from TESTS' test-function view), so it may
+// overlap TESTS; the header says so. Omitted when empty (D4).
+func writePlanTestCallSites(b *strings.Builder, p PlanResult, header string) {
+	if len(p.TestCallSites) == 0 && p.TestCallSitesTruncated == 0 {
+		return
+	}
+	fmt.Fprintln(b, header)
+	writePlanSiteGroups(b, p.TestCallSites)
+	if p.TestCallSitesTruncated > 0 {
+		fmt.Fprintf(b, "  +%d more test-file refs (raise --max-callers)\n", p.TestCallSitesTruncated)
+	}
+}
+
+// writePlanSiteGroups renders package-grouped call sites — the body shared by
+// the production CALL SITES and the TEST-FILE REFS sections. The header and the
+// "+N more" footer differ per section, so callers own those; this owns the rows.
+func writePlanSiteGroups(b *strings.Builder, groups []PlanPkgGroup) {
+	for _, g := range groups {
 		fmt.Fprintf(b, "%s (%d)\n", g.Pkg, len(g.Sites))
 		for _, s := range g.Sites {
 			id := s.ID
@@ -540,9 +585,6 @@ func writePlanCallSites(b *strings.Builder, p PlanResult, header string) {
 			}
 			fmt.Fprintln(b, line)
 		}
-	}
-	if p.Truncated > 0 {
-		fmt.Fprintf(b, "  +%d more call sites (raise --max-callers)\n", p.Truncated)
 	}
 }
 

--- a/test/blackbox/plan_testrefs_test.go
+++ b/test/blackbox/plan_testrefs_test.go
@@ -147,6 +147,85 @@ func TestPlan_TestFileRefsBeyondFindTests_Delete(t *testing.T) {
 	assertTestCallSiteEnclosing(t, r, "deepHelper")
 }
 
+// countPlanSites totals the emitted sites across the given result section
+// ("call_sites" or "test_call_sites"), summing each package group's sites.
+func countPlanSites(t *testing.T, result map[string]any, section string) int {
+	t.Helper()
+	groups, ok := result[section]
+	if !ok || groups == nil {
+		return 0
+	}
+	n := 0
+	for _, g := range requireSlice(t, groups, section) {
+		gm := requireMap(t, g, "group")
+		n += len(requireSlice(t, gm["sites"], "sites"))
+	}
+	return n
+}
+
+// writePlanBudgetFixture builds a module with 3 production call sites AND 2
+// test-file call sites of Target — enough that applying --max-callers to each
+// partition independently would over-emit.
+func writePlanBudgetFixture(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/planbudget\n\ngo 1.20\n")
+	writeFile(t, filepath.Join(repoDir, "foo", "foo.go"), `package foo
+
+func Target(id string) string { return "t:" + id }
+
+func Serve1(id string) string { return Target(id) }
+func Serve2(id string) string { return Target(id) }
+func Serve3(id string) string { return Target(id) }
+`)
+	writeFile(t, filepath.Join(repoDir, "foo", "foo_test.go"), `package foo
+
+import "testing"
+
+func TestA(t *testing.T) {
+	if Target("x") == "" {
+		t.Fatal("x")
+	}
+}
+
+func TestB(t *testing.T) {
+	if Target("y") == "" {
+		t.Fatal("y")
+	}
+}
+`)
+	return repoDir
+}
+
+// TestPlan_MaxCallersCapsCombinedSections proves --max-callers bounds the TOTAL
+// call sites emitted (commands.go contract), not each of the production and
+// test-ref sections independently. With 3 prod + 2 test sites and
+// --max-callers=4, the pre-fix code emitted 3+2=5; the shared budget caps the
+// combined output at 4.
+func TestPlan_MaxCallersCapsCombinedSections(t *testing.T) {
+	repoDir := writePlanBudgetFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	const maxCallers = 4
+	jout, jstderr, jexit := run(t, repoDir, "plan", "Target", "--max-callers", "4")
+	if jexit != 0 {
+		t.Fatalf("plan json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	r := requireMap(t, requireSlice(t, assertEnvelope(t, jout, "plan")["results"], "results")[0], "results[0]")
+	prod := countPlanSites(t, r, "call_sites")
+	test := countPlanSites(t, r, "test_call_sites")
+	if prod+test > maxCallers {
+		t.Fatalf("combined emitted sites = %d (prod %d + test %d); --max-callers=%d must cap the total",
+			prod+test, prod, test, maxCallers)
+	}
+	// The production section is primary — it should still claim its share.
+	if prod == 0 {
+		t.Fatalf("production call_sites empty; expected the primary section to keep its budget\nresult: %v", r)
+	}
+}
+
 // TestPlan_TestFileRefs_BehaviorOmits guards the scope: a behavior change edits
 // no call sites, so it carries no TEST-FILE REFS section.
 func TestPlan_TestFileRefs_BehaviorOmits(t *testing.T) {

--- a/test/blackbox/plan_testrefs_test.go
+++ b/test/blackbox/plan_testrefs_test.go
@@ -1,0 +1,165 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writePlanTestRefFixture builds a module where Target has a production caller
+// (foo.Serve) AND a >=3-hop test chain that FindTests' 2-hop reach can't surface:
+//
+//	TestDeep -> midHelper -> deepHelper -> Target
+//
+// The `deepHelper -> Target` ref lives in foo_test.go. On the signature and
+// delete (MustRemove) paths the old code dropped every _test.go ref and leaned
+// on the TESTS list to recover them — but FindTests only reaches Test*-named
+// funcs within 2 hops, so this ref surfaced NOWHERE, while the worklist header
+// still promised "edit/remove every ref". `deepHelper` is the sentinel: it is
+// not a production call site, not a Test* func, and not a churn path, so it
+// appears in plan output ONLY via the TEST-FILE REFS section this bead adds.
+//
+// Self-contained (own module, own helper) so it shares nothing with
+// plan_test.go's writePlanFixture — a change here can't perturb that fixture's
+// goldens/assertions and vice-versa.
+func writePlanTestRefFixture(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/planrefs\n\ngo 1.20\n")
+
+	writeFile(t, filepath.Join(repoDir, "foo", "foo.go"), `package foo
+
+func Target(id string) string {
+	return "t:" + id
+}
+
+// Serve is a production (non-test) caller, so Target is NOT delete-safe: plan
+// takes the MustRemove / signature CALL SITES path, not the fast path.
+func Serve(id string) string {
+	return Target(id)
+}
+`)
+
+	writeFile(t, filepath.Join(repoDir, "foo", "foo_test.go"), `package foo
+
+import "testing"
+
+// deepHelper directly refs Target but sits 2 hops below any Test* func — past
+// FindTests' 2-hop reach, so the TESTS list never names this ref.
+func deepHelper(id string) string {
+	return Target(id)
+}
+
+func midHelper(id string) string {
+	return deepHelper(id)
+}
+
+func TestDeep(t *testing.T) {
+	if midHelper("x") == "" {
+		t.Fatal("x")
+	}
+}
+`)
+
+	return repoDir
+}
+
+// assertTestCallSiteEnclosing fails unless results[0].test_call_sites carries a
+// site enclosed by the named function.
+func assertTestCallSiteEnclosing(t *testing.T, result map[string]any, enclosing string) {
+	t.Helper()
+	groups, ok := result["test_call_sites"]
+	if !ok || groups == nil {
+		t.Fatalf("test_call_sites absent; want a site enclosed by %q\nresult: %v", enclosing, result)
+	}
+	for _, g := range requireSlice(t, groups, "test_call_sites") {
+		gm := requireMap(t, g, "group")
+		for _, s := range requireSlice(t, gm["sites"], "sites") {
+			sm := requireMap(t, s, "site")
+			if enc, _ := sm["enclosing"].(string); enc == enclosing {
+				return
+			}
+		}
+	}
+	t.Fatalf("no test_call_sites entry enclosed by %q\nresult: %v", enclosing, result)
+}
+
+// TestPlan_TestFileRefsBeyondFindTests_Signature proves the >=3-hop test ref
+// (deepHelper -> Target) is surfaced on the signature path, in text and JSON.
+func TestPlan_TestFileRefsBeyondFindTests_Signature(t *testing.T) {
+	repoDir := writePlanTestRefFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "TEST-FILE REFS") {
+		t.Fatalf("signature must surface a TEST-FILE REFS section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "deepHelper") {
+		t.Fatalf("signature must list the >=3-hop test ref (deepHelper), got:\n%s", out)
+	}
+
+	jout, jstderr, jexit := run(t, repoDir, "plan", "Target")
+	if jexit != 0 {
+		t.Fatalf("plan json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	r := requireMap(t, requireSlice(t, assertEnvelope(t, jout, "plan")["results"], "results")[0], "results[0]")
+	assertTestCallSiteEnclosing(t, r, "deepHelper")
+}
+
+// TestPlan_TestFileRefsBeyondFindTests_Delete proves the same ref is surfaced on
+// the delete MustRemove path (Target has a production caller, so not the fast
+// path).
+func TestPlan_TestFileRefsBeyondFindTests_Delete(t *testing.T) {
+	repoDir := writePlanTestRefFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target", "--change=delete")
+	if exit != 0 {
+		t.Fatalf("plan exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	out := string(stdout)
+	if !strings.Contains(out, "MUST REMOVE") {
+		t.Fatalf("delete with a production caller must be MustRemove, got:\n%s", out)
+	}
+	if !strings.Contains(out, "TEST-FILE REFS") {
+		t.Fatalf("delete must surface a TEST-FILE REFS section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "deepHelper") {
+		t.Fatalf("delete must list the >=3-hop test ref (deepHelper), got:\n%s", out)
+	}
+
+	jout, jstderr, jexit := run(t, repoDir, "plan", "Target", "--change=delete")
+	if jexit != 0 {
+		t.Fatalf("plan delete json exit %d stderr=%s", jexit, string(jstderr))
+	}
+	r := requireMap(t, requireSlice(t, assertEnvelope(t, jout, "plan")["results"], "results")[0], "results[0]")
+	assertTestCallSiteEnclosing(t, r, "deepHelper")
+}
+
+// TestPlan_TestFileRefs_BehaviorOmits guards the scope: a behavior change edits
+// no call sites, so it carries no TEST-FILE REFS section.
+func TestPlan_TestFileRefs_BehaviorOmits(t *testing.T) {
+	repoDir := writePlanTestRefFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exit := runRaw(t, repoDir, "plan", "Target", "--change=behavior")
+	if exit != 0 {
+		t.Fatalf("behavior exit %d stderr=%s stdout=%s", exit, string(stderr), string(stdout))
+	}
+	if strings.Contains(string(stdout), "TEST-FILE REFS") {
+		t.Fatalf("behavior change must omit TEST-FILE REFS, got:\n%s", string(stdout))
+	}
+}


### PR DESCRIPTION
## What

`snipe plan --change=signature` and `--change=delete` now emit a **TEST-FILE REFS** section listing the `_test.go` call sites the TESTS list can't reach — test helpers and ≥3-hop chains past FindTests' 2-hop, `Test*`-named cap.

## Why

On the non-zero-production-callers path, plan dropped every `_test.go` ref (`planFilterRefs(refs, false)`) and leaned on the TESTS section to recover them. But TESTS uses `FindTests`, a 2-hop cap over `Test*/Benchmark*/Fuzz*/Example*` funcs. So a test **helper** (non-`Test*`-named) with a direct ref, or a ≥3-hop chain (`TestX → h1 → h2 → Target`), surfaced **nowhere** — while the worklist header still promised "edit/remove every ref". Applying the worklist then broke `go test` on an unlisted ref.

## How

Option (a), contained — no shared query touched:
- `FindCallSites` already returns every ref with an `IsTest` flag; those test refs were fetched then discarded. New `planPartitionRefs` splits them into two fresh slices (replacing the destructive-reuse `planFilterRefs`), so both production and test call sites survive.
- Render test-file call sites as a distinct **TEST-FILE REFS** section (signature + delete MustRemove paths). Ref-location view — may overlap TESTS (which lists test *functions*, not ref locations); the header says so. Text renderer shares the site-group body with CALL SITES via an extracted `writePlanSiteGroups`.
- New JSON field `test_call_sites` (+ `test_call_sites_truncated`), both `omitempty` — absent when there are no test-file refs (D4).

Unchanged: production call sites, TESTS, the safe-delete fast path, the behavior path (no signature change → no section). No SQL added; no change to `internal/query`.

## Proof

New `test/blackbox/plan_testrefs_test.go`: a self-contained fixture with a ≥3-hop chain (`TestDeep → midHelper → deepHelper → Target`) plus a production caller (`Serve`). `deepHelper` is a sentinel that appears in plan output only via the new section — asserted present in signature + delete (text and JSON), absent for behavior. `make audit` green (vet/lint/race/blackbox/eval/vuln).

Closes: sn-8f6q.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **TEST-FILE REFS** section to plan results for signature and deletion changes.
  * JSON output now includes test-file call-site references and truncation details.
  * Test-file references are included even when they are beyond standard test discovery paths.
  * The `--max-callers` limit now applies collectively across production and test-file references.

* **Bug Fixes**
  * Behavior-change plans continue to omit test-file references when no call sites are generated.

* **Tests**
  * Added coverage for test-file reference discovery, deletion and signature plans, and combined caller limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->