### PR TITLE
feat(doctor): --probe live-checks external API keys

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -564,10 +564,12 @@ func (c *StatusCmd) Run() error {
 	return runStatus()
 }
 
-type DoctorCmd struct{}
+type DoctorCmd struct {
+	Probe bool `help:"Live-probe external APIs (e.g. Voyage embeddings) to verify keys work, not just that they're present. Makes a network call."`
+}
 
 func (c *DoctorCmd) Run() error {
-	return runDoctor()
+	return runDoctor(c.Probe)
 }
 
 // --- Misc ---

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,12 +36,13 @@ const (
 	DoctorIndexStale       = "INDEX_STALE"
 	DoctorOrphanedRefs     = "ORPHANED_REFS"
 	DoctorEmbedAuthMissing = "EMBED_AUTH_MISSING"
+	DoctorEmbedProbeFailed = "EMBED_PROBE_FAILED"
 )
 
 // Common remediation commands.
 const remediationReindex = "snipe index"
 
-func runDoctor() error {
+func runDoctor(probe bool) error {
 	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
 	allOK := true
@@ -67,9 +69,12 @@ func runDoctor() error {
 		allOK = false
 	}
 
-	// Check embeddings credentials
-	embedCheck := checkEmbeddings()
+	// Check embeddings credentials (and, with --probe, that they work)
+	embedCheck := checkEmbeddings(probe)
 	checks = append(checks, embedCheck)
+	if !embedCheck.OK {
+		allOK = false
+	}
 
 	// Check orphaned references (only if index exists)
 	if indexCheck.OK {
@@ -257,7 +262,7 @@ func checkGoToolchain() DoctorCheck {
 	return check
 }
 
-func checkEmbeddings() DoctorCheck {
+func checkEmbeddings(probe bool) DoctorCheck {
 	check := DoctorCheck{
 		Name: "embeddings",
 	}
@@ -268,6 +273,9 @@ func checkEmbeddings() DoctorCheck {
 	case has && probeErr == nil:
 		check.OK = true
 		check.Message = "embedding credentials available"
+		if probe {
+			liveProbeEmbeddings(&check)
+		}
 	case has && probeErr != nil:
 		// Keychain is locked/unreadable but the SNIPE_VOYAGE_API_KEY env var
 		// covers it — say so instead of a false "credentials available".
@@ -275,6 +283,9 @@ func checkEmbeddings() DoctorCheck {
 		check.Message = "keychain locked or unreadable — using env credentials"
 		check.Details = probeErr.Error()
 		check.Remediation = "security unlock-keychain"
+		if probe {
+			liveProbeEmbeddings(&check)
+		}
 	case probeErr != nil:
 		check.OK = true // Not a failure, just informational
 		check.Code = DoctorEmbedAuthMissing
@@ -289,6 +300,25 @@ func checkEmbeddings() DoctorCheck {
 	}
 
 	return check
+}
+
+// liveProbeEmbeddings makes one minimal Voyage request to confirm the resolved
+// key actually works — present is not the same as working (revoked, typo'd, or
+// the endpoint is unreachable). It downgrades the check to a failure on a bad
+// key so `snipe doctor --probe` exits non-zero. Called only when credentials are
+// present and --probe is set.
+func liveProbeEmbeddings(check *DoctorCheck) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := embed.LiveProbe(ctx); err != nil {
+		check.OK = false
+		check.Code = DoctorEmbedProbeFailed
+		check.Message = "embedding credentials present but live probe failed (key invalid, revoked, or endpoint unreachable)"
+		check.Details = err.Error()
+		check.Remediation = "verify the Voyage API key is valid and the network reaches api.voyageai.com"
+		return
+	}
+	check.Message = "embedding credentials verified (live probe OK)"
 }
 
 // embedAuthRemediation orders the credential recipes by platform: the macOS

--- a/cmd/testdata/help/doctor.golden
+++ b/cmd/testdata/help/doctor.golden
@@ -18,3 +18,7 @@ Flags:
       --timeout=DURATION    Timeout for command (e.g., 30s, 5m)
       --select="all"        Pick top candidates by score: all, best, top3,
                             top5 (applied before --limit)
+
+      --probe               Live-probe external APIs (e.g. Voyage embeddings)
+                            to verify keys work, not just that they're present.
+                            Makes a network call.

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -281,3 +281,20 @@ func (c *Client) EmbedOne(ctx context.Context, text string, inputType string) ([
 func (c *Client) Model() string {
 	return c.model
 }
+
+// LiveProbe verifies the resolved credentials actually work by making one
+// minimal embedding request against Voyage. Presence of a key (HasCredentials)
+// does not prove it is valid, unrevoked, or that the endpoint is reachable —
+// this is the "is it working" check for doctor. Returns nil on a successful
+// round-trip; the wrapped error otherwise (401/403 = bad key, network = offline,
+// etc.). Costs one tiny billable request, so callers gate it behind an opt-in.
+func LiveProbe(ctx context.Context) error {
+	client, err := NewClient()
+	if err != nil {
+		return err
+	}
+	if _, err := client.EmbedOne(ctx, "ping", "query"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -291,10 +291,10 @@ func (c *Client) Model() string {
 func LiveProbe(ctx context.Context) error {
 	client, err := NewClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("create embedding client: %w", err)
 	}
 	if _, err := client.EmbedOne(ctx, "ping", "query"); err != nil {
-		return err
+		return fmt.Errorf("live embedding probe: %w", err)
 	}
 	return nil
 }

--- a/internal/embed/client_test.go
+++ b/internal/embed/client_test.go
@@ -216,6 +216,59 @@ func TestCredentials_EnvFirst(t *testing.T) {
 	}
 }
 
+// TestLiveProbe covers the doctor --probe path: a real one-shot request that
+// proves the resolved key works (2xx) or surfaces the failure (bad key, 4xx).
+// NewClient reads VOYAGE_API_URL for the endpoint, so the httptest server stands
+// in for Voyage. KEYRING_DISABLE keeps the probe hermetic — env key only.
+func TestLiveProbe(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "valid key returns nil",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(EmbeddingResponse{
+					Data: []struct {
+						Object    string    `json:"object"`
+						Embedding []float32 `json:"embedding"`
+						Index     int       `json:"index"`
+					}{{Embedding: []float32{0.1}, Index: 0}},
+				})
+			},
+			wantErr: false,
+		},
+		{
+			name: "unauthorized key returns error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid_api_key"}`))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			t.Cleanup(server.Close)
+
+			t.Setenv("KEYRING_DISABLE", "1")
+			t.Setenv("SNIPE_VOYAGE_API_KEY", "test-key")
+			t.Setenv("VOYAGE_API_URL", server.URL)
+
+			err := LiveProbe(context.Background())
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("LiveProbe: %v", err)
+			}
+		})
+	}
+}
+
 func TestEmbedOne_ReturnsFirstEmbedding(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(EmbeddingResponse{


### PR DESCRIPTION
## What

`snipe doctor --probe` now verifies the Voyage API key actually **works**, not just that it's present.

- `embed.LiveProbe(ctx)` — one minimal Voyage request; nil = key valid + endpoint reachable, error = bad/revoked key or offline.
- `--probe` flag on `doctor` (default off — keeps `doctor` network-free unless asked).
- On probe failure the embeddings check flips to `OK:false` / code `EMBED_PROBE_FAILED`, so doctor exits non-zero.

Voyage embeddings is snipe's only external API dependency.

## Tests

- `TestLiveProbe` — valid key → nil, 401 → error (httptest).
- Help golden regenerated for the new flag.
- `make` green (vet + lint + test).

Closes: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--probe` option to `snipe doctor` for live verification of embedding credentials.
  * The probe performs a minimal API request to confirm configured keys are valid.
* **Bug Fixes**
  * Doctor now reports a clear failure and remediation guidance when credential verification fails.
* **Documentation**
  * Updated command help to explain that probing makes a live network request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->