### PR TITLE
fix(json): emit results:[] not null on valid-but-empty answers (sn-wa2h)

### DIFF
--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -20,6 +21,20 @@ type Response[T any] struct {
 	Meta        Meta         `json:"meta"`
 	Error       *Error       `json:"error"`
 	Suggestions []Suggestion `json:"suggestions,omitempty"`
+}
+
+// responseJSON mirrors Response[T] but carries no methods, so MarshalJSON can
+// delegate to the encoder without recursing.
+type responseJSON[T any] Response[T]
+
+// MarshalJSON guarantees a valid-but-empty answer serializes results as [], not
+// null (AXI #5, definitive empty states). A nil slice would force every JSON
+// consumer to null-guard where an empty array would not.
+func (r Response[T]) MarshalJSON() ([]byte, error) {
+	if r.Results == nil {
+		r.Results = []T{}
+	}
+	return json.Marshal(responseJSON[T](r))
 }
 
 // TelemetryCommand exposes the command name for the usage sink without

--- a/test/blackbox/empty_state_test.go
+++ b/test/blackbox/empty_state_test.go
@@ -1,0 +1,31 @@
+//go:build blackbox
+
+package blackbox
+
+import "testing"
+
+// sn-wa2h — AXI #5 (definitive empty states). A valid-but-empty answer must
+// serialize results as [], never null. A nil slice forces every JSON consumer
+// to null-guard where an empty array would not. requireSlice fatals on a JSON
+// null (it isn't a []any), so it doubles as the regression guard: before the
+// fix, `search <no-match>` emitted "results":null and this would fail.
+func TestEmptyStateResultsIsArray(t *testing.T) {
+	repoDir, _ := writeFixture(t)
+	repoDir = canonicalRepoDir(t, repoDir)
+
+	// search runs via ripgrep, no index required — the exact case the bead cites.
+	stdout, _, exitCode := run(t, repoDir, "search", "zzz-no-such-symbol-xyz")
+	if exitCode != 0 {
+		t.Fatalf("no-match search must exit 0 (valid empty answer), got %d", exitCode)
+	}
+
+	resp := assertEnvelope(t, stdout, "search")
+	results := requireSlice(t, resp["results"], "results") // fatals on null
+	if len(results) != 0 {
+		t.Fatalf("no-match search: want 0 results, got %d", len(results))
+	}
+	meta := requireMap(t, resp["meta"], "meta")
+	if total, ok := meta["total"].(float64); !ok || total != 0 {
+		t.Fatalf("no-match search: meta.total = %v, want 0", meta["total"])
+	}
+}

--- a/testdata/golden/ambiguous_output.json
+++ b/testdata/golden/ambiguous_output.json
@@ -1,7 +1,7 @@
 {
   "protocol": 1,
   "ok": false,
-  "results": null,
+  "results": [],
   "meta": {
     "command": "def",
     "index_state": "fresh",

--- a/testdata/golden/missing_index_output.json
+++ b/testdata/golden/missing_index_output.json
@@ -1,7 +1,7 @@
 {
   "protocol": 1,
   "ok": false,
-  "results": null,
+  "results": [],
   "meta": {
     "command": "def",
     "index_state": "missing",

--- a/testdata/golden/not_found_output.json
+++ b/testdata/golden/not_found_output.json
@@ -1,7 +1,7 @@
 {
   "protocol": 1,
   "ok": false,
-  "results": null,
+  "results": [],
   "meta": {
     "command": "def",
     "index_state": "fresh",


### PR DESCRIPTION
## What

`snipe <query> --format json` with no hits serialized `"results": null`. AXI #5 (definitive empty states) wants a valid-but-empty answer to be `"results": []` — a nil slice forces every JSON consumer to null-guard where an empty array would not.

## How

Added `Response[T].MarshalJSON` that normalizes a nil `Results` slice to `[]` at the single marshal point, so every command inherits the fix (search, refs, callers, error envelopes, …). Regenerated 3 goldens (not-found / ambiguous / missing-index) that previously pinned `null`.

## Contract note

Safe against the cc-plugins `risk`/`verify` JSON contract (RealBison's judge reads `.results[0]`): that command always emits exactly one row and is unaffected. This change only touches cases that were *already* empty — null→[], never one-row→[]. `TestRiskJSONContract` stays green.

## Test

New blackbox `TestEmptyStateResultsIsArray`: `search <no-match>` must exit 0 and emit `results:[]` (requireSlice fatals on a JSON null, so it's the regression guard). `make audit` green.

Closes: sn-wa2h