### PR TITLE
Close 3 AXI agent-ergonomics gaps: exit codes, truncation hints, no-prompt keyring

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -252,6 +252,15 @@ func Execute() {
 		kong.Description(rootHelp),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{Compact: false}),
+		// Own the exit code (AXI #6): --help still exits 0, but a flag/usage
+		// error exits a deliberate 2 instead of kong's default. Run and
+		// error-envelope exits (1) are handled below, bypassing kong.
+		kong.Exit(func(code int) {
+			if code != 0 {
+				code = 2
+			}
+			os.Exit(code)
+		}),
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -288,11 +297,24 @@ func Execute() {
 
 	ctx, err := parser.Parse(args)
 	if err != nil {
+		// Prints usage (UsageOnError) then exits 2 via the kong.Exit hook above.
 		parser.FatalIfErrorf(err)
 	}
 
-	err = ctx.Run()
-	ctx.FatalIfErrorf(err)
+	if err := ctx.Run(); err != nil {
+		// An internal Go error from a command (rare — most command-level
+		// problems are emitted via WriteError and return nil). Exit 1 directly,
+		// bypassing kong so the usage-error hook can't remap it to 2.
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// The command ran, but may have emitted an error envelope (e.g. symbol not
+	// found) and returned nil. Reflect that in the exit code so agents chaining
+	// commands can detect failure (AXI #6).
+	if output.ProcessErrored() {
+		os.Exit(1)
+	}
 }
 
 // GetContext returns the command context (with timeout and signal handling).

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -107,59 +107,71 @@ type EmbeddingResponse struct {
 }
 
 // HasCredentials checks if embedding credentials are available.
-// Returns true if the keychain holds a voyage key or the SNIPE_VOYAGE_API_KEY
-// env var is set. An unreadable keychain (locked/denied — keyring.ErrUnreadable)
-// is NOT treated as "credentials available": the probe falls through to the env
-// var and records the locked state in LastProbeErr so doctor can name it,
-// keeping this probe in agreement with resolveCredentials.
+// Returns true if the SNIPE_VOYAGE_API_KEY env var is set or the keychain holds
+// a voyage key. The env var is checked FIRST so an env-provisioned process never
+// touches the keychain (AXI #6: never prompt — a `security` read can pop an OS
+// unlock/allow dialog). An unreadable keychain (locked/denied — ErrUnreadable)
+// is NOT treated as "credentials available": the locked state is recorded in
+// LastProbeErr so doctor can name it, keeping this probe in agreement with
+// resolveCredentials.
 func HasCredentials() bool {
 	recordProbe(nil)
+	if envAPIKey() != "" {
+		return true
+	}
 	if store, err := credStore(); err == nil {
 		ok, hasErr := store.Has(keyringAccount)
 		if hasErr == nil && ok {
 			return true
 		}
 		if hasErr != nil && errors.Is(hasErr, keyring.ErrUnreadable) {
-			// Locked or denied keychain — not confirmation of absence.
-			// Record it and consult the env var below.
+			// Locked or denied keychain — not confirmation of absence. Record it
+			// so doctor can name the state.
 			recordProbe(hasErr)
 		}
 	}
-	return envAPIKey() != ""
+	return false
 }
 
-// resolveCredentials reads the API key keychain-first, then the
-// SNIPE_VOYAGE_API_KEY env var. Model and endpoint are config, not secrets —
-// plain env only. Returns (apiKey, model, endpoint, error).
+// resolveCredentials reads the API key env-first (SNIPE_VOYAGE_API_KEY), then
+// the keychain. Env-first means an env-provisioned process — agents, CI, orca —
+// never execs `security`, so it can never trigger an OS keychain prompt (AXI #6:
+// never prompt for interactive input). The keychain is consulted only as a
+// fallback for humans who stored the key there. Model and endpoint are config,
+// not secrets — plain env only. Returns (apiKey, model, endpoint, error).
 func resolveCredentials() (string, string, string, error) {
-	store, err := credStore()
-	if err != nil {
-		return "", "", "", err
-	}
-	apiKey, keyErr := store.GetOrEnv(keyringAccount, "SNIPE_VOYAGE_API_KEY")
-	switch {
-	case keyErr == nil:
-	case errors.Is(keyErr, keyring.ErrNotFound), errors.Is(keyErr, keyring.ErrUnsupported):
-		// Confirmed absent, or no keychain backend: GetOrEnv already
-		// consulted the env var; nothing left to try.
-	case errors.Is(keyErr, keyring.ErrUnreadable):
-		// Locked or denied keychain. snipe index can run headless or in the
-		// background, so a hard error here would be wrong — but a silent
-		// downgrade violates the keyring contract. Warn LOUDLY once per
-		// process, then consult the env var explicitly (GetOrEnv does not fall
-		// through on ErrUnreadable). If nothing else exists, embeddings
-		// switch off via the caller's existing Warning path.
-		recordProbe(keyErr)
-		warnUnreadableOnce(keyringAccount, keyErr)
-		apiKey = envAPIKey()
-	default:
-		return "", "", "", fmt.Errorf("reading voyage API key from keychain: %w", keyErr)
+	apiKey := envAPIKey()
+	if apiKey == "" {
+		// Env absent — fall back to the keychain. This is the only path that
+		// execs `security`; skipping it whenever the env var is set is what
+		// keeps automated invocations prompt-free.
+		store, err := credStore()
+		if err != nil {
+			return "", "", "", err
+		}
+		key, keyErr := store.Get(keyringAccount)
+		switch {
+		case keyErr == nil:
+			apiKey = key
+		case errors.Is(keyErr, keyring.ErrNotFound), errors.Is(keyErr, keyring.ErrUnsupported):
+			// Confirmed absent, or no keychain backend (incl. KEYRING_DISABLE):
+			// nothing left to try.
+		case errors.Is(keyErr, keyring.ErrUnreadable):
+			// Locked or denied keychain. snipe index can run headless or in the
+			// background, so a hard error here would be wrong — but a silent
+			// downgrade violates the keyring contract. Warn LOUDLY once per
+			// process; embeddings then switch off via the caller's Warning path.
+			recordProbe(keyErr)
+			warnUnreadableOnce(keyringAccount, keyErr)
+		default:
+			return "", "", "", fmt.Errorf("reading voyage API key from keychain: %w", keyErr)
+		}
 	}
 	model := os.Getenv("VOYAGE_MODEL")
 	endpoint := os.Getenv("VOYAGE_API_URL")
 
 	if apiKey == "" {
-		return "", "", "", fmt.Errorf("no API key: store one in the keychain (security add-generic-password -U -s snipe -a voyage -w KEY) or set SNIPE_VOYAGE_API_KEY")
+		return "", "", "", fmt.Errorf("no API key: set SNIPE_VOYAGE_API_KEY or store one in the keychain (security add-generic-password -U -s snipe -a voyage -w KEY)")
 	}
 	if model == "" {
 		model = "voyage-code-3"
@@ -168,7 +180,7 @@ func resolveCredentials() (string, string, string, error) {
 }
 
 // NewClient creates a new embedding client.
-// It reads the API key keychain-first, falling back to SNIPE_VOYAGE_API_KEY.
+// It reads the API key env-first (SNIPE_VOYAGE_API_KEY), falling back to the keychain.
 func NewClient() (*Client, error) {
 	apiKey, model, endpoint, err := resolveCredentials()
 	if err != nil {

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -25,8 +25,9 @@ const (
 
 // credStore returns the keychain store for snipe's secrets. keyring.New only
 // fails on an empty service name, so the error is effectively unreachable
-// with the literal above.
-func credStore() (*keyring.Store, error) {
+// with the literal above. A var, not a func, so tests can assert it is never
+// opened when the env key short-circuits the keychain path.
+var credStore = func() (*keyring.Store, error) {
 	return keyring.New(keyringService)
 }
 
@@ -147,7 +148,7 @@ func resolveCredentials() (string, string, string, error) {
 		// keeps automated invocations prompt-free.
 		store, err := credStore()
 		if err != nil {
-			return "", "", "", err
+			return "", "", "", fmt.Errorf("opening keyring store: %w", err)
 		}
 		key, keyErr := store.Get(keyringAccount)
 		switch {

--- a/internal/embed/client_test.go
+++ b/internal/embed/client_test.go
@@ -179,6 +179,30 @@ func TestCredentials_IgnoresPlaintextFile(t *testing.T) {
 	}
 }
 
+// TestCredentials_EnvFirst locks the env-first ordering (AXI #6: never prompt).
+// When SNIPE_VOYAGE_API_KEY is set, resolveCredentials returns it and
+// HasCredentials reports true WITHOUT consulting the keychain — so an
+// env-provisioned process (agent, CI, orca) never execs `security` and can never
+// trip an OS unlock/allow dialog. KEYRING_DISABLE is left UNSET to prove the env
+// var alone short-circuits even with a keychain backend available; that
+// short-circuit is also what keeps this test hermetic across platforms.
+func TestCredentials_EnvFirst(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KEYRING_DISABLE", "")
+	t.Setenv("SNIPE_VOYAGE_API_KEY", "env-provided-key")
+
+	if !HasCredentials() {
+		t.Error("HasCredentials should report true when the env var is set")
+	}
+	key, _, _, err := resolveCredentials()
+	if err != nil {
+		t.Fatalf("resolveCredentials: %v", err)
+	}
+	if key != "env-provided-key" {
+		t.Errorf("apiKey = %q, want the env-provided key (env must win over keychain)", key)
+	}
+}
+
 func TestEmbedOne_ReturnsFirstEmbedding(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(EmbeddingResponse{

--- a/internal/embed/client_test.go
+++ b/internal/embed/client_test.go
@@ -3,6 +3,7 @@ package embed
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dkoosis/keyring"
 )
 
 func testClient(endpoint string) *Client {
@@ -190,6 +193,16 @@ func TestCredentials_EnvFirst(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("KEYRING_DISABLE", "")
 	t.Setenv("SNIPE_VOYAGE_API_KEY", "env-provided-key")
+
+	// The no-prompt contract is not "env wins" but "the keychain is never
+	// opened": opening it is what execs `security` and can hang a headless
+	// agent. Fail if credStore is touched at all while the env key is set.
+	orig := credStore
+	t.Cleanup(func() { credStore = orig })
+	credStore = func() (*keyring.Store, error) {
+		t.Error("credStore opened despite SNIPE_VOYAGE_API_KEY being set — this can exec `security` and hang headless agents")
+		return nil, errors.New("credStore must not be opened when the env key is set")
+	}
 
 	if !HasCredentials() {
 		t.Error("HasCredentials should report true when the env var is set")

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -35,6 +35,19 @@ var showSuggestionsEnabled = false
 // SetShowSuggestions configures suggestion output for Claude mode.
 func SetShowSuggestions(v bool) { showSuggestionsEnabled = v }
 
+// processErrored records whether any emitted response signalled failure, so
+// Execute can exit non-zero (AXI #6: agents gate on the exit code). A valid
+// empty answer (Ok:true, zero results) leaves this false and keeps exit 0; an
+// error envelope (WriteError, or a WriteResponse whose Ok is false) trips it.
+var processErrored = false
+
+// ProcessErrored reports whether an error envelope was emitted this run.
+func ProcessErrored() bool { return processErrored }
+
+// ResetProcessErrored clears the error flag; for in-process tests that reuse
+// the package across cases.
+func ResetProcessErrored() { processErrored = false }
+
 // Writer handles output formatting for LLM consumers.
 type Writer struct {
 	out    io.Writer
@@ -64,6 +77,9 @@ func NewWriter(out io.Writer, format OutputFormat) *Writer {
 func (w *Writer) WriteResponse(resp any) error {
 	if m, ok := resp.(interface{ TelemetryCommand() string }); ok {
 		telemetry.Emit(m.TelemetryCommand(), "ok", time.Since(w.start).Milliseconds())
+	}
+	if r, ok := resp.(interface{ IsOk() bool }); ok && !r.IsOk() {
+		processErrored = true
 	}
 	switch w.format {
 	case OutputJSON:
@@ -909,6 +925,7 @@ func shortPkg(p string) string {
 
 // WriteError writes an error response
 func (w *Writer) WriteError(command string, err *Error) error {
+	processErrored = true
 	telemetry.Emit(command, err.Code, time.Since(w.start).Milliseconds())
 	if err.Next == nil {
 		err.Next = DefaultNextForCode(err.Code)

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -247,7 +247,16 @@ func (w *Writer) writeClaudeMeta(b *strings.Builder, meta Meta) {
 	// Only include metadata that helps Claude, skip noise
 	var parts []string
 	if meta.Truncated {
-		parts = append(parts, "truncated")
+		// Name the recovery lever so the agent can fetch the rest (AXI #3).
+		// Most commands truncate at --limit; the token-budget path (no --limit)
+		// falls through to a hint naming both possible levers.
+		switch {
+		case meta.Limit > 0 && meta.Total >= meta.Limit:
+			parts = append(parts, fmt.Sprintf("truncated at --limit=%d (raise --limit or --offset %d for more)",
+				meta.Limit, meta.Offset+meta.Total))
+		default:
+			parts = append(parts, "truncated (raise --max-tokens or --limit for the rest)")
+		}
 	}
 	if len(meta.StaleFiles) > 0 {
 		parts = append(parts, fmt.Sprintf("%d stale files", len(meta.StaleFiles)))
@@ -1278,7 +1287,11 @@ func truncateBodySemantic(result *Result, maxLines int) bool {
 		truncateAt = maxLines // Fallback to hard limit
 	}
 
-	result.Body = strings.Join(lines[:truncateAt], "\n") + "\n// ... truncated"
+	// Name the total and the recovery lever so the agent knows content is
+	// missing AND how to get it (AXI #3): --max-tokens=0 disables the budget.
+	result.Body = strings.Join(lines[:truncateAt], "\n") +
+		fmt.Sprintf("\n// ... +%d more lines (%d total — use --max-tokens=0 for full)",
+			len(lines)-truncateAt, len(lines))
 	return true
 }
 

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -28,6 +28,12 @@ func (r Response[T]) TelemetryCommand() string {
 	return r.Meta.Command
 }
 
+// IsOk reports whether the response signalled success, so the Writer can set
+// the process exit code (AXI #6) without knowing every Response[T] instance.
+func (r Response[T]) IsOk() bool {
+	return r.Ok
+}
+
 // Suggestion provides actionable next steps for LLM consumers
 type Suggestion struct {
 	Command     string `json:"command"`             // The suggested snipe command

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -407,13 +407,14 @@ func TestTruncateBodySemantic(t *testing.T) {
 		if !truncated {
 			t.Error("should truncate")
 		}
-		if !strings.Contains(result.Body, "// ... truncated") {
-			t.Error("should contain truncation marker")
+		// The marker names the omitted-line count and the recovery lever (AXI #3).
+		if !strings.Contains(result.Body, "more lines") || !strings.Contains(result.Body, "--max-tokens=0") {
+			t.Errorf("marker should state omitted count and recovery flag, got %q", result.Body)
 		}
 		lines := strings.Split(result.Body, "\n")
 		lastContentLine := ""
 		for i := len(lines) - 1; i >= 0; i-- {
-			if !strings.Contains(lines[i], "truncated") && strings.TrimSpace(lines[i]) != "" {
+			if !strings.HasPrefix(strings.TrimSpace(lines[i]), "// ...") && strings.TrimSpace(lines[i]) != "" {
 				lastContentLine = strings.TrimSpace(lines[i])
 				break
 			}

--- a/test/script/script_test.go
+++ b/test/script/script_test.go
@@ -41,6 +41,7 @@ package script
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -231,6 +232,73 @@ func copyTree(src, dst string) error {
 		}
 		return os.WriteFile(target, data, info.Mode())
 	})
+}
+
+// TestExitCodeContract asserts the exact process exit codes snipe promises, so
+// agents chaining commands can gate on them (AXI #6). testscript's `! exec` only
+// distinguishes zero from non-zero; this drives the built binary directly to
+// pin the specific codes:
+//
+//	0 — success, or a valid empty answer (no results is not a failure)
+//	1 — an error envelope was emitted (e.g. symbol not found)
+//	2 — a flag / usage error (deliberate, not kong's default)
+func TestExitCodeContract(t *testing.T) {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("find repo root: %v", err)
+	}
+
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "snipe")
+	build := exec.Command("go", "build", "-o", binPath, "./")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build snipe: %v\n%s", err, out)
+	}
+
+	fixtureDir := t.TempDir()
+	if err := writeScriptFixture(fixtureDir); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	index := exec.Command(binPath, "index", fixtureDir, "--enrich=false", "--embed-mode=off")
+	index.Dir = fixtureDir
+	index.Env = append(os.Environ(), "KEYRING_DISABLE=1")
+	if out, err := index.CombinedOutput(); err != nil {
+		t.Fatalf("index fixture: %v\n%s", err, out)
+	}
+
+	run := func(args ...string) int {
+		cmd := exec.Command(binPath, args...)
+		cmd.Dir = fixtureDir
+		cmd.Env = append(os.Environ(), "KEYRING_DISABLE=1")
+		if err := cmd.Run(); err != nil {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				return ee.ExitCode()
+			}
+			t.Fatalf("run %v: %v", args, err)
+		}
+		return 0
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"success", []string{"def", "Run"}, 0},
+		{"valid empty (no callers)", []string{"callers", "Orphan"}, 0},
+		{"symbol not found", []string{"def", "ZZZNotARealSymbol"}, 1},
+		{"unknown bare command", []string{"frobnicatezzz"}, 1},
+		{"bad flag", []string{"def", "--definitely-not-a-flag"}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := run(tt.args...); got != tt.want {
+				t.Errorf("snipe %v exit = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
 }
 
 func findRepoRoot() (string, error) {

--- a/test/script/testdata/script/show.txtar
+++ b/test/script/testdata/script/show.txtar
@@ -2,7 +2,7 @@
 # The valid-ID happy path is blackbox-covered (TestShow); asserting a real ID
 # here would hardcode a hash that drifts if indexing changes. Instead we smoke
 # the default text surface of the graceful miss: a bogus ID renders a
-# not-found error (exit 0) rather than crashing.
+# not-found error envelope (exit 1, AXI #6) rather than crashing.
 cd $FIXTURE
-exec snipe show deadbeefdeadbeef
+! exec snipe show deadbeefdeadbeef
 stdout 'symbol not found: deadbeefdeadbeef'

--- a/test/script/testdata/script/sim.txtar
+++ b/test/script/testdata/script/sim.txtar
@@ -2,7 +2,9 @@
 # The fixture index is built with --embed-mode=off (zero embeddings) and no
 # Voyage key resolves, so a real semantic hit is impossible here. Per the bead
 # exemption for embedding-backed commands, we assert the graceful no-key path:
-# sim explains embeddings are unavailable and points at doctor, exit 0.
+# sim explains embeddings are unavailable and points at doctor. The command
+# could not fulfil the query, so it emits an error envelope and exits non-zero
+# (exit 1, AXI #6) — distinct from a valid empty result.
 cd $FIXTURE
-exec snipe sim Greet
+! exec snipe sim Greet
 stdout 'no API key'


### PR DESCRIPTION
Assessed snipe against [AXI's 10 agent-ergonomic CLI principles](https://axi.md/). snipe already embodies the thesis (D1/D4 == "token budget first-class") and in places exceeds it (prose default is denser than AXI's suggested TOON; JSON is opt-in). Three real gaps, fixed here as one commit each.

## 1. Deliberate exit codes (sn-9jaa) — AXI #6
Every path exited 0, including a not-found error, an unknown bare command, and a flag-parse error (kong's raw 80). Agents chaining `snipe def X && ...` couldn't detect failure.
Contract now: **0** success or valid-empty · **1** error envelope emitted · **2** flag/usage error. `TestExitCodeContract` pins the numbers via subprocess.

## 2. Truncation markers name the recovery lever (sn-9gtb) — AXI #3
A truncation signal should say content is missing *and* how to get it. `! truncated` now names the lever (`at --limit=N (raise --limit or --offset M for more)` vs `raise --max-tokens`), and the body marker becomes `// ... +N more lines (M total — use --max-tokens=0 for full)`.

## 3. Env-first credentials so automation never prompts (sn-gpxw) — AXI #6
Credentials were read keychain-first, so even with `SNIPE_VOYAGE_API_KEY` set, snipe execed `security` first — which on a locked/ACL-untrusted keychain pops an OS dialog that hangs headless agents (the boot.md trap). Now env-first: an env-provisioned process never touches the keychain. Keychain stays a fallback for humans.

## Not changed (by-design divergences, not misses)
- Suggestions stay off by default (D4 — always-on next-steps judged token noise).
- No TOON: prose beats it for single symbols. For long uniform lists TOON *might* win — flagged as a future measurement, not done here.

## Verification
`make audit` green — race, blackbox, eval (100% file/symbol accuracy, no regression), govulncheck. New tests: `TestExitCodeContract`, `TestCredentials_EnvFirst`, updated `TestTruncateBodySemantic` + show/sim txtar smokes.

Closes: sn-9jaa, sn-9gtb, sn-gpxw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-provided API keys now take priority over saved credentials, with non-keychain fallback behavior when the env var is set.
  * Improved truncated output messaging, including clearer hints for fetching more results and how to disable truncation.

* **Bug Fixes**
  * CLI exit codes are now consistent and contract-validated across valid runs, usage/flag errors, and command-level failures.
  * Failures are more reliably surfaced (e.g., missing/invalid credentials, invalid symbol expansion, and unavailable semantic search).

* **Tests**
  * Added/updated coverage for the exit-code contract and env-first credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->