### PR TITLE
fix(c4): name multi-main containers after their own package

### DIFF
--- a/internal/c4/facts.go
+++ b/internal/c4/facts.go
@@ -237,11 +237,15 @@ func goVersionFromMod(dir string) (string, error) {
 }
 
 // findContainers returns one Container per distinct package declaring a
-// `func main()`, named after the module (the design field's AC expects a
-// single "snipe" container on snipe's own single-binary repo).
+// `func main()`, named after its own package (path.Base of pkg_path) so a
+// repo with multiple cmd/<tool>/main.go binaries gets distinct names per
+// container instead of one module-wide name repeated N times. The root/
+// single-binary case (pkg_path == modulePath, e.g. a top-level main.go) falls
+// back to the module display name, preserving today's behavior on snipe's
+// own single-binary repo (design field's AC: a single "snipe" container).
 func findContainers(db *sql.DB, modulePath string) ([]Container, error) {
 	rows, err := db.Query(`
-		SELECT DISTINCT file_path, line_start
+		SELECT DISTINCT file_path, COALESCE(pkg_path, ''), line_start
 		FROM symbols
 		WHERE name = 'main' AND kind = 'func'
 		ORDER BY file_path, line_start
@@ -251,21 +255,32 @@ func findContainers(db *sql.DB, modulePath string) ([]Container, error) {
 	}
 	defer rows.Close()
 
-	name := moduleDisplayName(modulePath)
+	moduleName := moduleDisplayName(modulePath)
 	var out []Container
 	for rows.Next() {
-		var file string
+		var file, pkgPath string
 		var line int
-		if err := rows.Scan(&file, &line); err != nil {
+		if err := rows.Scan(&file, &pkgPath, &line); err != nil {
 			return nil, fmt.Errorf("scan main func: %w", err)
 		}
 		out = append(out, Container{
-			Name: name,
+			Name: containerName(pkgPath, modulePath, moduleName),
 			File: file,
 			Line: line,
 		})
 	}
 	return out, rows.Err()
+}
+
+// containerName names a main-package container after its own package
+// (path.Base of pkgPath) so distinct cmd/<tool>/main.go binaries get distinct
+// names. Falls back to the module display name when pkgPath is empty or is
+// the module root itself (the single-binary case).
+func containerName(pkgPath, modulePath, moduleName string) string {
+	if pkgPath == "" || pkgPath == modulePath {
+		return moduleName
+	}
+	return path.Base(pkgPath)
 }
 
 // moduleDisplayName returns the last path segment of a module path, e.g.

--- a/internal/c4/facts_test.go
+++ b/internal/c4/facts_test.go
@@ -40,7 +40,7 @@ func newC4TestRepo(t *testing.T) (*store.Store, string) {
 	return s, dir
 }
 
-func addSymbol(t *testing.T, db *sql.DB, id, name, kind, pkgPath, filePath string, lineStart int) {
+func addSymbol(t *testing.T, db *sql.DB, id, name, kind, pkgPath, filePath string, lineStart int) { //nolint:unparam // general-purpose test fixture helper; every call site happens to pass "main" today
 	t.Helper()
 	_, err := db.Exec(`
 		INSERT INTO symbols (id, name, kind, pkg_path, file_path, line_start, col_start, line_end, col_end)
@@ -82,6 +82,33 @@ func TestBuildFacts_Container(t *testing.T) {
 	}
 	if got.Line != 5 {
 		t.Errorf("want line 5, got %d", got.Line)
+	}
+}
+
+func TestBuildFacts_Container_MultiMainDistinctNames(t *testing.T) {
+	// sn-57vf: a repo with two cmd/<tool>/main.go binaries must report two
+	// containers with distinct names derived from their own package (foo,
+	// bar), not two rows both named after the module.
+	s, dir := newC4TestRepo(t)
+	addSymbol(t, s.DB(), "m1", "main", "func", testModule+"/cmd/foo", filepath.Join(dir, "cmd/foo/main.go"), 5)
+	addSymbol(t, s.DB(), "m2", "main", "func", testModule+"/cmd/bar", filepath.Join(dir, "cmd/bar/main.go"), 7)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Containers) != 2 {
+		t.Fatalf("want 2 containers, got %d: %+v", len(f.Containers), f.Containers)
+	}
+	names := make(map[string]bool)
+	for _, c := range f.Containers {
+		names[c.Name] = true
+	}
+	if !names["foo"] || !names["bar"] {
+		t.Errorf("want containers named %q and %q, got %v", "foo", "bar", names)
+	}
+	if names["proj"] {
+		t.Errorf("want no container named after the module (%q), got %v", "proj", names)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `findContainers` (internal/c4/facts.go) previously named every discovered main-package container after one module-wide display name, so a repo with multiple `cmd/<tool>/main.go` binaries reported N identically-named containers (CodeRabbit flagged this on sn-t0ge's PR #214).
- Now derives each container's name from `symbols.pkg_path` via `path.Base`, falling back to the module display name for the root/single-binary case — preserves snipe's own self-check output unchanged.
- Added `TestBuildFacts_Container_MultiMainDistinctNames` (two synthetic `cmd/foo` + `cmd/bar` main packages) proving two distinct container names, following existing fixture conventions in `facts_test.go`.

## Test plan
- [x] `go test ./internal/c4/...` — new + existing tests pass
- [x] `make audit` equivalent: vet, lint (0 issues, verified with `--allow-parallel-runners` due to a concurrent lint run from a sibling worktree), test, race, blackbox, govulncheck — all green

Closes: sn-57vf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container naming for projects with multiple command-line tools.
  * Containers now use each tool’s package name, while preserving the module name for root or unspecified packages.
  * Prevented multiple binaries from being incorrectly grouped under the same container name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->