### PR TITLE
fix(triage): resolve package for files with no indexed symbols

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -298,6 +298,27 @@ func runIndex(args []string) error {
 		return fmt.Errorf("write files: %w", err)
 	}
 
+	// Write file→package fallback rows (sn-dzbj): tier-2 (loader) covers every
+	// file go/packages actually loaded, including symbol-less ones (doc.go);
+	// tier-3 (header) covers files go/packages never loaded at all
+	// (build-tag-excluded), via the bare package name captured in
+	// ExtractFileInfo. Loader MUST write first — tier-3's INSERT OR IGNORE
+	// relies on it to implement "same-dir loader row wins" (write.go doc).
+	filePkgs := index.ExtractFilePackages(result)
+	if err := s.WriteFilePackages(filePkgs, absDir, store.FilePackageSourceLoader); err != nil {
+		return fmt.Errorf("write file packages (loader): %w", err)
+	}
+	headerPkgs := make([]index.FilePackage, 0, len(files))
+	for _, f := range files {
+		if f.PackageName == "" {
+			continue
+		}
+		headerPkgs = append(headerPkgs, index.FilePackage{Path: f.Path, PkgPath: f.PackageName})
+	}
+	if err := s.WriteFilePackages(headerPkgs, absDir, store.FilePackageSourceHeader); err != nil {
+		return fmt.Errorf("write file packages (header): %w", err)
+	}
+
 	// Store fingerprint and metadata
 	if err := s.SetMeta("fingerprint", fp.Combined); err != nil {
 		return fmt.Errorf("store fingerprint: %w", err)
@@ -783,6 +804,26 @@ func runIncrementalIndex(s *store.Store, result *index.LoadResult, allSymbols []
 	}
 	if err := s.WriteFiles(files); err != nil {
 		return fmt.Errorf("write files: %w", err)
+	}
+
+	// Write file→package fallback rows (sn-dzbj) — same two-tier write as the
+	// full-reindex path (see comment there). `result`/`files` cover ALL files
+	// here too (ExtractFileInfo/the go/packages load are not filtered to
+	// changed files), so this stays correct on every incremental run, not just
+	// full reindexes.
+	filePkgs := index.ExtractFilePackages(result)
+	if err := s.WriteFilePackages(filePkgs, absDir, store.FilePackageSourceLoader); err != nil {
+		return fmt.Errorf("write file packages (loader): %w", err)
+	}
+	headerPkgs := make([]index.FilePackage, 0, len(files))
+	for _, f := range files {
+		if f.PackageName == "" {
+			continue
+		}
+		headerPkgs = append(headerPkgs, index.FilePackage{Path: f.Path, PkgPath: f.PackageName})
+	}
+	if err := s.WriteFilePackages(headerPkgs, absDir, store.FilePackageSourceHeader); err != nil {
+		return fmt.Errorf("write file packages (header): %w", err)
 	}
 
 	// Update metadata

--- a/cmd/triage.go
+++ b/cmd/triage.go
@@ -136,9 +136,15 @@ func triageRelPath(root, f string) string {
 	return relToRoot(root, f)
 }
 
-// resolveFilePackage looks up the real Go package for a file via the
-// symbols table's pkg_path column — NOT path-dirname (plan: package must be
-// the real Go package). Returns "" when the file has no indexed symbols.
+// resolveFilePackage looks up the real Go package for a file — NOT
+// path-dirname (plan: package must be the real Go package). It tries, in
+// order: (1) symbols.pkg_path — the common case, most authoritative; (2)
+// file_packages.pkg_path (schema v20) — covers files that contribute zero
+// indexed symbols, either because go/packages loaded the file but it declares
+// no func/type/const/var (doc.go) or because go/packages never loaded it at
+// all (build-tag-excluded), the latter via a file-local `package X` parse
+// rather than a canonical import path. Returns "" only when neither
+// mechanism found any package identity for the file (sn-dzbj).
 func resolveFilePackage(db *sql.DB, rel string) string {
 	var pkg sql.NullString
 	err := db.QueryRow(`
@@ -147,6 +153,11 @@ func resolveFilePackage(db *sql.DB, rel string) string {
 		ORDER BY pkg_path
 		LIMIT 1
 	`, rel).Scan(&pkg)
+	if err == nil && pkg.String != "" {
+		return pkg.String
+	}
+
+	err = db.QueryRow(`SELECT pkg_path FROM file_packages WHERE file_path_rel = ?`, rel).Scan(&pkg)
 	if err != nil {
 		return ""
 	}

--- a/cmd/triage_test.go
+++ b/cmd/triage_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dkoosis/snipe/internal/index"
 	"github.com/dkoosis/snipe/internal/store"
 )
 
@@ -288,6 +289,65 @@ func TestTriage_TestFileInput_CountsAsTested(t *testing.T) {
 	}
 	if len(got.FilesWithTests) != 1 || got.FilesWithTests[0] != "cmd/thing_test.go" {
 		t.Errorf("a _test.go file declaring TestThing must count as tested, got with_tests=%v without=%v", got.FilesWithTests, got.FilesWithoutTests)
+	}
+}
+
+// TestTriage_ResolvesPackageForSymbolFreeFile pins the sn-dzbj fix: a file
+// that contributes ZERO rows to symbols (doc.go-style — package-comment-only,
+// or a file go/packages never loaded) must still resolve a real package via
+// the file_packages fallback table, and package_count must count it instead
+// of silently undercounting.
+func TestTriage_ResolvesPackageForSymbolFreeFile(t *testing.T) {
+	root := t.TempDir()
+	s, err := store.Open(store.DefaultIndexPath(root))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer s.Close()
+	if err := s.SetMeta("repo_root", root); err != nil {
+		t.Fatalf("set repo_root: %v", err)
+	}
+
+	// cmd/other.go: normal case, package resolves via symbols.pkg_path.
+	insertTriageSymbol(t, s, root, "sym-qux", "Qux", "cmd/other.go")
+
+	// cmd/doc.go: NO symbols row at all — simulates a doc.go with only a
+	// package-level comment (ExtractSymbols finds nothing to emit) or a
+	// build-tag-excluded file. Its package identity comes ONLY from
+	// file_packages, written the way a real `snipe index` run would via
+	// index.ExtractFilePackages / WriteFilePackages(source="loader").
+	if err := s.WriteFilePackages([]index.FilePackage{
+		{Path: filepath.Join(root, "cmd/doc.go"), PkgPath: "example.com/newpkg"},
+	}, root, store.FilePackageSourceLoader); err != nil {
+		t.Fatalf("write file_packages: %v", err)
+	}
+
+	t.Chdir(root)
+	stdout, _, err := runCLI(t, "--format", "json", "triage", "cmd/other.go", "cmd/doc.go")
+	if err != nil {
+		t.Fatalf("triage error: %v", err)
+	}
+	var got triageJSON
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, stdout)
+	}
+
+	byPath := map[string]string{}
+	for _, f := range got.Files {
+		byPath[f.Path] = f.Package
+	}
+	if byPath["cmd/doc.go"] != "example.com/newpkg" {
+		t.Errorf("cmd/doc.go package = %q, want example.com/newpkg (via file_packages fallback, not empty)", byPath["cmd/doc.go"])
+	}
+	if byPath["cmd/other.go"] != "example.com/p" {
+		t.Errorf("cmd/other.go package = %q, want example.com/p", byPath["cmd/other.go"])
+	}
+
+	// package_count must include the symbol-free file's package — the bug
+	// this bead fixes was resolveFilePackage returning "" for it, which drops
+	// the file out of pkgSeen and silently undercounts.
+	if got.PackageCount != 2 {
+		t.Errorf("package_count = %d, want 2 (example.com/p + example.com/newpkg)", got.PackageCount)
 	}
 }
 

--- a/internal/index/files.go
+++ b/internal/index/files.go
@@ -13,10 +13,11 @@ import (
 
 // FileInfo represents file metadata for change detection
 type FileInfo struct {
-	Path   string
-	Mtime  int64
-	Hash   string
-	Header string // leading comment block above package clause (cleaned, capped)
+	Path        string
+	Mtime       int64
+	Hash        string
+	Header      string // leading comment block above package clause (cleaned, capped)
+	PackageName string // bare `package <name>` clause; "" if unparsed/unknown
 }
 
 // maxHeaderLen caps the stored header length to keep token budget honest (D4).
@@ -80,23 +81,26 @@ func computeFileInfo(path string) (FileInfo, error) {
 		return FileInfo{}, err // HashFileSHA256 already includes path context
 	}
 
-	header, _ := extractFileHeader(path) // best-effort; empty on error
+	header, pkgName, _ := extractFileHeader(path) // best-effort; empty on error
 
 	return FileInfo{
-		Path:   path,
-		Mtime:  stat.ModTime().Unix(),
-		Hash:   hash,
-		Header: header,
+		Path:        path,
+		Mtime:       stat.ModTime().Unix(),
+		Hash:        hash,
+		Header:      header,
+		PackageName: pkgName,
 	}, nil
 }
 
-// extractFileHeader reads the leading comment block above the `package` clause.
-// Skips build constraints (`//go:build`, `// +build`). Joins consecutive `//`
-// lines with spaces and caps at maxHeaderLen.
-func extractFileHeader(path string) (string, error) {
+// extractFileHeader reads the leading comment block above the `package` clause,
+// plus the bare package name declared on that clause (tier-3 fallback identity
+// for resolveFilePackage when go/packages never loaded the file at all — see
+// ExtractFilePackages). Skips build constraints (`//go:build`, `// +build`).
+// Joins consecutive `//` lines with spaces and caps at maxHeaderLen.
+func extractFileHeader(path string) (header, pkgName string, err error) {
 	f, err := os.Open(path) // #nosec G304 -- path from indexer walk
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer f.Close()
 
@@ -107,6 +111,7 @@ func extractFileHeader(path string) (string, error) {
 		line := strings.TrimRight(sc.Text(), " \t")
 		trim := strings.TrimSpace(line)
 		if strings.HasPrefix(trim, "package ") {
+			pkgName = strings.TrimSpace(strings.TrimPrefix(trim, "package "))
 			break
 		}
 		if trim == "" {
@@ -126,7 +131,7 @@ func extractFileHeader(path string) (string, error) {
 	if len(joined) > maxHeaderLen {
 		joined = joined[:maxHeaderLen] + "…"
 	}
-	return joined, nil
+	return joined, pkgName, nil
 }
 
 // HashFileSHA256 computes a truncated SHA256 hash of a file (16 hex chars).

--- a/internal/index/loader.go
+++ b/internal/index/loader.go
@@ -224,6 +224,34 @@ func loadPackagesChunked(ctx context.Context, dir string, fset *token.FileSet, p
 	}, nil
 }
 
+// FilePackage maps one source file to the Go package that declares it,
+// derived directly from go/packages — populated even for files that
+// contribute zero *indexed symbols* (e.g. doc.go: package-comment-only, no
+// func/type/const/var declarations for ExtractSymbols to find). Covers the
+// resolveFilePackage tier-2 fallback in cmd/triage.go (sn-dzbj).
+type FilePackage struct {
+	Path    string // absolute path — matches Symbol.FilePath / FileInfo.Path
+	PkgPath string
+}
+
+// ExtractFilePackages walks the same pkg.Syntax/pkg.GoFiles pairing
+// ExtractSymbols uses (symbols.go:ExtractSymbols), but records one row per
+// loaded file unconditionally, regardless of whether it declares any symbols
+// ExtractSymbols would emit. This is the source of the canonical (full
+// import-path) file→package mapping for symbol-less-but-loaded files.
+func ExtractFilePackages(result *LoadResult) []FilePackage {
+	var out []FilePackage
+	for _, pkg := range result.Packages {
+		for i := range pkg.Syntax {
+			if i >= len(pkg.GoFiles) {
+				continue
+			}
+			out = append(out, FilePackage{Path: pkg.GoFiles[i], PkgPath: pkg.PkgPath})
+		}
+	}
+	return out
+}
+
 // dropTestBinaryPackages removes test-binary packages (PkgPath ending in
 // ".test") that go/packages synthesizes when Tests is true. Their only file
 // is a generated _testmain.go in the go-build cache — indexing it pollutes

--- a/internal/index/loader_test.go
+++ b/internal/index/loader_test.go
@@ -253,3 +253,45 @@ func TestLoad_ExcludesTestBinaryPackages(t *testing.T) {
 		}
 	}
 }
+
+// TestExtractFilePackages_CoversSymbolFreeFile pins the sn-dzbj fix's tier-2
+// source: a doc.go file that go/packages loads but that declares no
+// func/type/const/var (so ExtractSymbols emits zero Symbol rows for it) must
+// still appear in ExtractFilePackages, with the package's canonical import
+// path — the fallback resolveFilePackage (cmd/triage.go) reads via
+// WriteFilePackages/file_packages.
+func TestExtractFilePackages_CoversSymbolFreeFile(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"go.mod":  "module example.com/tarn\n\ngo 1.22\n",
+		"doc.go":  "// Package tarn does a thing.\npackage tarn\n",
+		"real.go": "package tarn\n\nfunc Real() int { return 1 }\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := Load(LoadConfig{Dir: dir})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	got := ExtractFilePackages(result)
+	byPath := make(map[string]string, len(got))
+	for _, fp := range got {
+		byPath[filepath.Base(fp.Path)] = fp.PkgPath
+	}
+
+	docPkg, ok := byPath["doc.go"]
+	if !ok {
+		t.Fatalf("doc.go missing from ExtractFilePackages result: %+v", got)
+	}
+	if docPkg != "example.com/tarn" {
+		t.Errorf("doc.go package = %q, want example.com/tarn", docPkg)
+	}
+	if realPkg := byPath["real.go"]; realPkg != "example.com/tarn" {
+		t.Errorf("real.go package = %q, want example.com/tarn", realPkg)
+	}
+}

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const schemaVersion = 19
+const schemaVersion = 20
 
 // migration represents a database migration.
 type migration struct {
@@ -283,6 +283,18 @@ var migrations = []migration{
 			score        REAL NOT NULL
 		);
 		CREATE INDEX IF NOT EXISTS idx_file_churn_commits ON file_churn(commits);
+		`,
+	},
+	{
+		version: 20,
+		name:    "file_packages_table",
+		up: `
+		CREATE TABLE IF NOT EXISTS file_packages (
+			file_path_rel TEXT PRIMARY KEY,
+			pkg_path      TEXT NOT NULL,
+			source        TEXT NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_file_packages_pkg ON file_packages(pkg_path);
 		`,
 	},
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -106,7 +106,7 @@ func TestSchemaCreation(t *testing.T) {
 	defer s.Close()
 
 	// Verify tables exist by querying them
-	tables := []string{"symbols", "refs", "call_graph", "meta", "files", "package_docs"}
+	tables := []string{"symbols", "refs", "call_graph", "meta", "files", "package_docs", "file_packages"}
 	for _, table := range tables {
 		var count int
 		err := s.DB().QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count)
@@ -120,8 +120,8 @@ func TestSchemaCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMeta(schema_version) failed: %v", err)
 	}
-	if version != "19" {
-		t.Errorf("schema_version = %q, want %q", version, "19")
+	if version != "20" {
+		t.Errorf("schema_version = %q, want %q", version, "20")
 	}
 }
 

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -425,6 +425,69 @@ func (s *Store) WriteFiles(files []index.FileInfo) (err error) {
 	return nil
 }
 
+// File-package source tags for the file_packages table (schema v20). Loader
+// rows carry the canonical Go import path go/packages resolved (tier 2 in
+// resolveFilePackage); header rows carry a bare package-name parse used only
+// when go/packages never loaded the file at all (tier 3).
+const (
+	FilePackageSourceLoader = "loader"
+	FilePackageSourceHeader = "header"
+)
+
+// WriteFilePackages populates the file_packages table, the fallback path
+// resolveFilePackage (cmd/triage.go) uses when a file contributes zero rows to
+// symbols (doc.go-style, or build-tag-excluded).
+//
+// Source-scoped delete: only rows for the given source are cleared before
+// insert, so a tier-2 refresh during incremental indexing can't wipe tier-3
+// rows written by a prior full index (or vice versa) — each call only ever
+// owns its own source's slice of the table.
+//
+// file_path_rel is the PRIMARY KEY across ALL sources (one package identity
+// per file), so the two tiers use different conflict resolution:
+//   - FilePackageSourceLoader (authoritative): INSERT OR REPLACE — a fresh
+//     go/packages load always supersedes a stale tier-3 guess for the same file.
+//   - FilePackageSourceHeader (fallback): INSERT OR IGNORE — so calling this
+//     AFTER the loader call in the same index run leaves any already-committed
+//     tier-2 row untouched. This is what implements "same-dir loader row wins"
+//     (sn-dzbj plan §7 open-question 1); callers MUST write loader before header.
+func (s *Store) WriteFilePackages(pkgs []index.FilePackage, repoRoot, source string) (err error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { rollbackOnError(tx, &err) }()
+
+	if _, err := tx.Exec(`DELETE FROM file_packages WHERE source = ?`, source); err != nil {
+		return fmt.Errorf("clear file_packages source=%s: %w", source, err)
+	}
+
+	verb := "INSERT OR IGNORE"
+	if source == FilePackageSourceLoader {
+		verb = "INSERT OR REPLACE"
+	}
+	stmt, err := tx.Prepare(verb + ` INTO file_packages (file_path_rel, pkg_path, source) VALUES (?, ?, ?)`) // #nosec G201 -- verb is one of two hardcoded constants, never user input
+	if err != nil {
+		return fmt.Errorf("prepare file_packages insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, p := range pkgs {
+		if p.PkgPath == "" {
+			continue
+		}
+		rel := toRelPath(p.Path, repoRoot)
+		if _, err := stmt.Exec(rel, p.PkgPath, source); err != nil {
+			return fmt.Errorf("insert file_packages %s: %w", rel, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+	return nil
+}
+
 // GetAllFiles retrieves all stored file metadata for change detection.
 func (s *Store) GetAllFiles() (map[string]index.FileInfo, error) {
 	rows, err := s.db.Query(`SELECT path, mtime, COALESCE(hash, '') FROM files`)

--- a/internal/store/write_test.go
+++ b/internal/store/write_test.go
@@ -856,3 +856,101 @@ func TestWritePackageDocsEmptyClearsTable(t *testing.T) {
 		t.Errorf("want empty table, got %d rows", n)
 	}
 }
+
+// TestWriteFilePackages_LoaderWinsOverHeader pins the sn-dzbj write ordering
+// invariant (write.go doc on WriteFilePackages): a loader (tier-2) row for a
+// path always wins over a header (tier-3) row for the same path, regardless
+// of which call happens first within a run — INSERT OR REPLACE for loader,
+// INSERT OR IGNORE for header, against the shared file_path_rel primary key.
+func TestWriteFilePackages_LoaderWinsOverHeader(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+	root := "/repo"
+
+	// Normal run order: loader first, then header for the complement. A file
+	// covered by loader must not be shadowed by a stale/weaker header guess.
+	if err := s.WriteFilePackages([]index.FilePackage{
+		{Path: "/repo/pkg/a.go", PkgPath: "example.com/repo/pkg"},
+	}, root, FilePackageSourceLoader); err != nil {
+		t.Fatalf("write loader: %v", err)
+	}
+	if err := s.WriteFilePackages([]index.FilePackage{
+		{Path: "/repo/pkg/a.go", PkgPath: "pkg"}, // bare name, would be wrong if it won
+		{Path: "/repo/other/b.go", PkgPath: "other"},
+	}, root, FilePackageSourceHeader); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+
+	got := map[string]string{}
+	rows, err := s.DB().Query(`SELECT file_path_rel, pkg_path FROM file_packages`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rel, pkg string
+		if err := rows.Scan(&rel, &pkg); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[rel] = pkg
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	if got["pkg/a.go"] != "example.com/repo/pkg" {
+		t.Errorf("pkg/a.go = %q, want loader's example.com/repo/pkg (header must not shadow it)", got["pkg/a.go"])
+	}
+	if got["other/b.go"] != "other" {
+		t.Errorf("other/b.go = %q, want header's bare name (no loader row to shadow)", got["other/b.go"])
+	}
+}
+
+// TestWriteFilePackages_SourceScopedDelete confirms a refresh of one source
+// never touches rows from the other source — the whole point of scoping the
+// DELETE by source (write.go doc): a tier-2 refresh during incremental
+// indexing must not wipe tier-3 rows from a prior full index, and vice versa.
+func TestWriteFilePackages_SourceScopedDelete(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+	root := "/repo"
+
+	if err := s.WriteFilePackages([]index.FilePackage{
+		{Path: "/repo/a.go", PkgPath: "example.com/repo/a"},
+	}, root, FilePackageSourceLoader); err != nil {
+		t.Fatalf("seed loader: %v", err)
+	}
+	if err := s.WriteFilePackages([]index.FilePackage{
+		{Path: "/repo/b.go", PkgPath: "b"},
+	}, root, FilePackageSourceHeader); err != nil {
+		t.Fatalf("seed header: %v", err)
+	}
+
+	// Refresh loader with an EMPTY set (e.g. a run where go/packages loaded
+	// nothing new) — the header row for b.go must survive untouched.
+	if err := s.WriteFilePackages(nil, root, FilePackageSourceLoader); err != nil {
+		t.Fatalf("refresh loader empty: %v", err)
+	}
+
+	var loaderCount, headerCount int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM file_packages WHERE source = ?`, FilePackageSourceLoader).Scan(&loaderCount); err != nil {
+		t.Fatalf("count loader: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM file_packages WHERE source = ?`, FilePackageSourceHeader).Scan(&headerCount); err != nil {
+		t.Fatalf("count header: %v", err)
+	}
+	if loaderCount != 0 {
+		t.Errorf("loader rows = %d, want 0 (refreshed with empty set)", loaderCount)
+	}
+	if headerCount != 1 {
+		t.Errorf("header rows = %d, want 1 (untouched by loader-scoped refresh)", headerCount)
+	}
+}


### PR DESCRIPTION
## Summary

- `resolveFilePackage()` in `cmd/triage.go` joined only through `symbols.pkg_path`, so a file contributing zero symbol rows (doc.go-style package-comment-only files, build-tag-excluded files, or a newly-added file not yet in the symbols table) always resolved `""` and silently dropped out of `package_count`.
- Adds a two-tier fallback via a new `file_packages` table (schema v20):
  - **tier 2 (`loader`)**: `index.ExtractFilePackages` walks the same `pkg.Syntax`/`pkg.GoFiles` pairing `ExtractSymbols` uses, recording one row per file `go/packages` actually loaded — including doc.go files that declare zero symbols — with the canonical `pkg_path`.
  - **tier 3 (`header`)**: covers files `go/packages` never loaded at all (build-tag-excluded), via a file-local `package X` parse extending `extractFileHeader`'s existing scan.
  - Tier 2 always wins a same-path conflict (`INSERT OR REPLACE` vs tier 3's `INSERT OR IGNORE`), so a build-tag-excluded file's bare package name never shadows its directory's canonical import path once the file is actually loaded.
- Wired into both the full-reindex and incremental `snipe index` paths (`cmd/index.go`).

## Test plan

- [x] New `cmd/triage_test.go` case (`TestTriage_ResolvesPackageForSymbolFreeFile`) proves a file with zero `symbols` rows resolves its package via the `file_packages` fallback, and `package_count` no longer undercounts it.
- [x] `internal/index/loader_test.go` — `TestExtractFilePackages_CoversSymbolFreeFile` proves a doc.go file lands in `ExtractFilePackages` output.
- [x] `internal/store/write_test.go` — `TestWriteFilePackages_LoaderWinsOverHeader` and `TestWriteFilePackages_SourceScopedDelete` pin the tier-ordering and source-scoped-delete invariants.
- [x] `internal/store/store_test.go` — `TestSchemaCreation` updated for schema v20 + `file_packages` table.
- [x] `make audit` green (vet, lint, unit+race tests, blackbox, govulncheck).

Closes: sn-dzbj