### PR TITLE
fix: 5 commands leaked JSON in default (Claude) output

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -45,54 +45,36 @@ const remediationReindex = "snipe index"
 func runDoctor(probe bool) error {
 	w := output.NewWriter(os.Stdout, GetOutputFormat())
 
-	allOK := true
-	var checks []DoctorCheck
-
-	// Check ripgrep
-	rgCheck := checkRipgrep()
-	checks = append(checks, rgCheck)
-	if !rgCheck.OK {
-		allOK = false
-	}
-
-	// Check index
+	// ripgrep, index, Go toolchain, embeddings credentials (--probe live-checks).
 	indexCheck := checkIndex()
-	checks = append(checks, indexCheck)
-	if !indexCheck.OK {
-		allOK = false
-	}
-
-	// Check Go toolchain
-	goCheck := checkGoToolchain()
-	checks = append(checks, goCheck)
-	if !goCheck.OK {
-		allOK = false
-	}
-
-	// Check embeddings credentials (and, with --probe, that they work)
-	embedCheck := checkEmbeddings(probe)
-	checks = append(checks, embedCheck)
-	if !embedCheck.OK {
-		allOK = false
+	checks := []DoctorCheck{
+		checkRipgrep(),
+		indexCheck,
+		checkGoToolchain(),
+		checkEmbeddings(probe),
 	}
 
 	// Check orphaned references (only if index exists)
 	if indexCheck.OK {
-		orphanCheck := checkOrphans()
-		checks = append(checks, orphanCheck)
+		checks = append(checks, checkOrphans())
 	}
 
 	// Check index staleness
 	if indexCheck.OK {
-		staleCheck := checkStaleness()
-		checks = append(checks, staleCheck)
+		checks = append(checks, checkStaleness())
 	}
 
 	// Check for root mismatch
-	mismatchCheck := checkRootMismatch()
-	checks = append(checks, mismatchCheck)
-	if !mismatchCheck.OK {
-		allOK = false
+	checks = append(checks, checkRootMismatch())
+
+	// allOK derived from every rendered check — no check can be silently
+	// excluded from the summary verdict (a check that passes when degraded,
+	// e.g. staleness, sets its own OK=true).
+	allOK := true
+	for i := range checks {
+		if !checks[i].OK {
+			allOK = false
+		}
 	}
 
 	// Find repo root for meta (best-effort)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -111,7 +111,44 @@ func runDoctor(probe bool) error {
 		},
 	}
 
-	return w.WriteResponse(resp)
+	if GetOutputFormat() == output.OutputJSON {
+		return w.WriteResponse(resp)
+	}
+	return writeDoctorText(checks, allOK)
+}
+
+// writeDoctorText renders the diagnostic as terse text (D1). One summary line,
+// then one line per check; failures carry their remediation command indented.
+func writeDoctorText(checks []DoctorCheck, allOK bool) error {
+	okCount := 0
+	for i := range checks {
+		if checks[i].OK {
+			okCount++
+		}
+	}
+	var b strings.Builder
+	status := "✓ ok"
+	if !allOK {
+		status = "✗ FAILED"
+	}
+	fmt.Fprintf(&b, "doctor · %d/%d checks %s\n", okCount, len(checks), status)
+	for i := range checks {
+		c := &checks[i]
+		glyph := "✓"
+		if !c.OK {
+			glyph = "✗"
+		}
+		line := fmt.Sprintf("  %s %-14s %s", glyph, c.Name, c.Message)
+		if c.Code != "" {
+			line += fmt.Sprintf(" [%s]", c.Code)
+		}
+		fmt.Fprintln(&b, strings.TrimRight(line, " "))
+		if !c.OK && c.Remediation != "" {
+			fmt.Fprintf(&b, "    → %s\n", c.Remediation)
+		}
+	}
+	_, err := os.Stdout.WriteString(b.String())
+	return err
 }
 
 func checkRipgrep() DoctorCheck {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -267,7 +267,7 @@ doEdit:
 		},
 	}
 
-	return w.WriteResponse(resp)
+	return emitEdit(w, resp)
 }
 
 func runBatchEdit(w *output.Writer, start time.Time) error {
@@ -385,5 +385,31 @@ func runBatchEdit(w *output.Writer, start time.Time) error {
 		},
 	}
 
-	return w.WriteResponse(resp)
+	return emitEdit(w, resp)
+}
+
+// emitEdit renders edit results. Default (Claude) surface is a terse status
+// line per edit plus the unified diff; --format json emits the full envelope
+// (D1). Dry-run vs applied is stated explicitly.
+func emitEdit(w *output.Writer, resp output.Response[EditResponse]) error {
+	if GetOutputFormat() == output.OutputJSON {
+		return w.WriteResponse(resp)
+	}
+	var b strings.Builder
+	for i := range resp.Results {
+		r := &resp.Results[i]
+		mode := "dry-run"
+		if r.Applied {
+			mode = "applied"
+		}
+		fmt.Fprintf(&b, "edit · %s · %s:%d-%d · %s\n", r.Operation, r.File, r.LineStart, r.LineEnd, mode)
+		if r.Diff != "" {
+			b.WriteString(r.Diff)
+			if !strings.HasSuffix(r.Diff, "\n") {
+				b.WriteByte('\n')
+			}
+		}
+	}
+	_, err := os.Stdout.WriteString(b.String())
+	return err
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -410,6 +410,14 @@ func emitEdit(w *output.Writer, resp output.Response[EditResponse]) error {
 			}
 		}
 	}
+	// Degraded ops (symbol not found, ambiguous, edit failed) never land in
+	// Results — surface them so a batch where every op fails isn't silent.
+	if len(resp.Meta.Degraded) > 0 {
+		fmt.Fprintf(&b, "edit · %d degraded\n", len(resp.Meta.Degraded))
+		for _, d := range resp.Meta.Degraded {
+			fmt.Fprintf(&b, "  ✗ %s\n", d)
+		}
+	}
 	_, err := os.Stdout.WriteString(b.String())
 	return err
 }

--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dkoosis/snipe/internal/embed"
@@ -83,12 +84,7 @@ func runEmbedStatus() error {
 			Status:  "no_batch",
 			Message: "No batch embedding job found. Run 'snipe index' to start one.",
 		}
-		return w.WriteResponse(output.Response[EmbedStatusResult]{
-			Protocol: output.ProtocolVersion,
-			Ok:       true,
-			Results:  []EmbedStatusResult{result},
-			Meta:     output.Meta{Command: cmdNameEmbedStatus},
-		})
+		return emitEmbedStatus(w, result)
 	}
 
 	// Poll loop (or single check)
@@ -149,12 +145,7 @@ func runEmbedStatus() error {
 				EmbedCount: embedCount,
 				Message:    fmt.Sprintf("Downloaded and saved %d embeddings", embedCount),
 			}
-			return w.WriteResponse(output.Response[EmbedStatusResult]{
-				Protocol: output.ProtocolVersion,
-				Ok:       true,
-				Results:  []EmbedStatusResult{result},
-				Meta:     output.Meta{Command: cmdNameEmbedStatus},
-			})
+			return emitEmbedStatus(w, result)
 		}
 
 		// Handle failure
@@ -173,12 +164,7 @@ func runEmbedStatus() error {
 				CreatedAt: &state.CreatedAt,
 				Message:   "Batch job failed or was cancelled",
 			}
-			return w.WriteResponse(output.Response[EmbedStatusResult]{
-				Protocol: output.ProtocolVersion,
-				Ok:       true,
-				Results:  []EmbedStatusResult{result},
-				Meta:     output.Meta{Command: cmdNameEmbedStatus},
-			})
+			return emitEmbedStatus(w, result)
 		}
 
 		// If not waiting, return current status
@@ -201,12 +187,7 @@ func runEmbedStatus() error {
 				Stale:     isStale,
 				Message:   msg,
 			}
-			return w.WriteResponse(output.Response[EmbedStatusResult]{
-				Protocol: output.ProtocolVersion,
-				Ok:       true,
-				Results:  []EmbedStatusResult{result},
-				Meta:     output.Meta{Command: cmdNameEmbedStatus},
-			})
+			return emitEmbedStatus(w, result)
 		}
 
 		// Wait and poll again — honor ctx so Ctrl+C returns promptly instead of
@@ -217,6 +198,46 @@ func runEmbedStatus() error {
 		case <-time.After(time.Duration(embedPollSecs) * time.Second):
 		}
 	}
+}
+
+// emitEmbedStatus renders one embed-status result. Default (Claude) surface is
+// a terse one-liner; --format json emits the full envelope (D1).
+func emitEmbedStatus(w *output.Writer, result EmbedStatusResult) error {
+	resp := output.Response[EmbedStatusResult]{
+		Protocol: output.ProtocolVersion,
+		Ok:       true,
+		Results:  []EmbedStatusResult{result},
+		Meta:     output.Meta{Command: cmdNameEmbedStatus},
+	}
+	if GetOutputFormat() == output.OutputJSON {
+		return w.WriteResponse(resp)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "embeddings · %s", result.Status)
+	if result.Total > 0 {
+		fmt.Fprintf(&b, " · %d/%d", result.Completed, result.Total)
+	}
+	if result.Failed > 0 {
+		fmt.Fprintf(&b, " · %d failed", result.Failed)
+	}
+	if result.EmbedCount > 0 {
+		fmt.Fprintf(&b, " · %d saved", result.EmbedCount)
+	}
+	if result.Model != "" {
+		fmt.Fprintf(&b, " · %s", result.Model)
+	}
+	if result.Age != "" {
+		fmt.Fprintf(&b, " · age %s", result.Age)
+	}
+	if result.Stale {
+		b.WriteString(" · STALE")
+	}
+	if result.Message != "" {
+		fmt.Fprintf(&b, "\n%s", result.Message)
+	}
+	b.WriteByte('\n')
+	_, err := os.Stdout.WriteString(b.String())
+	return err
 }
 
 // embeddingSaver is the persistence seam downloadAndSaveEmbeddings writes

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -344,7 +344,7 @@ func runIndex(args []string) error {
 		fmt.Fprintf(os.Stderr, "Batch embedding started (async). Use 'snipe embed-status' to check progress.\n")
 	}
 
-	return w.WriteResponse(indexResponse(absDir, start, len(symbols), nil))
+	return emitIndex(w, indexResponse(absDir, start, len(symbols), nil))
 }
 
 // filterEmbeddableSymbols returns symbols suitable for embedding (functions, methods,
@@ -798,7 +798,7 @@ func runIncrementalIndex(s *store.Store, result *index.LoadResult, allSymbols []
 		nMod+nAdd+nDel, nMod, nAdd, nDel)
 
 	symCount, _, _, _ := s.GetStats()
-	return w.WriteResponse(indexResponse(absDir, start, symCount, orphanSuggestion(incResult)))
+	return emitIndex(w, indexResponse(absDir, start, symCount, orphanSuggestion(incResult)))
 }
 
 // runDeleteOnlyIndex handles the case where only files were deleted.
@@ -823,10 +823,31 @@ func runDeleteOnlyIndex(s *store.Store, changes *index.ChangeResult, absDir stri
 	fmt.Fprintf(os.Stderr, "Deleted %d files\n", nDel)
 
 	symCount, _, _, _ := s.GetStats()
-	return w.WriteResponse(indexResponse(absDir, start, symCount, orphanSuggestion(incResult)))
+	return emitIndex(w, indexResponse(absDir, start, symCount, orphanSuggestion(incResult)))
 }
 
 // indexResponse builds a standard index command response.
+// emitIndex renders the index response. Default (Claude) surface is a terse
+// one-liner (progress detail already went to stderr); --format json emits the
+// full envelope (D1).
+func emitIndex(w *output.Writer, resp output.Response[any]) error {
+	if GetOutputFormat() == output.OutputJSON {
+		return w.WriteResponse(resp)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "indexed · %d symbols · %s · %dms\n",
+		resp.Meta.Total, resp.Meta.IndexState, resp.Meta.Ms)
+	for _, s := range resp.Suggestions {
+		fmt.Fprintf(&b, "→ %s", s.Command)
+		if s.Description != "" {
+			fmt.Fprintf(&b, "  (%s)", s.Description)
+		}
+		b.WriteByte('\n')
+	}
+	_, err := os.Stdout.WriteString(b.String())
+	return err
+}
+
 func indexResponse(absDir string, start time.Time, symCount int, suggestions []output.Suggestion) output.Response[any] {
 	return output.Response[any]{
 		Protocol:    output.ProtocolVersion,
@@ -1355,7 +1376,7 @@ func trySkipIndex(s *store.Store, fp *index.Fingerprint, absDir string, start ti
 				Total:      symCount,
 			},
 		}
-		return &changeDetection{result: skipResultSkipped}, w.WriteResponse(resp)
+		return &changeDetection{result: skipResultSkipped}, emitIndex(w, resp)
 	}
 
 	// Changes detected — decide between incremental and full reindex

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dkoosis/snipe/internal/output"
 	"github.com/dkoosis/snipe/internal/query"
@@ -56,7 +58,7 @@ func runStatus() error {
 				Total:      1,
 			},
 		}
-		return w.WriteResponse(resp)
+		return emitStatus(w, resp)
 	}
 
 	// Open store (read-only mode)
@@ -108,5 +110,29 @@ func runStatus() error {
 		},
 	}
 
-	return w.WriteResponse(resp)
+	return emitStatus(w, resp)
+}
+
+// emitStatus renders the status response. Default (Claude) surface is a terse
+// one-liner; --format json emits the full envelope (D1: Claude reads text, not
+// JSON envelope noise).
+func emitStatus(w *output.Writer, resp output.Response[StatusResponse]) error {
+	if GetOutputFormat() == output.OutputJSON {
+		return w.WriteResponse(resp)
+	}
+	r := resp.Results[0]
+	var b strings.Builder
+	fmt.Fprintf(&b, "index · %s", r.State)
+	if r.State != output.IndexMissing {
+		fmt.Fprintf(&b, " · %d symbols · %d refs · %d calls", r.Symbols, r.Refs, r.Calls)
+		if r.Fingerprint != "" {
+			fmt.Fprintf(&b, " · %s", r.Fingerprint)
+		}
+		if r.IndexedAt != "" {
+			fmt.Fprintf(&b, " · indexed %s", r.IndexedAt)
+		}
+	}
+	b.WriteByte('\n')
+	_, err := os.Stdout.WriteString(b.String())
+	return err
 }

--- a/test/script/testdata/script/doctor.txtar
+++ b/test/script/testdata/script/doctor.txtar
@@ -1,7 +1,11 @@
 # doctor — check snipe installation and configuration.
-# doctor renders a JSON envelope as its default surface. Proves: the run
-# completes and reports the doctor command with its check results, exit 0.
+# Default surface is terse text (D1); --format json emits the full envelope.
+# Proves: the run completes, prints the summary + per-check lines, exit 0;
+# and the json surface still carries the envelope for toolchain consumers.
 cd $FIXTURE
 exec snipe doctor
+stdout 'doctor · '
+stdout 'ripgrep'
+exec snipe doctor --format json
 stdout '"command":"doctor"'
 stdout '"name":"ripgrep"'

--- a/test/script/testdata/script/edit.txtar
+++ b/test/script/testdata/script/edit.txtar
@@ -8,3 +8,13 @@ stdout 'dry-run'
 exec snipe edit Greet --operation replace_body --new-code 'return Banner' --format json
 stdout '"operation":"replace_body"'
 stdout '"applied":false'
+
+# Batch mode where every op fails must not be silent: degraded entries surface
+# on the default text surface, not only in --format json (D1).
+stdin $WORK/batch.json
+exec snipe edit --batch
+stdout 'edit · 1 degraded'
+stdout 'symbol_not_found:NoSuchSymbol'
+
+-- batch.json --
+[{"symbol":"NoSuchSymbol","operation":"replace_body","new_code":"x"}]

--- a/test/script/testdata/script/edit.txtar
+++ b/test/script/testdata/script/edit.txtar
@@ -1,7 +1,10 @@
-# edit — AST-aware code editing. Default is dry-run (no --apply), emitting the
-# edit plan as a JSON envelope without touching files.
-# Proves: a replace_body edit previews with applied=false (nothing written).
+# edit — AST-aware code editing. Default is dry-run (no --apply), touching no
+# files. Default surface is terse text (D1); --format json emits the full plan.
+# Proves: a replace_body edit previews as dry-run on both surfaces.
 cd $FIXTURE
 exec snipe edit Greet --operation replace_body --new-code 'return Banner'
+stdout 'edit · replace_body'
+stdout 'dry-run'
+exec snipe edit Greet --operation replace_body --new-code 'return Banner' --format json
 stdout '"operation":"replace_body"'
 stdout '"applied":false'

--- a/test/script/testdata/script/status.txtar
+++ b/test/script/testdata/script/status.txtar
@@ -1,7 +1,11 @@
 # status — index status and statistics (the default bare-`snipe` command).
-# status renders a JSON envelope as its default surface. Proves: a run over the
-# indexed fixture reports the status command with a fresh index state, exit 0.
+# Default surface is terse text (D1); --format json emits the full envelope.
+# Proves: a run over the indexed fixture reports a fresh index state on both
+# surfaces, exit 0.
 cd $FIXTURE
 exec snipe status
+stdout 'index · '
+stdout 'fresh'
+exec snipe status --format json
 stdout '"command":"status"'
 stdout '"state":"fresh"'


### PR DESCRIPTION
## What

`doctor`, `index`, `status`, `edit`, `embed-status` dumped the full JSON envelope in default/concise mode — a D1 violation (Claude is the primary consumer). Root cause: the `writeClaude` type switch (`internal/output/json.go`) has no case for their `Response[T]` payloads, so they hit `default: → writeJSON`. The types live in `cmd`, so the switch can't reach them (import direction) — fix is per-command self-branching, matching the existing metrics/verify/plan/guard/sensitive/pkg-digest pattern.

## Result

- Default surface: terse text (see below). `--format json` still emits the full envelope for orca/tooling.
- Blackbox tests unaffected (the `run` helper auto-injects `--format json`); 3 txtar default-surface tests updated to assert both surfaces.
- `make` green (vet + lint + test).

```
doctor · 7/7 checks ✓ ok
index · fresh · 3185 symbols · 11902 refs · 4347 calls · 56bd6a9b… · indexed …
embeddings · no_batch
edit · replace_body · internal/output/json.go:68-74 · dry-run
```

Closes: sn-k7mc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved concise, human-readable output for `doctor`, `edit`, `embed-status`, `index`, and `status` (with clearer summaries and status details).
  * `edit` now reports per-operation outcomes (including dry-run/applied), shows unified diffs, and surfaces degraded operation reasons when applicable.
  * `doctor` and other commands enhance text rendering while preserving `--format json` structured responses.
* **Tests**
  * Updated script fixtures to validate both terse text output and `--format json` envelopes, including doctor/edit/status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->