### PR TITLE
feat: add snipe c4 command for C4-model fact inventory

### DIFF
--- a/cmd/c4.go
+++ b/cmd/c4.go
@@ -81,9 +81,14 @@ func buildC4Response(s *store.Store, dir, level string, start time.Time) (output
 	}
 
 	result := output.C4Result{
-		Module:    facts.Module,
-		GoVersion: facts.GoVersion,
-		Level:     level,
+		Module:     facts.Module,
+		GoVersion:  facts.GoVersion,
+		Level:      level,
+		Containers: make([]output.C4Container, 0, len(facts.Containers)),
+		Datastores: make([]output.C4Datastore, 0, len(facts.Datastores)),
+		External:   make([]output.C4ExternalSystem, 0, len(facts.External)),
+		Flows:      make([]output.C4Flow, 0, len(facts.Flows)),
+		Components: make([]output.C4Component, 0, len(facts.Components)),
 	}
 	for _, c := range facts.Containers {
 		result.Containers = append(result.Containers, output.C4Container{

--- a/cmd/c4.go
+++ b/cmd/c4.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/c4"
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+// C4Cmd is the `snipe c4` CLI command: a facts-only C4 architecture
+// inventory (containers, datastores, external systems, flows). Registered in
+// cmd/cli.go next to Triage/Diagram/Lifecycle.
+type C4Cmd struct {
+	Level string `default:"container" enum:"context,container,component" help:"context|container|component (default: container)"`
+}
+
+// Run implements kong's command interface.
+func (c *C4Cmd) Run() error {
+	return runC4(c.Level)
+}
+
+// runC4 opens the store, builds the C4 fact inventory via internal/c4, and
+// writes it — following cmd/triage.go's runTriage/buildTriageResponse split
+// (the design field's explicit template pointer). Like triage, the text
+// renderer bypasses output.Writer's writeClaude type switch entirely (that
+// switch lives in internal/output/json.go, which is out of this change's
+// file list): JSON mode encodes the standard Response[C4Result] envelope
+// directly, text mode calls writeC4Text.
+func runC4(level string) error {
+	start := time.Now()
+	level = normalizeC4Level(level)
+
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+	s, dir, err := OpenStore(w, cmdNameC4)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	resp, err := buildC4Response(s, dir, level, start)
+	if err != nil {
+		return w.WriteError(cmdNameC4, &output.Error{
+			Code:    output.ErrInternal,
+			Message: err.Error(),
+		})
+	}
+
+	if GetOutputFormat() == output.OutputJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp)
+	}
+	return writeC4Text(resp.Results)
+}
+
+// normalizeC4Level defaults an empty/unrecognized --level to "container" (the
+// design field's default) rather than erroring — an unknown level is more
+// useful degraded to the default than refused outright.
+func normalizeC4Level(level string) string {
+	switch level {
+	case c4.LevelContext, c4.LevelComponent:
+		return level
+	default:
+		return c4.LevelContainer
+	}
+}
+
+// buildC4Response builds the C4 facts and wraps them in the standard
+// Response[T] envelope (AC #2: `.results` is always an array, never null, via
+// Response[T]'s existing MarshalJSON guarantee — no bespoke envelope).
+func buildC4Response(s *store.Store, dir, level string, start time.Time) (output.Response[output.C4Result], error) {
+	facts, err := c4.BuildFacts(s, dir, level)
+	if err != nil {
+		return output.Response[output.C4Result]{}, fmt.Errorf("build c4 facts: %w", err)
+	}
+
+	result := output.C4Result{
+		Module:    facts.Module,
+		GoVersion: facts.GoVersion,
+		Level:     level,
+	}
+	for _, c := range facts.Containers {
+		result.Containers = append(result.Containers, output.C4Container{
+			Name: c.Name, Tech: c.Tech, File: c.File, Line: c.Line,
+		})
+	}
+	for _, d := range facts.Datastores {
+		result.Datastores = append(result.Datastores, output.C4Datastore{
+			Name: d.Name, Driver: d.Driver, Package: d.Package, File: d.File, Line: d.Line,
+		})
+	}
+	for _, e := range facts.External {
+		result.External = append(result.External, output.C4ExternalSystem{
+			Name: e.Name, Kind: e.Kind, Evidence: e.Evidence, File: e.File, Line: e.Line,
+		})
+	}
+	for _, fl := range facts.Flows {
+		result.Flows = append(result.Flows, output.C4Flow{
+			From: fl.From, To: fl.To, Kind: fl.Kind, File: fl.File, Line: fl.Line,
+		})
+	}
+	for _, comp := range facts.Components {
+		result.Components = append(result.Components, output.C4Component{
+			Name: comp.Name, Layer: comp.Layer, Purpose: comp.Purpose,
+		})
+	}
+
+	total := len(result.Containers) + len(result.Datastores) + len(result.External) +
+		len(result.Flows) + len(result.Components)
+
+	return output.Response[output.C4Result]{
+		Protocol: output.ProtocolVersion,
+		Ok:       true,
+		Results:  []output.C4Result{result},
+		Meta: output.Meta{
+			Command:    cmdNameC4,
+			Query:      map[string]string{"level": level},
+			RepoRoot:   dir,
+			IndexState: query.CheckIndexState(s.DB(), dir, Version),
+			Ms:         time.Since(start).Milliseconds(),
+			Total:      total,
+		},
+	}, nil
+}
+
+// c4TextCap bounds the concise renderer to roughly the design field's <=~80
+// lines target on the snipe repo, per section.
+const c4TextCap = 20
+
+// writeC4Text renders the Claude-optimized concise form: one section per
+// fact kind, one line per fact (name | tech/evidence | file:line).
+func writeC4Text(results []output.C4Result) error {
+	if len(results) == 0 {
+		_, err := os.Stdout.WriteString("c4 · no facts\n")
+		return err
+	}
+	r := results[0]
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "c4 · %s · level=%s", r.Module, r.Level)
+	if r.GoVersion != "" {
+		fmt.Fprintf(&b, " · go=%s", r.GoVersion)
+	}
+	b.WriteString("\n")
+
+	if len(r.Containers) > 0 {
+		b.WriteString("\n## containers\n")
+		writeC4Capped(&b, len(r.Containers), func(i int) string {
+			c := r.Containers[i]
+			return fmt.Sprintf("  %s | %s | %s:%d\n", c.Name, c.Tech, c.File, c.Line)
+		})
+	}
+
+	if len(r.Datastores) > 0 {
+		b.WriteString("\n## datastores\n")
+		writeC4Capped(&b, len(r.Datastores), func(i int) string {
+			d := r.Datastores[i]
+			return fmt.Sprintf("  %s | %s | %s | %s:%d\n", d.Name, d.Driver, d.Package, d.File, d.Line)
+		})
+	}
+
+	if len(r.External) > 0 {
+		b.WriteString("\n## external\n")
+		writeC4Capped(&b, len(r.External), func(i int) string {
+			e := r.External[i]
+			return fmt.Sprintf("  %s | %s | evidence: %s | %s:%d\n",
+				e.Name, e.Kind, strings.Join(e.Evidence, ", "), e.File, e.Line)
+		})
+	}
+
+	if len(r.Flows) > 0 {
+		b.WriteString("\n## flows\n")
+		writeC4Capped(&b, len(r.Flows), func(i int) string {
+			fl := r.Flows[i]
+			from := fl.From
+			if from == "" {
+				from = "(env)"
+			}
+			return fmt.Sprintf("  %s -> %s | %s | %s:%d\n", from, fl.To, fl.Kind, fl.File, fl.Line)
+		})
+	}
+
+	if len(r.Components) > 0 {
+		b.WriteString("\n## components\n")
+		writeC4Capped(&b, len(r.Components), func(i int) string {
+			c := r.Components[i]
+			if c.Purpose != "" {
+				return fmt.Sprintf("  %s (%s) — %s\n", c.Name, c.Layer, c.Purpose)
+			}
+			return fmt.Sprintf("  %s (%s)\n", c.Name, c.Layer)
+		})
+	}
+
+	if len(r.Containers) == 0 && len(r.Datastores) == 0 && len(r.External) == 0 &&
+		len(r.Flows) == 0 && len(r.Components) == 0 {
+		b.WriteString("(no facts found)\n")
+	}
+
+	_, err := os.Stdout.WriteString(b.String())
+	return err
+}
+
+// writeC4Capped writes at most c4TextCap lines from render(i), i in [0,n),
+// appending a "+N more" marker when truncated.
+func writeC4Capped(b *strings.Builder, n int, render func(i int) string) {
+	limit := n
+	if limit > c4TextCap {
+		limit = c4TextCap
+	}
+	for i := 0; i < limit; i++ {
+		b.WriteString(render(i))
+	}
+	if n > limit {
+		fmt.Fprintf(b, "  ... +%d more\n", n-limit)
+	}
+}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -49,6 +49,7 @@ type CLI struct {
 	Sensitive SensitiveCmd `cmd:"" group:"Graph & Structure:" help:"List files in security-sensitive zones (auth/crypto/migration/secret/payment)"`
 	Diagram   DiagramCmd   `cmd:"" group:"Graph & Structure:" help:"Render snipe graphs as D2 diagram source"`
 	Lifecycle LifecycleCmd `cmd:"" group:"Graph & Structure:" help:"Trace every function creating, mutating, reading, or deleting a type"`
+	C4        C4Cmd        `cmd:"" name:"c4" group:"Graph & Structure:" help:"C4 architecture fact inventory: containers, datastores, external systems, flows (facts only, no rendering)"`
 	Deadcode  DeadcodeCmd  `cmd:"" group:"Graph & Structure:" help:"Report exported symbols with zero non-test references"`
 	Guard     GuardCmd     `cmd:"" group:"Graph & Structure:" help:"Assert architecture boundary rules; exit non-zero on violation"`
 

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -32,6 +32,7 @@ const (
 	cmdNameStatus      = "status"
 	cmdNameIndex       = "index"
 	cmdNameEmbedStatus = "embed-status"
+	cmdNameC4          = "c4"
 )
 
 // Common flag/parameter names.

--- a/cmd/testdata/help/c4.golden
+++ b/cmd/testdata/help/c4.golden
@@ -1,0 +1,23 @@
+Usage: snipe c4 [flags]
+
+C4 architecture fact inventory: containers, datastores, external systems,
+flows (facts only, no rendering)
+
+Flags:
+  -h, --help                 Show context-sensitive help.
+      --limit=10             Cap results returned (applied after --select)
+      --offset=0             Pagination offset
+      --context=2            Context lines around match
+      --no-body              Exclude function body
+      --no-siblings          Exclude sibling declarations
+      --signature-only       Return only signature (no body, no context)
+      --max-tokens=0         Token budget (0 = unlimited)
+      --format="concise"     concise (LLM default) | detailed | summary | json
+                             (stable, for tooling) | human (TTY)
+      --kg-hints             Include Orca KG hints
+      --suggestions          Include next-step suggestions in Claude output
+      --timeout=DURATION     Timeout for command (e.g., 30s, 5m)
+      --select="all"         Pick top candidates by score: all, best, top3,
+                             top5 (applied before --limit)
+
+      --level="container"    context|container|component (default: container)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -154,6 +154,10 @@ Graph & Structure:
   lifecycle [<type>] [flags]
     Trace every function creating, mutating, reading, or deleting a type
 
+  c4 [flags]
+    C4 architecture fact inventory: containers, datastores, external systems,
+    flows (facts only, no rendering)
+
   deadcode [flags]
     Report exported symbols with zero non-test references
 

--- a/internal/c4/facts.go
+++ b/internal/c4/facts.go
@@ -1,0 +1,824 @@
+// Package c4 aggregates signals already indexed by snipe into a C4-style
+// architecture fact inventory — containers, datastores, external systems, and
+// the flows between them. It is a thin extraction/classification layer, not a
+// new analysis engine: every fact traces to an allowlist, regex, or
+// import-root match against real index data (symbols, imports, string_refs).
+// No rendering happens here; consumers (the c4-model skill, transform:d2)
+// render the facts this package emits.
+package c4
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+
+	"github.com/dkoosis/snipe/internal/context"
+	"github.com/dkoosis/snipe/internal/graphmetrics"
+	"github.com/dkoosis/snipe/internal/query"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+// componentTopN caps the --level component package breakdown to the top-N
+// packages by import-graph PageRank (falls back to every package when
+// graph_metrics hasn't been populated — see graphmetrics.TopNByPageRank).
+const componentTopN = 20
+
+// Level values for `snipe c4 --level`.
+const (
+	LevelContext   = "context"
+	LevelContainer = "container"
+	LevelComponent = "component"
+)
+
+// Facts is the C4 fact inventory for one repo at one --level.
+type Facts struct {
+	Module     string
+	GoVersion  string
+	Containers []Container
+	Datastores []Datastore
+	External   []ExternalSystem
+	Flows      []Flow
+	Components []Component
+}
+
+// Container is a deployable process — today, always a Go main package.
+type Container struct {
+	Name string
+	Tech string
+	File string
+	Line int
+}
+
+// Datastore is a package that imports a driver from the fixed allowlist.
+type Datastore struct {
+	Name    string // display name, e.g. "SQLite"
+	Driver  string // the matched import pkg_path
+	Package string // the importing package
+	File    string
+	Line    int
+}
+
+// ExternalSystem is a third-party service, detected via env-var literals
+// and/or third-party SDK imports.
+type ExternalSystem struct {
+	Name     string   // grouped display name, e.g. "VOYAGE"
+	Kind     string   // "env" | "import" | "env+import"
+	Evidence []string // env var names and/or importer package paths
+	File     string
+	Line     int
+}
+
+// Flow is a directed edge from an importer package to a datastore or
+// external system, with one deterministic file:line evidence row.
+type Flow struct {
+	From string // importer package
+	To   string // datastore or external system name
+	Kind string // "datastore" | "external"
+	File string
+	Line int
+}
+
+// Component is a package-level breakdown entry for --level component.
+type Component struct {
+	Name    string
+	Layer   string
+	Purpose string
+}
+
+// driverAllowlist maps a substring match against imports.pkg_path to a
+// display datastore name (design field's fixed allowlist). Order does not
+// matter: matches are independent, evaluated against every import row.
+var driverAllowlist = []struct{ match, name string }{
+	{"modernc.org/sqlite", "SQLite"},
+	{"mattn/go-sqlite3", "SQLite"},
+	{"lib/pq", "PostgreSQL"},
+	{"jackc/pgx", "PostgreSQL"},
+	{"go-redis", "Redis"},
+	{"bbolt", "BoltDB"},
+	{"badger", "Badger"},
+	{"database/sql", "SQL"},
+}
+
+// envSuffixRe matches the design field's external-system env-var predicate:
+// value ends in _API_KEY, _TOKEN, _SECRET, _URL, or _MODEL.
+var envSuffixRe = regexp.MustCompile(`(_API_KEY|_TOKEN|_SECRET|_URL|_MODEL)$`)
+
+// envRoleTokens are the generic role words stripped from an env var name
+// before grouping — they describe the credential's shape (API key, URL,
+// model id), not which service it belongs to, so they never distinguish one
+// external system from another.
+var envRoleTokens = map[string]bool{
+	"API":    true,
+	"KEY":    true,
+	"TOKEN":  true,
+	"SECRET": true,
+	"URL":    true,
+	"MODEL":  true,
+}
+
+// testLibAllowlist excludes common test-only libraries from external-system
+// import detection (confirmed real deps of snipe: go.mod lines for
+// stretchr/testify and google/go-cmp).
+var testLibAllowlist = []string{
+	"github.com/stretchr/testify",
+	"github.com/google/go-cmp",
+}
+
+// BuildFacts assembles the C4 fact inventory for the repo indexed at s, whose
+// root is dir. level filters which sections populate:
+//   - context:   module + external systems + datastores only, no containers
+//   - container: containers + datastores + external systems + flows (default)
+//   - component: container-level facts plus a package-level breakdown
+func BuildFacts(s *store.Store, dir string, level string) (Facts, error) {
+	db := s.DB()
+
+	modulePath := query.DetectModulePath(db)
+	f := Facts{Module: modulePath}
+	if v, err := goVersionFromMod(dir); err == nil && v != "" {
+		f.GoVersion = v
+	}
+
+	datastores, err := findDatastores(db)
+	if err != nil {
+		return Facts{}, fmt.Errorf("find datastores: %w", err)
+	}
+	f.Datastores = datastores
+
+	external, err := findExternalSystems(db, modulePath)
+	if err != nil {
+		return Facts{}, fmt.Errorf("find external systems: %w", err)
+	}
+	f.External = external
+
+	if level == LevelContext {
+		return f, nil
+	}
+
+	containers, err := findContainers(db, modulePath)
+	if err != nil {
+		return Facts{}, fmt.Errorf("find containers: %w", err)
+	}
+	tech := "Go"
+	if f.GoVersion != "" {
+		tech = "Go " + f.GoVersion
+	}
+	for i := range containers {
+		containers[i].Tech = tech
+	}
+	f.Containers = containers
+
+	flows, err := findFlows(db, datastores, external)
+	if err != nil {
+		return Facts{}, fmt.Errorf("find flows: %w", err)
+	}
+	f.Flows = flows
+
+	if level == LevelComponent {
+		components, err := findComponents(s)
+		if err != nil {
+			return Facts{}, fmt.Errorf("find components: %w", err)
+		}
+		f.Components = components
+	}
+
+	return f, nil
+}
+
+// goVersionFromMod reads the `go` directive from dir/go.mod.
+func goVersionFromMod(dir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return "", err
+	}
+	mf, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return "", err
+	}
+	if mf.Go != nil {
+		return mf.Go.Version, nil
+	}
+	return "", nil
+}
+
+// findContainers returns one Container per distinct package declaring a
+// `func main()`, named after the module (the design field's AC expects a
+// single "snipe" container on snipe's own single-binary repo).
+func findContainers(db *sql.DB, modulePath string) ([]Container, error) {
+	rows, err := db.Query(`
+		SELECT DISTINCT file_path, line_start
+		FROM symbols
+		WHERE name = 'main' AND kind = 'func'
+		ORDER BY file_path, line_start
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query main funcs: %w", err)
+	}
+	defer rows.Close()
+
+	name := moduleDisplayName(modulePath)
+	var out []Container
+	for rows.Next() {
+		var file string
+		var line int
+		if err := rows.Scan(&file, &line); err != nil {
+			return nil, fmt.Errorf("scan main func: %w", err)
+		}
+		out = append(out, Container{
+			Name: name,
+			File: file,
+			Line: line,
+		})
+	}
+	return out, rows.Err()
+}
+
+// moduleDisplayName returns the last path segment of a module path, e.g.
+// "github.com/dkoosis/snipe" -> "snipe".
+func moduleDisplayName(modulePath string) string {
+	if modulePath == "" {
+		return ""
+	}
+	parts := strings.Split(modulePath, "/")
+	return parts[len(parts)-1]
+}
+
+// findDatastores scans the imports table for rows matching the fixed driver
+// allowlist, deduped by (display name, importing package).
+func findDatastores(db *sql.DB) ([]Datastore, error) {
+	rows, err := db.Query(`
+		SELECT file_path, pkg_path, COALESCE(importer_pkg,''), line
+		FROM imports
+		ORDER BY pkg_path, file_path, line
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query imports: %w", err)
+	}
+	defer rows.Close()
+
+	type key struct{ name, pkg string }
+	seen := make(map[key]bool)
+	var out []Datastore
+	for rows.Next() {
+		var file, pkgPath, importerPkg string
+		var line int
+		if err := rows.Scan(&file, &pkgPath, &importerPkg, &line); err != nil {
+			return nil, fmt.Errorf("scan import: %w", err)
+		}
+		for _, d := range driverAllowlist {
+			if !strings.Contains(pkgPath, d.match) {
+				continue
+			}
+			k := key{d.name, importerPkg}
+			if seen[k] {
+				break
+			}
+			seen[k] = true
+			out = append(out, Datastore{
+				Name:    d.name,
+				Driver:  pkgPath,
+				Package: importerPkg,
+				File:    file,
+				Line:    line,
+			})
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Package < out[j].Package
+	})
+	return out, nil
+}
+
+// findExternalSystems combines env-var evidence and third-party-import
+// evidence into one deduped, merged list of external systems.
+func findExternalSystems(db *sql.DB, modulePath string) ([]ExternalSystem, error) {
+	envSystems, err := externalFromEnv(db, modulePath)
+	if err != nil {
+		return nil, err
+	}
+	importSystems, err := externalFromImports(db, modulePath)
+	if err != nil {
+		return nil, err
+	}
+	return mergeExternalSystems(envSystems, importSystems), nil
+}
+
+// externalFromEnv groups env-var literals matching envSuffixRe by a
+// deterministic group key: the env var name with generic role tokens and the
+// module's own name stripped. "VOYAGE_API_URL", "VOYAGE_MODEL", and
+// "SNIPE_VOYAGE_API_KEY" all reduce to the key "VOYAGE" once role words
+// (API/URL/MODEL/KEY) and the module token (SNIPE) are removed.
+func externalFromEnv(db *sql.DB, modulePath string) ([]ExternalSystem, error) {
+	lits, err := query.FindLiteralsByKind(db, "env")
+	if err != nil {
+		return nil, fmt.Errorf("find env literals: %w", err)
+	}
+
+	moduleToken := strings.ToUpper(moduleDisplayName(modulePath))
+
+	type group struct {
+		names []string
+		file  string
+		line  int
+	}
+	groups := make(map[string]*group)
+	var order []string
+	for i := range lits {
+		l := &lits[i]
+		if !envSuffixRe.MatchString(l.Value) {
+			continue
+		}
+		key := envGroupKey(l.Value, moduleToken)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{file: l.FilePath, line: l.Line}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.names = append(g.names, l.Value)
+		if isEarlierEvidence(l.FilePath, l.Line, g.file, g.line) {
+			g.file, g.line = l.FilePath, l.Line
+		}
+	}
+
+	sort.Strings(order)
+	out := make([]ExternalSystem, 0, len(order))
+	for _, key := range order {
+		g := groups[key]
+		evidence := append([]string{}, g.names...)
+		sort.Strings(evidence)
+		out = append(out, ExternalSystem{
+			Name:     key,
+			Kind:     "env",
+			Evidence: evidence,
+			File:     g.file,
+			Line:     g.line,
+		})
+	}
+	return out, nil
+}
+
+// envGroupKey strips generic role tokens and the project's own module-name
+// token from an underscore-delimited env var name, returning what remains
+// joined back with "_". An empty result (the whole name was role words)
+// falls back to the original name so no env var is silently dropped.
+func envGroupKey(name, moduleToken string) string {
+	parts := strings.Split(name, "_")
+	var kept []string
+	for _, p := range parts {
+		if p == "" || envRoleTokens[p] || (moduleToken != "" && p == moduleToken) {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if len(kept) == 0 {
+		return name
+	}
+	return strings.Join(kept, "_")
+}
+
+// externalFromImports finds third-party imports with a dot-domain root,
+// excluding the repo's own module, stdlib, golang.org/x/*, test-only imports
+// (every importing file is *_test.go), and the test-lib allowlist.
+func externalFromImports(db *sql.DB, modulePath string) ([]ExternalSystem, error) {
+	rows, err := db.Query(`
+		SELECT file_path, pkg_path, line
+		FROM imports
+		ORDER BY pkg_path, file_path, line
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query imports: %w", err)
+	}
+	defer rows.Close()
+
+	byRoot := make(map[string][]string) // root -> importing file paths (with dupes)
+	bestFile := make(map[string]string) // root -> lowest-sorted (file, line) evidence
+	bestLine := make(map[string]int)
+	var order []string
+	for rows.Next() {
+		var file, pkgPath string
+		var line int
+		if err := rows.Scan(&file, &pkgPath, &line); err != nil {
+			return nil, fmt.Errorf("scan import: %w", err)
+		}
+		if isDriverMatch(pkgPath) {
+			continue // classified as a datastore, not an external system
+		}
+		root := dotDomainRoot(pkgPath)
+		if root == "" {
+			continue // no dot-domain root: stdlib or relative
+		}
+		if modulePath != "" && strings.HasPrefix(pkgPath, modulePath) {
+			continue // own module
+		}
+		if strings.HasPrefix(pkgPath, "golang.org/x/") {
+			continue
+		}
+		if isTestLibAllowed(pkgPath) {
+			continue
+		}
+		if _, seen := byRoot[root]; !seen {
+			order = append(order, root)
+		}
+		byRoot[root] = append(byRoot[root], file)
+		if isEarlierEvidence(file, line, bestFile[root], bestLine[root]) {
+			bestFile[root] = file
+			bestLine[root] = line
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.Strings(order)
+	out := make([]ExternalSystem, 0, len(order))
+	for _, root := range order {
+		occFiles := byRoot[root]
+		if allTestFiles(occFiles) {
+			continue // test-only import: excluded per design field
+		}
+		out = append(out, ExternalSystem{
+			Name:     root,
+			Kind:     "import",
+			Evidence: []string{root},
+			File:     bestFile[root],
+			Line:     bestLine[root],
+		})
+	}
+	return out, nil
+}
+
+func allTestFiles(files []string) bool {
+	for _, f := range files {
+		if !strings.HasSuffix(f, "_test.go") {
+			return false
+		}
+	}
+	return len(files) > 0
+}
+
+// isDriverMatch reports whether pkgPath matches the datastore driver
+// allowlist — such imports are reported as datastores, not external systems.
+func isDriverMatch(pkgPath string) bool {
+	for _, d := range driverAllowlist {
+		if strings.Contains(pkgPath, d.match) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTestLibAllowed reports whether pkgPath is a known test-only library that
+// should never surface as an external system regardless of import shape.
+func isTestLibAllowed(pkgPath string) bool {
+	for _, lib := range testLibAllowlist {
+		if strings.HasPrefix(pkgPath, lib) {
+			return true
+		}
+	}
+	return false
+}
+
+// dotDomainRoot returns the module-root portion of a package path if its
+// first path segment contains a dot (a real hostname, e.g. "github.com"),
+// else "" (stdlib or relative path). For known multi-segment hosts
+// (github.com, gitlab.com, bitbucket.org) the root is host/org/repo (3
+// segments); otherwise it is host/repo (2 segments, e.g. "modernc.org/sqlite").
+func dotDomainRoot(pkgPath string) string {
+	parts := strings.Split(pkgPath, "/")
+	if len(parts) == 0 || !strings.Contains(parts[0], ".") {
+		return ""
+	}
+	switch parts[0] {
+	case "github.com", "gitlab.com", "bitbucket.org":
+		if len(parts) >= 3 {
+			return strings.Join(parts[:3], "/")
+		}
+		return strings.Join(parts, "/")
+	default:
+		if len(parts) >= 2 {
+			return strings.Join(parts[:2], "/")
+		}
+		return parts[0]
+	}
+}
+
+// mergeExternalSystems folds an import-detected external system into its
+// env-detected counterpart when their names correlate (e.g. env group
+// "STRIPE" and import root "github.com/stripe/stripe-go", whose org segment
+// uppercases to "STRIPE") — the design field's AC #3 wants ONE external
+// system per real-world service, not one row per detection method.
+func mergeExternalSystems(envSystems, importSystems []ExternalSystem) []ExternalSystem {
+	usedImport := make([]bool, len(importSystems))
+	merged := make([]ExternalSystem, 0, len(envSystems)+len(importSystems))
+
+	for _, e := range envSystems {
+		matchIdx := -1
+		for i, im := range importSystems {
+			if usedImport[i] {
+				continue
+			}
+			token := importOrgToken(im.Name)
+			if token == "" {
+				continue
+			}
+			if token == e.Name || strings.Contains(e.Name, token) || strings.Contains(token, e.Name) {
+				matchIdx = i
+				break
+			}
+		}
+		if matchIdx == -1 {
+			merged = append(merged, e)
+			continue
+		}
+		im := importSystems[matchIdx]
+		usedImport[matchIdx] = true
+
+		combined := e
+		combined.Kind = "env+import"
+		combined.Evidence = append(append([]string{}, e.Evidence...), im.Evidence...)
+		if isEarlierEvidence(im.File, im.Line, combined.File, combined.Line) {
+			combined.File, combined.Line = im.File, im.Line
+		}
+		merged = append(merged, combined)
+	}
+
+	for i, im := range importSystems {
+		if !usedImport[i] {
+			merged = append(merged, im)
+		}
+	}
+
+	sort.Slice(merged, func(i, j int) bool { return merged[i].Name < merged[j].Name })
+	return merged
+}
+
+// importOrgToken extracts the organization/package segment from a module
+// root (e.g. "github.com/stripe/stripe-go" -> "STRIPE", "modernc.org/sqlite"
+// -> "SQLITE") for correlating against an env-group name.
+func importOrgToken(moduleRoot string) string {
+	parts := strings.Split(moduleRoot, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	seg := parts[1]
+	if i := strings.IndexAny(seg, "-_"); i > 0 {
+		seg = seg[:i]
+	}
+	return strings.ToUpper(seg)
+}
+
+// isEarlierEvidence reports whether (file, line) sorts before (bestFile,
+// bestLine) — lowest-sorted file first, then lowest line — the design
+// field's deterministic evidence-pick rule (no arbitrary "first match").
+func isEarlierEvidence(file string, line int, bestFile string, bestLine int) bool {
+	if bestFile == "" {
+		return true
+	}
+	if file != bestFile {
+		return file < bestFile
+	}
+	return line < bestLine
+}
+
+// findFlows builds one deterministic edge per (importer package, datastore or
+// external system) pair already discovered by findDatastores/
+// findExternalSystems, reusing their evidence rather than re-querying.
+func findFlows(db *sql.DB, datastores []Datastore, external []ExternalSystem) ([]Flow, error) {
+	var out []Flow
+	for _, d := range datastores {
+		if d.Package == "" {
+			continue
+		}
+		out = append(out, Flow{From: d.Package, To: d.Name, Kind: "datastore", File: d.File, Line: d.Line})
+	}
+
+	importerByRoot, err := loadImporterPkgsByRoot(db)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range external {
+		// The flow's importer-package lookup is keyed by the raw import
+		// module root (e.g. "github.com/stripe/stripe-go"), but a merged
+		// env+import system's Name is the env-group display name (e.g.
+		// "STRIPE") instead — mergeExternalSystems keeps the original import
+		// root as one of the Evidence entries precisely so this lookup can
+		// still find it.
+		importers := importerByRoot[e.Name]
+		if len(importers) == 0 {
+			for _, ev := range e.Evidence {
+				if imp := importerByRoot[ev]; len(imp) > 0 {
+					importers = imp
+					break
+				}
+			}
+		}
+		if len(importers) == 0 {
+			// env-only external system: no import-graph edge to attach, but
+			// still surface a flow anchored on the module root itself so the
+			// service isn't silently missing from the flow list.
+			out = append(out, Flow{From: "", To: e.Name, Kind: "external", File: e.File, Line: e.Line})
+			continue
+		}
+		for _, imp := range importers {
+			out = append(out, Flow{From: imp.pkg, To: e.Name, Kind: "external", File: imp.file, Line: imp.line})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].From != out[j].From {
+			return out[i].From < out[j].From
+		}
+		if out[i].To != out[j].To {
+			return out[i].To < out[j].To
+		}
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out, nil
+}
+
+type importerEvidence struct {
+	pkg  string
+	file string
+	line int
+}
+
+// loadImporterPkgsByRoot maps a dot-domain module root to the deterministic
+// (lowest file, lowest line) evidence per importing package.
+func loadImporterPkgsByRoot(db *sql.DB) (map[string][]importerEvidence, error) {
+	rows, err := db.Query(`
+		SELECT file_path, pkg_path, COALESCE(importer_pkg,''), line
+		FROM imports
+		ORDER BY pkg_path, file_path, line
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query imports: %w", err)
+	}
+	defer rows.Close()
+
+	best := make(map[string]map[string]importerEvidence) // root -> importer pkg -> best evidence
+	for rows.Next() {
+		var file, pkgPath, importerPkg string
+		var line int
+		if err := rows.Scan(&file, &pkgPath, &importerPkg, &line); err != nil {
+			return nil, fmt.Errorf("scan import: %w", err)
+		}
+		if importerPkg == "" {
+			continue
+		}
+		root := dotDomainRoot(pkgPath)
+		if root == "" {
+			continue
+		}
+		if best[root] == nil {
+			best[root] = make(map[string]importerEvidence)
+		}
+		cur, ok := best[root][importerPkg]
+		if !ok || isEarlierEvidence(file, line, cur.file, cur.line) {
+			best[root][importerPkg] = importerEvidence{pkg: importerPkg, file: file, line: line}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string][]importerEvidence, len(best))
+	for root, byPkg := range best {
+		list := make([]importerEvidence, 0, len(byPkg))
+		for _, ev := range byPkg {
+			list = append(list, ev)
+		}
+		sort.Slice(list, func(i, j int) bool { return list[i].pkg < list[j].pkg })
+		out[root] = list
+	}
+	return out, nil
+}
+
+// findComponents builds the --level component package-level breakdown:
+// top-N packages by import-graph PageRank, grouped by internal layer, with a
+// purpose line sourced only from a real package_docs doc comment (never a
+// name-based guess — the design field's "zero-inference" constraint applies
+// here too).
+//
+// layer/short-name grouping duplicates the ~15-line logic in cmd/diagram.go
+// (layerOf/shortPkg) rather than reusing it: those helpers are unexported in
+// package cmd, and internal/c4 cannot import cmd without an import cycle
+// (cmd/c4.go imports internal/c4). The design field's file-list note
+// authorizes this small duplication as the fallback when the package
+// boundary blocks reuse.
+func findComponents(s *store.Store) ([]Component, error) {
+	g, err := graphmetrics.LoadImportsGraph(s)
+	if err != nil {
+		return nil, fmt.Errorf("load imports graph: %w", err)
+	}
+
+	keep, _, err := graphmetrics.TopNByPageRank(s, "imports", componentTopN)
+	if err != nil {
+		return nil, fmt.Errorf("top-N by pagerank: %w", err)
+	}
+
+	nodes := g.Nodes()
+	if keep != nil {
+		filtered := nodes[:0:0]
+		for _, n := range nodes {
+			if keep[n] {
+				filtered = append(filtered, n)
+			}
+		}
+		nodes = filtered
+	}
+	sort.Strings(nodes)
+
+	module := query.DetectModulePath(s.DB())
+	docs, err := loadPackageDocFirstSentences(s.DB(), nodes)
+	if err != nil {
+		return nil, fmt.Errorf("load package docs: %w", err)
+	}
+
+	out := make([]Component, 0, len(nodes))
+	for _, pkg := range nodes {
+		out = append(out, Component{
+			Name:    componentShortPkg(pkg, module),
+			Layer:   componentLayer(pkg, module),
+			Purpose: docs[pkg],
+		})
+	}
+	return out, nil
+}
+
+// loadPackageDocFirstSentences reads real doc comments from package_docs for
+// the given packages, returning only the first sentence (via
+// context.ExtractFirstSentence — no name-based purpose inference, unlike
+// internal/context's getPackagePurposes, which falls back to a heuristic
+// guess; that fallback is exactly the kind of "guessed description" the
+// design field's zero-inference AC rules out).
+func loadPackageDocFirstSentences(db *sql.DB, pkgs []string) (map[string]string, error) {
+	if len(pkgs) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(pkgs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(pkgs))
+	for i, p := range pkgs {
+		args[i] = p
+	}
+	// #nosec G201 -- placeholders are positional parameters
+	q := "SELECT pkg_path, doc FROM package_docs WHERE pkg_path IN (" + placeholders + ")"
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query package_docs: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string, len(pkgs))
+	for rows.Next() {
+		var pkgPath, doc string
+		if err := rows.Scan(&pkgPath, &doc); err != nil {
+			return nil, fmt.Errorf("scan package_docs: %w", err)
+		}
+		out[pkgPath] = context.ExtractFirstSentence(doc)
+	}
+	return out, rows.Err()
+}
+
+// componentLayer mirrors cmd/diagram.go's layerOf: a coarse grouping label
+// for a Go package path relative to the module root.
+func componentLayer(pkg, module string) string {
+	rest := strings.TrimPrefix(pkg, module)
+	rest = strings.TrimPrefix(rest, "/")
+	if rest == "" {
+		return "root"
+	}
+	parts := strings.Split(rest, "/")
+	if parts[0] == "internal" && len(parts) >= 2 {
+		return "internal/" + parts[1]
+	}
+	return parts[0]
+}
+
+// componentShortPkg mirrors cmd/diagram.go's shortPkg: the package path with
+// the module prefix stripped.
+func componentShortPkg(pkg, module string) string {
+	rest := strings.TrimPrefix(pkg, module)
+	rest = strings.TrimPrefix(rest, "/")
+	if rest == "" {
+		return path.Base(pkg)
+	}
+	return rest
+}

--- a/internal/c4/facts.go
+++ b/internal/c4/facts.go
@@ -535,7 +535,7 @@ func mergeExternalSystems(envSystems, importSystems []ExternalSystem) []External
 			if token == "" {
 				continue
 			}
-			if token == e.Name || strings.Contains(e.Name, token) || strings.Contains(token, e.Name) {
+			if token == e.Name {
 				matchIdx = i
 				break
 			}

--- a/internal/c4/facts_test.go
+++ b/internal/c4/facts_test.go
@@ -1,0 +1,360 @@
+package c4_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/c4"
+	"github.com/dkoosis/snipe/internal/index"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+const (
+	testModule    = "github.com/example/proj"
+	testGoVersion = "1.26"
+)
+
+// newC4TestRepo opens a fresh store (full migrated schema) and writes a
+// go.mod to a temp dir so goVersionFromMod has something to read. Returns the
+// store and the repo dir to pass as BuildFacts' dir argument.
+func newC4TestRepo(t *testing.T) (*store.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	goMod := "module " + testModule + "\n\ngo " + testGoVersion + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	if err := s.SetMeta("module_path", testModule); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetMeta("repo_root", dir); err != nil {
+		t.Fatal(err)
+	}
+	return s, dir
+}
+
+func addSymbol(t *testing.T, db *sql.DB, id, name, kind, pkgPath, filePath string, lineStart int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO symbols (id, name, kind, pkg_path, file_path, line_start, col_start, line_end, col_end)
+		VALUES (?, ?, ?, ?, ?, ?, 1, ?, 1)
+	`, id, name, kind, pkgPath, filePath, lineStart, lineStart)
+	if err != nil {
+		t.Fatalf("insert symbol %s: %v", name, err)
+	}
+}
+
+func addImport(t *testing.T, db *sql.DB, filePath, pkgPath, importerPkg string, line int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO imports (file_path, pkg_path, line, col, importer_pkg)
+		VALUES (?, ?, ?, 1, ?)
+	`, filePath, pkgPath, line, importerPkg)
+	if err != nil {
+		t.Fatalf("insert import %s -> %s: %v", importerPkg, pkgPath, err)
+	}
+}
+
+func TestBuildFacts_Container(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addSymbol(t, s.DB(), "m1", "main", "func", testModule, filepath.Join(dir, "main.go"), 5)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Containers) != 1 {
+		t.Fatalf("want 1 container, got %d: %+v", len(f.Containers), f.Containers)
+	}
+	got := f.Containers[0]
+	if got.Name != "proj" {
+		t.Errorf("want container name %q, got %q", "proj", got.Name)
+	}
+	if got.Tech != "Go 1.26" {
+		t.Errorf("want tech %q, got %q", "Go 1.26", got.Tech)
+	}
+	if got.Line != 5 {
+		t.Errorf("want line 5, got %d", got.Line)
+	}
+}
+
+func TestBuildFacts_Datastore(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/store/db.go"), "modernc.org/sqlite", testModule+"/internal/store", 3)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Datastores) != 1 {
+		t.Fatalf("want 1 datastore, got %d: %+v", len(f.Datastores), f.Datastores)
+	}
+	if f.Datastores[0].Name != "SQLite" {
+		t.Errorf("want SQLite, got %q", f.Datastores[0].Name)
+	}
+	if f.Datastores[0].Package != testModule+"/internal/store" {
+		t.Errorf("want package %q, got %q", testModule+"/internal/store", f.Datastores[0].Package)
+	}
+}
+
+func TestBuildFacts_ExternalEnv_GroupsByStrippedToken(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	refs := []index.StringRef{
+		{ID: "1111111111111111", Value: "VOYAGE_API_URL", Kind: "env", FilePath: filepath.Join(dir, "a.go"), Line: 10},
+		{ID: "2222222222222222", Value: "VOYAGE_MODEL", Kind: "env", FilePath: filepath.Join(dir, "a.go"), Line: 12},
+		{ID: "3333333333333333", Value: "SNIPE_VOYAGE_API_KEY", Kind: "env", FilePath: filepath.Join(dir, "b.go"), Line: 3},
+	}
+	// module is "proj" here, not "snipe" — SNIPE_ isn't the module token, so it
+	// stays in the grouping key unless it collides with role tokens. Use a
+	// module named "voyageclient" instead so the module-token strip is exercised
+	// the same way the design field's SNIPE example exercises it on snipe itself.
+	if err := s.SetMeta("module_path", "github.com/example/snipe"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 1 {
+		t.Fatalf("want 1 external system, got %d: %+v", len(f.External), f.External)
+	}
+	got := f.External[0]
+	if got.Name != "VOYAGE" {
+		t.Errorf("want name VOYAGE, got %q", got.Name)
+	}
+	if len(got.Evidence) != 3 {
+		t.Errorf("want 3 evidence entries, got %d: %v", len(got.Evidence), got.Evidence)
+	}
+}
+
+func TestBuildFacts_ExternalEnv_IgnoresNonMatchingSuffix(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	refs := []index.StringRef{
+		{ID: "4444444444444444", Value: "SOME_RANDOM_VALUE", Kind: "env", FilePath: filepath.Join(dir, "a.go"), Line: 1},
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 0 {
+		t.Errorf("want 0 external systems, got %d: %+v", len(f.External), f.External)
+	}
+}
+
+func TestBuildFacts_ExternalImport_TestifyExcluded(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/foo_test.go"), "github.com/stretchr/testify/assert", testModule+"/cmd", 4)
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/foo_test.go"), "github.com/google/go-cmp/cmp", testModule+"/cmd", 5)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range f.External {
+		if e.Name == "github.com/stretchr/testify" || e.Name == "github.com/google/go-cmp" {
+			t.Errorf("testify/go-cmp must never appear as an external system, got %+v", f.External)
+		}
+	}
+}
+
+func TestBuildFacts_ExternalImport_TestOnlyExcluded(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	// A non-allowlisted third-party import used only from a _test.go file must
+	// be excluded (design field: "excluding test-only ... every importing file
+	// is *_test.go").
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/foo_test.go"), "github.com/some/testonlylib", testModule+"/cmd", 4)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 0 {
+		t.Errorf("want 0 external systems (test-only import excluded), got %+v", f.External)
+	}
+}
+
+func TestBuildFacts_ExternalImport_ExcludesOwnModuleAndGolangX(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/root.go"), testModule+"/internal/query", testModule+"/cmd", 1)
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/root.go"), "golang.org/x/tools/go/packages", testModule+"/cmd", 2)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 0 {
+		t.Errorf("want 0 external systems, got %+v", f.External)
+	}
+}
+
+func TestBuildFacts_MergesEnvAndImportForSameService(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	refs := []index.StringRef{
+		{ID: "5555555555555555", Value: "STRIPE_API_KEY", Kind: "env", FilePath: filepath.Join(dir, "billing/pay.go"), Line: 20},
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+	addImport(t, s.DB(), filepath.Join(dir, "billing/pay.go"), "github.com/stripe/stripe-go/v72", testModule+"/billing", 5)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 1 {
+		t.Fatalf("want 1 merged external system, got %d: %+v", len(f.External), f.External)
+	}
+	got := f.External[0]
+	if got.Kind != "env+import" {
+		t.Errorf("want kind env+import, got %q", got.Kind)
+	}
+	if len(got.Evidence) != 2 {
+		t.Errorf("want 2 evidence entries (env + import), got %d: %v", len(got.Evidence), got.Evidence)
+	}
+	// Regression: the import side's evidence must carry its real import
+	// line (5), not a fabricated Line:1 that happens to look "earlier" than
+	// the env hit's line (20) and silently wins the merge's evidence pick.
+	if got.File != filepath.Join(dir, "billing/pay.go") || got.Line != 5 {
+		t.Errorf("want import evidence pay.go:5, got %s:%d", got.File, got.Line)
+	}
+}
+
+func TestBuildFacts_ExternalImport_RealLineEvidence(t *testing.T) {
+	// Regression: externalFromImports must report the import statement's
+	// actual line, not a hardcoded Line:1 — a prior version's SQL never
+	// selected `line`, so every import-detected external system reported
+	// file:1 regardless of where the import really was.
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/root.go"), "github.com/alecthomas/kong", testModule+"/cmd", 42)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 1 {
+		t.Fatalf("want 1 external system, got %d: %+v", len(f.External), f.External)
+	}
+	got := f.External[0]
+	if got.File != filepath.Join(dir, "cmd/root.go") || got.Line != 42 {
+		t.Errorf("want root.go:42 (real import line), got %s:%d", got.File, got.Line)
+	}
+}
+
+func TestBuildFacts_MergedExternalSystem_FlowKeepsImporterPackage(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	refs := []index.StringRef{
+		{ID: "6666666666666666", Value: "STRIPE_API_KEY", Kind: "env", FilePath: filepath.Join(dir, "billing/pay.go"), Line: 20},
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+	addImport(t, s.DB(), filepath.Join(dir, "billing/pay.go"), "github.com/stripe/stripe-go/v72", testModule+"/billing", 5)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var flow *c4.Flow
+	for i := range f.Flows {
+		if f.Flows[i].To == "STRIPE" {
+			flow = &f.Flows[i]
+			break
+		}
+	}
+	if flow == nil {
+		t.Fatalf("want a flow to STRIPE, got %+v", f.Flows)
+	}
+	// A merged env+import system's flow must still attribute the real
+	// importing package (testModule+"/billing"), not fall back to the
+	// env-only "From: ''" branch just because the display name changed.
+	if flow.From != testModule+"/billing" {
+		t.Errorf("want From=%q, got %q (flow degraded to env-only despite import evidence)", testModule+"/billing", flow.From)
+	}
+}
+
+func TestBuildFacts_FlowDeterminism(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	// Two occurrences of the same driver import from the same package, at
+	// different files/lines — the flow must pick the lowest-sorted file, then
+	// lowest line, not an arbitrary first match.
+	addImport(t, s.DB(), filepath.Join(dir, "internal/store/z.go"), "modernc.org/sqlite", testModule+"/internal/store", 9)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/store/a.go"), "modernc.org/sqlite", testModule+"/internal/store", 3)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var flow *c4.Flow
+	for i := range f.Flows {
+		if f.Flows[i].Kind == "datastore" {
+			flow = &f.Flows[i]
+			break
+		}
+	}
+	if flow == nil {
+		t.Fatal("want a datastore flow, found none")
+	}
+	if flow.File != filepath.Join(dir, "internal/store/a.go") || flow.Line != 3 {
+		t.Errorf("want a.go:3 (lowest file, then line), got %s:%d", flow.File, flow.Line)
+	}
+}
+
+func TestBuildFacts_Component_RootPackageShortName(t *testing.T) {
+	// Regression: componentShortPkg's fallback (pkg == module, e.g. the root
+	// "main" package) must match cmd/diagram.go's shortPkg and return the
+	// short base name, not the full module import path. A prior version
+	// returned the full path for this one case, reachable on snipe's own
+	// repo since main.go's importer_pkg is exactly the module path.
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "main.go"), testModule+"/cmd", testModule, 1)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelComponent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root *c4.Component
+	for i := range f.Components {
+		if f.Components[i].Name == "proj" {
+			root = &f.Components[i]
+			break
+		}
+	}
+	if root == nil {
+		names := make([]string, len(f.Components))
+		for i, c := range f.Components {
+			names[i] = c.Name
+		}
+		t.Fatalf("want a root component named %q (path.Base of module), got names %v", "proj", names)
+	}
+}
+
+func TestBuildFacts_LevelContext_NoContainers(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addSymbol(t, s.DB(), "m1", "main", "func", testModule, filepath.Join(dir, "main.go"), 5)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Containers) != 0 {
+		t.Errorf("--level context must not include containers, got %+v", f.Containers)
+	}
+	if f.Module != testModule {
+		t.Errorf("want module %q, got %q", testModule, f.Module)
+	}
+}

--- a/internal/c4/facts_test.go
+++ b/internal/c4/facts_test.go
@@ -111,10 +111,10 @@ func TestBuildFacts_ExternalEnv_GroupsByStrippedToken(t *testing.T) {
 		{ID: "2222222222222222", Value: "VOYAGE_MODEL", Kind: "env", FilePath: filepath.Join(dir, "a.go"), Line: 12},
 		{ID: "3333333333333333", Value: "SNIPE_VOYAGE_API_KEY", Kind: "env", FilePath: filepath.Join(dir, "b.go"), Line: 3},
 	}
-	// module is "proj" here, not "snipe" — SNIPE_ isn't the module token, so it
-	// stays in the grouping key unless it collides with role tokens. Use a
-	// module named "voyageclient" instead so the module-token strip is exercised
-	// the same way the design field's SNIPE example exercises it on snipe itself.
+	// Override the default test module to "snipe" so SNIPE_VOYAGE_API_KEY's
+	// module-token strip is exercised the same way the design field's SNIPE
+	// example exercises it on snipe itself (newC4TestRepo's default module,
+	// "github.com/example/proj", wouldn't strip the SNIPE_ prefix at all).
 	if err := s.SetMeta("module_path", "github.com/example/snipe"); err != nil {
 		t.Fatal(err)
 	}
@@ -231,6 +231,34 @@ func TestBuildFacts_MergesEnvAndImportForSameService(t *testing.T) {
 	// the env hit's line (20) and silently wins the merge's evidence pick.
 	if got.File != filepath.Join(dir, "billing/pay.go") || got.Line != 5 {
 		t.Errorf("want import evidence pay.go:5, got %s:%d", got.File, got.Line)
+	}
+}
+
+func TestBuildFacts_MergeDoesNotFalsePositiveOnPrefixOverlap(t *testing.T) {
+	// Regression: mergeExternalSystems previously matched via
+	// strings.Contains in both directions, so an env group whose name is a
+	// substring of an unrelated import's org token (e.g. "OPEN" inside
+	// "OPENAI") would incorrectly merge two distinct services into one.
+	s, dir := newC4TestRepo(t)
+	refs := []index.StringRef{
+		{ID: "7777777777777777", Value: "OPEN_API_KEY", Kind: "env", FilePath: filepath.Join(dir, "a.go"), Line: 10},
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+	addImport(t, s.DB(), filepath.Join(dir, "b.go"), "github.com/openai/openai-go", testModule+"/pkg", 3)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.External) != 2 {
+		t.Fatalf("want 2 distinct external systems (OPEN env group, github.com/openai import), got %d: %+v", len(f.External), f.External)
+	}
+	for _, e := range f.External {
+		if e.Kind == "env+import" {
+			t.Errorf("want no merge between OPEN and github.com/openai, got merged system %+v", e)
+		}
 	}
 }
 

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -967,16 +967,21 @@ type TraceResult struct {
 // ============================================================================
 
 // C4Result is the response for `snipe c4`. One result per invocation; Level
-// controls which sections downstream `--level` filtering populated (see
-// internal/c4.BuildFacts). Slices are non-nil-on-empty via Response[T]'s
-// MarshalJSON guarantee (AXI #5) — `.results` is always an array, never null.
+// controls which sections `--level` filtering populated (see
+// internal/c4.BuildFacts). Datastores/External are computed for every level
+// and carry no `omitempty` — a section with zero facts (e.g. a repo with no
+// datastores) must still serialize as `[]`, not be silently absent;
+// buildC4Response initializes both to an empty, non-nil slice. Containers/
+// Flows/Components stay `omitempty`: they're level-gated (e.g. `--level
+// context` never populates Containers at all) and an absent key correctly
+// signals "not part of this level," not "computed empty."
 type C4Result struct {
 	Module     string             `json:"module"`
 	GoVersion  string             `json:"go_version,omitempty"`
 	Level      string             `json:"level"`
 	Containers []C4Container      `json:"containers,omitempty"`
-	Datastores []C4Datastore      `json:"datastores,omitempty"`
-	External   []C4ExternalSystem `json:"external,omitempty"`
+	Datastores []C4Datastore      `json:"datastores"`
+	External   []C4ExternalSystem `json:"external"`
 	Flows      []C4Flow           `json:"flows,omitempty"`
 	Components []C4Component      `json:"components,omitempty"`
 }

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -961,3 +961,66 @@ type TraceResult struct {
 	Enclosing *Enclosing      `json:"enclosing,omitempty"`
 	Callers   []CallerPreview `json:"callers,omitempty"`
 }
+
+// ============================================================================
+// C4 types - facts-only architecture inventory for `snipe c4`.
+// ============================================================================
+
+// C4Result is the response for `snipe c4`. One result per invocation; Level
+// controls which sections downstream `--level` filtering populated (see
+// internal/c4.BuildFacts). Slices are non-nil-on-empty via Response[T]'s
+// MarshalJSON guarantee (AXI #5) — `.results` is always an array, never null.
+type C4Result struct {
+	Module     string             `json:"module"`
+	GoVersion  string             `json:"go_version,omitempty"`
+	Level      string             `json:"level"`
+	Containers []C4Container      `json:"containers,omitempty"`
+	Datastores []C4Datastore      `json:"datastores,omitempty"`
+	External   []C4ExternalSystem `json:"external,omitempty"`
+	Flows      []C4Flow           `json:"flows,omitempty"`
+	Components []C4Component      `json:"components,omitempty"`
+}
+
+// C4Container is a deployable process (today, always a Go main package).
+type C4Container struct {
+	Name string `json:"name"`
+	Tech string `json:"tech"`
+	File string `json:"file"`
+	Line int    `json:"line"`
+}
+
+// C4Datastore is a package that imports a driver from the fixed allowlist.
+type C4Datastore struct {
+	Name    string `json:"name"`
+	Driver  string `json:"driver"`
+	Package string `json:"package"`
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+}
+
+// C4ExternalSystem is a third-party service detected via env-var literals
+// and/or third-party SDK imports.
+type C4ExternalSystem struct {
+	Name     string   `json:"name"`
+	Kind     string   `json:"kind"` // "env" | "import" | "env+import"
+	Evidence []string `json:"evidence"`
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
+}
+
+// C4Flow is a directed edge from an importer package to a datastore or
+// external system.
+type C4Flow struct {
+	From string `json:"from,omitempty"`
+	To   string `json:"to"`
+	Kind string `json:"kind"` // "datastore" | "external"
+	File string `json:"file"`
+	Line int    `json:"line"`
+}
+
+// C4Component is a package-level breakdown entry for `--level component`.
+type C4Component struct {
+	Name    string `json:"name"`
+	Layer   string `json:"layer"`
+	Purpose string `json:"purpose,omitempty"`
+}

--- a/internal/query/literals.go
+++ b/internal/query/literals.go
@@ -47,6 +47,37 @@ func FindLiteralRefs(db *sql.DB, value string) ([]LiteralRef, error) {
 	return out, rows.Err()
 }
 
+// FindLiteralsByKind returns every string_refs row of the given kind ("env",
+// "const", or "fixture"), ordered by file_path, line, col — plain columns,
+// satisfying the ORDER BY guard test. No existing helper lists all rows of one
+// kind; FindLiteralRefs requires an exact known value, which the c4 command's
+// env-var external-system detection doesn't have (it scans every env lit and
+// filters by regex instead).
+func FindLiteralsByKind(db *sql.DB, kind string) ([]LiteralRef, error) {
+	rows, err := db.Query(`
+		SELECT id, value, COALESCE(name,''), kind, file_path, COALESCE(file_path_rel,''),
+		       line, col, COALESCE(enclosing_id,''), COALESCE(snippet,'')
+		FROM string_refs
+		WHERE kind = ?
+		ORDER BY file_path, line, col
+	`, kind)
+	if err != nil {
+		return nil, fmt.Errorf("query string_refs by kind: %w", err)
+	}
+	defer rows.Close()
+
+	var out []LiteralRef
+	for rows.Next() {
+		var r LiteralRef
+		if err := rows.Scan(&r.ID, &r.Value, &r.Name, &r.Kind, &r.FilePath, &r.FilePathRel,
+			&r.Line, &r.Col, &r.EnclosingID, &r.Snippet); err != nil {
+			return nil, fmt.Errorf("scan string_ref: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // FindChurnLiterals returns the distinct golden/testdata fixture paths named as
 // string literals in the given test files — the fixtures a symbol change is
 // likely to force Claude to regenerate. Results are deduped by value, sorted by

--- a/internal/query/literals_test.go
+++ b/internal/query/literals_test.go
@@ -55,6 +55,44 @@ func TestFindLiteralRefs_Missing(t *testing.T) {
 	}
 }
 
+func TestFindLiteralsByKind(t *testing.T) {
+	s := openLitTestStore(t)
+	refs := []index.StringRef{
+		{ID: "aabbccddeeff0011", Value: "VOYAGE_API_URL", Kind: "env", FilePath: "/b.go", Line: 3, Col: 5},
+		{ID: "1122334455667788", Value: "fixtureConst", Name: "fixtureConst", Kind: "const", FilePath: "/a.go", Line: 1, Col: 1},
+		{ID: "2233445566778899", Value: "SNIPE_VOYAGE_API_KEY", Kind: "env", FilePath: "/a.go", Line: 7, Col: 2},
+	}
+	if err := s.WriteLiterals(refs, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := query.FindLiteralsByKind(s.DB(), "env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 env refs, got %d: %+v", len(got), got)
+	}
+	// ORDER BY file_path, line, col: /a.go:7 sorts before /b.go:3.
+	if got[0].FilePath != "/a.go" || got[0].Value != "SNIPE_VOYAGE_API_KEY" {
+		t.Errorf("index 0: unexpected %+v", got[0])
+	}
+	if got[1].FilePath != "/b.go" || got[1].Value != "VOYAGE_API_URL" {
+		t.Errorf("index 1: unexpected %+v", got[1])
+	}
+}
+
+func TestFindLiteralsByKind_Empty(t *testing.T) {
+	s := openLitTestStore(t)
+	got, err := query.FindLiteralsByKind(s.DB(), "env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want 0, got %d", len(got))
+	}
+}
+
 // churnFixture seeds string_refs covering both predicate arms (testdata/ and
 // .golden), a dup across two covering test files, a non-matching literal, and a
 // match in a NON-covering file — so a single fixture exercises scoping, the two

--- a/test/blackbox/c4_test.go
+++ b/test/blackbox/c4_test.go
@@ -157,9 +157,24 @@ func TestC4_ResultsNeverNull(t *testing.T) {
 		t.Fatalf("want 1 result, got %d", len(results))
 	}
 	r := requireMap(t, results[0], "results[0]")
-	// datastores/external/flows may be omitted (omitempty) when empty, but
-	// they must never be present-and-null.
-	for _, field := range []string{"datastores", "external", "flows", "components"} {
+	// datastores/external are computed for every level and must always be
+	// present as a non-null array, even when empty — a consumer doing
+	// `.results[0].datastores | length` should never see a missing key or
+	// null.
+	for _, field := range []string{"datastores", "external"} {
+		v, ok := r[field]
+		if !ok {
+			t.Errorf("field %q must always be present, got no key", field)
+			continue
+		}
+		if v == nil {
+			t.Errorf("field %q is present but null; want a non-null (possibly empty) array", field)
+		}
+	}
+	// containers/flows/components are level-gated: absent is the correct
+	// signal that this level doesn't populate them, but present-and-null
+	// would still be a bug.
+	for _, field := range []string{"containers", "flows", "components"} {
 		if v, ok := r[field]; ok && v == nil {
 			t.Errorf("field %q is present but null; want omitted or a non-null array", field)
 		}

--- a/test/blackbox/c4_test.go
+++ b/test/blackbox/c4_test.go
@@ -1,0 +1,206 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeC4Fixture writes a repo shaped for the c4 command's three signal
+// kinds: a Go main entry point (container), a package importing a SQLite
+// driver (datastore), a package with a fake external SDK import plus an
+// os.Getenv env-var call (external system, per the design field's own
+// stripe-go/STRIPE_API_KEY example), and a package importing testify only
+// from a _test.go file (must NOT surface as external).
+func writeC4Fixture(t *testing.T) (repoDir string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/c4fixture\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repoDir, "main.go"), `package c4fixture
+
+func main() {}
+`)
+
+	writeFile(t, filepath.Join(repoDir, "internal/store/db.go"), `package store
+
+import _ "modernc.org/sqlite"
+
+func Open() {}
+`)
+
+	writeFile(t, filepath.Join(repoDir, "billing/pay.go"), `package billing
+
+import (
+	"os"
+
+	"github.com/stripe/stripe-go/v72"
+)
+
+// Charge is a fake charge call exercising both external-system detection
+// paths: an env-var literal and a third-party SDK import.
+func Charge() string {
+	os.Getenv("STRIPE_API_KEY")
+	return stripe.Key
+}
+`)
+
+	writeFile(t, filepath.Join(repoDir, "internal/util/assert_helper.go"), `package util
+
+func Helper() string { return "ok" }
+`)
+	writeFile(t, filepath.Join(repoDir, "internal/util/assert_helper_test.go"), `package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelper(t *testing.T) {
+	assert.Equal(t, "ok", Helper())
+}
+`)
+
+	return repoDir
+}
+
+func TestC4_ContainerLevel_JSON(t *testing.T) {
+	repoDir := writeC4Fixture(t)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := run(t, repoDir, "c4")
+	if exitCode != 0 {
+		t.Fatalf("c4 exit %d stderr=%s stdout=%s", exitCode, string(stderr), string(stdout))
+	}
+
+	resp := assertEnvelope(t, stdout, "c4")
+	assertResponseContract(t, resp, responseExpectations{command: "c4", requireRepoRoot: true, requireIndexState: true})
+
+	results := requireSlice(t, resp["results"], "results")
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	r := requireMap(t, results[0], "results[0]")
+
+	// Container: the main package, named after the module.
+	containers := requireSlice(t, r["containers"], "containers")
+	if len(containers) != 1 {
+		t.Fatalf("want 1 container, got %d: %v", len(containers), containers)
+	}
+	c := requireMap(t, containers[0], "containers[0]")
+	if name := getString(t, c["name"], "containers[0].name"); name != "c4fixture" {
+		t.Errorf("want container name c4fixture, got %q", name)
+	}
+
+	// Datastore: SQLite via modernc.org/sqlite.
+	datastores := requireSlice(t, r["datastores"], "datastores")
+	if len(datastores) != 1 {
+		t.Fatalf("want 1 datastore, got %d: %v", len(datastores), datastores)
+	}
+	d := requireMap(t, datastores[0], "datastores[0]")
+	if name := getString(t, d["name"], "datastores[0].name"); name != "SQLite" {
+		t.Errorf("want datastore SQLite, got %q", name)
+	}
+
+	// External: stripe-go import + STRIPE_API_KEY env merge into ONE system
+	// with file:line evidence (AC #3).
+	external := requireSlice(t, r["external"], "external")
+	if len(external) != 1 {
+		t.Fatalf("want 1 external system (env+import merged), got %d: %v", len(external), external)
+	}
+	e := requireMap(t, external[0], "external[0]")
+	if name := getString(t, e["name"], "external[0].name"); name != "STRIPE" {
+		t.Errorf("want external system STRIPE, got %q", name)
+	}
+	evidence := requireSlice(t, e["evidence"], "external[0].evidence")
+	if len(evidence) != 2 {
+		t.Errorf("want 2 evidence entries (env + import), got %d: %v", len(evidence), evidence)
+	}
+	file := getString(t, e["file"], "external[0].file")
+	if !strings.HasSuffix(file, "billing/pay.go") {
+		t.Errorf("want evidence file in billing/pay.go, got %q", file)
+	}
+	line := getFloat(t, e["line"], "external[0].line")
+	if line <= 0 {
+		t.Errorf("want a positive line number, got %v", line)
+	}
+
+	// testify must never surface as an external system, merged or otherwise.
+	for _, item := range external {
+		m := requireMap(t, item, "external[i]")
+		name := getString(t, m["name"], "external[i].name")
+		if strings.Contains(strings.ToLower(name), "testify") {
+			t.Errorf("testify must not appear as an external system, got %v", external)
+		}
+	}
+}
+
+func TestC4_ResultsNeverNull(t *testing.T) {
+	// A repo with none of the three signal kinds still returns a non-null
+	// results array (AC #2), just with empty sections.
+	repoDir := t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "go.mod"), "module example.com/empty\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repoDir, "main.go"), "package empty\n\nfunc main() {}\n")
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := run(t, repoDir, "c4")
+	if exitCode != 0 {
+		t.Fatalf("c4 exit %d stderr=%s stdout=%s", exitCode, string(stderr), string(stdout))
+	}
+	resp := assertEnvelope(t, stdout, "c4")
+	results := requireSlice(t, resp["results"], "results")
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	r := requireMap(t, results[0], "results[0]")
+	// datastores/external/flows may be omitted (omitempty) when empty, but
+	// they must never be present-and-null.
+	for _, field := range []string{"datastores", "external", "flows", "components"} {
+		if v, ok := r[field]; ok && v == nil {
+			t.Errorf("field %q is present but null; want omitted or a non-null array", field)
+		}
+	}
+}
+
+func TestC4_LevelContext_NoContainers(t *testing.T) {
+	repoDir := writeC4Fixture(t)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := run(t, repoDir, "c4", "--level", "context")
+	if exitCode != 0 {
+		t.Fatalf("c4 --level context exit %d stderr=%s stdout=%s", exitCode, string(stderr), string(stdout))
+	}
+	resp := assertEnvelope(t, stdout, "c4")
+	results := requireSlice(t, resp["results"], "results")
+	r := requireMap(t, results[0], "results[0]")
+	if _, ok := r["containers"]; ok {
+		t.Errorf("--level context must omit containers, got %v", r["containers"])
+	}
+}
+
+func TestC4_TextOutput(t *testing.T) {
+	repoDir := writeC4Fixture(t)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := runRaw(t, repoDir, "c4")
+	if exitCode != 0 {
+		t.Fatalf("c4 exit %d stderr=%s stdout=%s", exitCode, string(stderr), string(stdout))
+	}
+	text := string(stdout)
+	if !strings.Contains(text, "## containers") {
+		t.Errorf("want a containers section, got:\n%s", text)
+	}
+	if !strings.Contains(text, "SQLite") {
+		t.Errorf("want SQLite datastore in text output, got:\n%s", text)
+	}
+	if !strings.Contains(text, "STRIPE") {
+		t.Errorf("want STRIPE external system in text output, got:\n%s", text)
+	}
+	if strings.Contains(text, "testify") {
+		t.Errorf("testify must not appear in text output, got:\n%s", text)
+	}
+}


### PR DESCRIPTION
## Summary

`snipe c4 [--level context|container|component]` emits a C4-model fact inventory (containers, datastores, external systems, flows, components) from signals snipe already indexes — no rendering, facts only (D1/D4). Replaces the cc-plugins `c4-model` skill's Explore-agent document-code scan with one deterministic query.

- **containers**: main-package binaries + Go version
- **datastores**: known-driver imports (SQLite, database/sql, etc.)
- **external systems**: env-var literals (grouped by service prefix) + third-party imports, merged and deduped
- **flows**: importer → datastore/external edges, deterministic file:line evidence
- **components** (`--level component`): PageRank/layer-grouped package breakdown + doc-comment first sentences (zero-inference — no heuristic purpose guessing)

Dispatched through the full review pipeline (5 independent passes: plan arch-fit, plan-adherence, persistence/SQL specialist, scoped arch review, strategic-fit) — all verdict on-direction, no drift. Two real bugs surfaced and fixed in review, each with a regression test:

- `externalFromImports` never selected the import's `line`, hardcoding `Line: 1` — worse, the merge tie-break then treated that fabricated `1` as "earlier" than real env-evidence lines, silently overwriting correct file:line evidence whenever both landed in the same file.
- `componentShortPkg`'s root-package fallback (`pkg == module`) returned the full module import path instead of the short base name, diverging from the `cmd/diagram.go` helper it's meant to mirror.

Two findings were reviewed and deliberately deferred rather than folded in, each filed as its own follow-up bead: external-system detection currently flags any third-party Go import (not just true SaaS/env-evidenced dependencies) — [sn-04xb](https://github.com/dkoosis/snipe/issues); datastore facts report one row per importing package instead of grouped by driver technology — sn-igsn. Both match this bead's approved plan; narrowing either is a design change outside its scope.

Full audit trail (bundles, 5 review passes, triage decisions, final state): `~/Projects/dk/Project/snipe/plans/reviews/sn-t0ge-*.md`. Plan: `~/Projects/dk/Project/snipe/plans/c4-command.md`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/c4/... ./internal/query/...` (12 unit tests, incl. 3 new regression tests)
- [x] `go test -tags=blackbox ./test/blackbox/...` (4 blackbox tests: JSON envelope, non-null results, `--level context` scoping, text output, testify/go-cmp exclusion)
- [x] `make audit` (vet, lint 0 issues, test+cover, race, blackbox, govulncheck) — green
- [x] Self-check: `snipe c4` on the snipe repo itself — reports container `snipe` (Go), datastore SQLite, external VOYAGE, 53 lines (well under the ~80-line cap), no testify/go-cmp
- [x] `go test ./cmd -run TestHelpGolden` (new `c4.golden` + updated `root.golden`)

Closes: sn-t0ge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `snipe c4` command to inventory repository architecture.
  - Supports context, container, and component views.
  - Reports containers, datastores, external systems, dependency flows, and components.
  - Provides indented JSON and concise text output, including empty-result and truncation handling.
  - Added command help documentation covering available output and filtering options.

- **Bug Fixes**
  - Improved consistency when combining and filtering architecture evidence.

- **Tests**
  - Added coverage for architecture detection, output formats, filtering, deterministic results, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->