### PR TITLE
feat(diagram): rank pluggable interfaces by fan-in as a seam map (sn-l1kh.5)

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -398,6 +398,7 @@ type DiagramCmd struct {
 	Arch      DiagramArchCmd      `cmd:"" help:"Package import graph trimmed to the top-N by PageRank, grouped by layer. Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)"`
 	Flow      DiagramFlowCmd      `cmd:"" help:"Depth-limited call graph from an entry symbol"`
 	Lifecycle DiagramLifecycleCmd `cmd:"" help:"Render lifecycle CRUD groups for a type as D2"`
+	Seams     DiagramSeamsCmd     `cmd:"" help:"Rank pluggable interfaces by implementation count and fan-in. Writes docs/diagrams/seam-map.md by default (--format d2/svg for stdout)"`
 }
 
 // AfterApply maps the global --format into the diagram package var. Unset
@@ -444,6 +445,15 @@ type DiagramLifecycleCmd struct {
 
 func (c *DiagramLifecycleCmd) Run() error {
 	return runDiagramLifecycle([]string{c.Type})
+}
+
+type DiagramSeamsCmd struct {
+	Top int `default:"20" help:"Max ranked seams to render (0 = no cap)"`
+}
+
+func (c *DiagramSeamsCmd) Run() error {
+	diagramSeamsTopN = c.Top
+	return runDiagramSeams()
 }
 
 type LifecycleCmd struct {

--- a/cmd/seammap.go
+++ b/cmd/seammap.go
@@ -1,0 +1,288 @@
+package cmd
+
+// sn-l1kh.5: seam map — surface where THIS repo is intentionally extensible.
+//
+// A "seam" here is an interface that (a) has at least one concrete
+// implementation and (b) is leaned on from more than one call site — an
+// interface satisfied by exactly one type and referenced nowhere outside its
+// own file is dependency inversion in name only, not a real extension point.
+//
+// Reuses query.FindImplementers (the same lookup `snipe impl` uses) and
+// query.FindRefs (the same lookup `snipe refs`/lifecycle use) rather than
+// inventing new traversal. The new surface here is the ranking (fan-in +
+// implementation count -> one score) and the docs/diagrams/seam-map.md
+// render, which reuses diagram.Builder + emitDoc/writeDiagramDoc from
+// cmd/diagram.go (sn-l1kh.1) unchanged.
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dkoosis/snipe/internal/diagram"
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+)
+
+// minSeamFanIn excludes interfaces touched by fewer than this many distinct
+// call-site files (outside the interface's own definition file). "A seam
+// touched by 1 caller isn't really a seam" (sn-l1kh.5 acceptance) — it's
+// dependency inversion nobody depends on yet.
+const minSeamFanIn = 2
+
+// seamInterface is the minimal projection of an interface symbol needed to
+// build a Seam. Populated by a direct query rather than query.LookupByID,
+// since we only need a handful of columns across potentially many rows.
+type seamInterface struct {
+	ID          string
+	Name        string
+	PkgPath     string
+	FilePath    string
+	FilePathRel string
+	LineStart   int
+}
+
+// Seam is one ranked extension point: an interface, its implementations, and
+// how much other code leans on it.
+type Seam struct {
+	Interface seamInterface
+	Impls     []query.SymbolRow
+	FanInDeg  int // distinct call-site files referencing the interface, excluding its own def file
+	FanInPkgs int // distinct packages among those call sites
+	Score     int
+}
+
+// scoreSeam combines fan-in and implementation count into one ranking score.
+// Fan-in is weighted higher than implementation count: a seam's value comes
+// from how widely other code depends on the abstraction, not merely from how
+// many concrete types happen to satisfy it (an interface can be a genuine
+// seam with just one implementation, e.g. for testability).
+func scoreSeam(fanInPkgs, implCount int) int {
+	return fanInPkgs*2 + implCount
+}
+
+// rankSeams filters out interfaces that aren't real seams (no implementation,
+// or fan-in below minSeamFanIn), scores the rest, and sorts by score
+// descending, breaking ties by name for determinism.
+func rankSeams(seams []Seam) []Seam {
+	out := make([]Seam, 0, len(seams))
+	for i := range seams {
+		if len(seams[i].Impls) == 0 || seams[i].FanInDeg < minSeamFanIn {
+			continue
+		}
+		seams[i].Score = scoreSeam(seams[i].FanInPkgs, len(seams[i].Impls))
+		out = append(out, seams[i])
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].Interface.Name < out[j].Interface.Name
+	})
+	return out
+}
+
+// seamFanIn computes distinct call-site files and distinct packages that
+// reference an interface type, given its usage refs (query.FindRefs output)
+// and a file->package lookup. Refs inside defFile (the interface's own
+// definition file) are excluded — a self-reference (e.g. an embedding alias
+// declared alongside the interface) doesn't demonstrate the interface being
+// leaned on elsewhere.
+func seamFanIn(refs []query.RefRow, defFile string, fileToPkg map[string]string) (sites, pkgs int) {
+	siteSet := make(map[string]bool, len(refs))
+	pkgSet := make(map[string]bool, len(refs))
+	for i := range refs {
+		if refs[i].FilePath == defFile {
+			continue
+		}
+		siteSet[refs[i].FilePath] = true
+		if pkg := fileToPkg[refs[i].FilePath]; pkg != "" {
+			pkgSet[pkg] = true
+		}
+	}
+	return len(siteSet), len(pkgSet)
+}
+
+// findInterfaceSymbols enumerates interfaces defined in-repo (excludes
+// symbols outside the indexed tree and _test.go-only interfaces, which aren't
+// real extension points).
+func findInterfaceSymbols(db *sql.DB) ([]seamInterface, error) {
+	rows, err := db.Query(`
+		SELECT id, name, pkg_path, file_path, file_path_rel, line_start
+		FROM symbols
+		WHERE kind = ?
+		  AND file_path_rel != ''
+		  AND file_path NOT LIKE '%_test.go'
+		ORDER BY name, file_path_rel
+	`, cmdKindInterface)
+	if err != nil {
+		return nil, fmt.Errorf("query interfaces: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []seamInterface
+	for rows.Next() {
+		var si seamInterface
+		if err := rows.Scan(&si.ID, &si.Name, &si.PkgPath, &si.FilePath, &si.FilePathRel, &si.LineStart); err != nil {
+			return nil, fmt.Errorf("scan interface row: %w", err)
+		}
+		out = append(out, si)
+	}
+	return out, rows.Err()
+}
+
+// fileToPkgMap builds an absolute-file-path -> package-path lookup from the
+// symbols table (every file belongs to exactly one package, so any symbol
+// defined in a file names that file's package).
+func fileToPkgMap(db *sql.DB) (map[string]string, error) {
+	rows, err := db.Query(`SELECT DISTINCT file_path, pkg_path FROM symbols WHERE pkg_path != '' AND file_path != ''`)
+	if err != nil {
+		return nil, fmt.Errorf("query file->pkg map: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]string{}
+	for rows.Next() {
+		var file, pkg string
+		if err := rows.Scan(&file, &pkg); err != nil {
+			return nil, fmt.Errorf("scan file->pkg row: %w", err)
+		}
+		out[file] = pkg
+	}
+	return out, rows.Err()
+}
+
+// buildSeams enumerates every in-repo interface, finds its implementations
+// and fan-in, and returns the unranked, unfiltered set. rankSeams applies the
+// seam threshold and ordering.
+func buildSeams(db *sql.DB) ([]Seam, error) {
+	ifaces, err := findInterfaceSymbols(db)
+	if err != nil {
+		return nil, err
+	}
+	fileToPkg, err := fileToPkgMap(db)
+	if err != nil {
+		return nil, err
+	}
+
+	seams := make([]Seam, 0, len(ifaces))
+	for _, iface := range ifaces {
+		// Cap well above realistic fan-out; this is a comprehension view, not
+		// a paginated listing.
+		impls, err := query.FindImplementers(db, iface.ID, 1000, 0)
+		if err != nil {
+			return nil, fmt.Errorf("find implementers of %s: %w", iface.Name, err)
+		}
+		refs, err := query.FindRefs(db, iface.ID, 5000, 0)
+		if err != nil {
+			return nil, fmt.Errorf("find refs of %s: %w", iface.Name, err)
+		}
+		sites, pkgs := seamFanIn(refs, iface.FilePath, fileToPkg)
+		seams = append(seams, Seam{
+			Interface: iface,
+			Impls:     impls,
+			FanInDeg:  sites,
+			FanInPkgs: pkgs,
+		})
+	}
+	return seams, nil
+}
+
+// seamNodeStyle highlights the top-3 ranked seams so the diagram's visual
+// hierarchy matches the ranking, mirroring nodeStyleForRank's tiering for the
+// arch diagram (pos is 1-indexed rank within the rendered set).
+func seamNodeStyle(pos int) map[string]string {
+	switch {
+	case pos <= 3:
+		return map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue}
+	case pos <= 10:
+		return map[string]string{diagramFill: "#fef3c7"}
+	default:
+		return nil
+	}
+}
+
+// perSeamImplCap bounds how many implementations are drawn per seam node so
+// a widely-implemented interface (e.g. an error type or io.Writer-shaped
+// thing) doesn't blow up the diagram.
+const perSeamImplCap = 6
+
+// buildSeamMap renders the Claude-summary text and D2 source for a ranked
+// seam list, following the same emit shape as runDiagramArch/Flow/Lifecycle.
+func buildSeamMap(seams []Seam, totalInterfaces int) (summary, d2src string) {
+	var b diagram.Builder
+	b.Title = "snipe seam map · pluggable interfaces / extension points"
+	b.Direction = "right"
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "seam map · %d seams ranked (of %d interfaces scanned) · score = fan_in_pkgs*2 + impl_count\n", len(seams), totalInterfaces)
+	if len(seams) == 0 {
+		sb.WriteString("  no seams found — either no interfaces have implementations, or none clear the fan-in>=2 bar\n")
+	}
+	for i := range seams {
+		s := &seams[i]
+		pos := i + 1
+		fmt.Fprintf(&sb, "%2d. %-28s impl=%-3d fan_pkgs=%-3d fan_sites=%-3d score=%-3d  %s:%d\n",
+			pos, s.Interface.Name, len(s.Impls), s.FanInPkgs, s.FanInDeg, s.Score,
+			s.Interface.FilePathRel, s.Interface.LineStart)
+
+		nodeID := diagram.SanitizeID(fmt.Sprintf("seam_%s", s.Interface.ID))
+		label := fmt.Sprintf("%s  (impl=%d fan=%d)", s.Interface.Name, len(s.Impls), s.FanInPkgs)
+		b.AddNode(nodeID, label, "diamond", seamNodeStyle(pos))
+
+		shown := s.Impls
+		truncated := 0
+		if len(shown) > perSeamImplCap {
+			truncated = len(shown) - perSeamImplCap
+			shown = shown[:perSeamImplCap]
+		}
+		for j := range shown {
+			impl := &shown[j]
+			implLabel := impl.Name
+			if impl.FilePathRel != "" {
+				fmt.Fprintf(&sb, "      - %s  (%s)\n", impl.Name, impl.FilePathRel)
+			} else {
+				fmt.Fprintf(&sb, "      - %s\n", impl.Name)
+			}
+			implID := nodeID + "_" + diagram.SanitizeID(impl.PkgPath+"."+impl.Name)
+			b.AddNode(implID, implLabel, "", nil)
+			b.AddDashedEdge(implID, nodeID, "implements")
+		}
+		if truncated > 0 {
+			fmt.Fprintf(&sb, "      + %d more implementations\n", truncated)
+			moreID := nodeID + "_more"
+			b.AddNode(moreID, fmt.Sprintf("+%d more", truncated), "", map[string]string{"font-color": "#6b7280"})
+			b.AddDashedEdge(moreID, nodeID, "implements")
+		}
+	}
+
+	return sb.String(), b.Render()
+}
+
+// diagramSeamsTopN caps how many ranked seams are rendered; set by
+// DiagramSeamsCmd.Run (cmd/commands.go).
+var diagramSeamsTopN int
+
+// runDiagramSeams is the Kong entry point for `snipe diagram seams`.
+func runDiagramSeams() error {
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+	s, _, err := OpenStore(w, "diagram seams")
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	all, err := buildSeams(s.DB())
+	if err != nil {
+		return fmt.Errorf("build seams: %w", err)
+	}
+	ranked := rankSeams(all)
+	if diagramSeamsTopN > 0 && len(ranked) > diagramSeamsTopN {
+		ranked = ranked[:diagramSeamsTopN]
+	}
+
+	summary, d2src := buildSeamMap(ranked, len(all))
+	return emitDoc("seam-map", summary, d2src)
+}

--- a/cmd/seammap_test.go
+++ b/cmd/seammap_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/query"
+)
+
+// sn-l1kh.5: scoreSeam weights fan-in (packages leaning on the abstraction)
+// over raw implementation count — a widely-depended-on interface with one
+// implementation still matters more than a rarely-used interface with many.
+func TestScoreSeam(t *testing.T) {
+	cases := []struct {
+		name             string
+		fanInPkgs, impls int
+		want             int
+	}{
+		{"zero everything", 0, 0, 0},
+		{"fan-in dominates", 5, 1, 11},
+		{"impl-heavy but low fan-in", 1, 8, 10},
+		{"balanced", 3, 3, 9},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := scoreSeam(c.fanInPkgs, c.impls)
+			if got != c.want {
+				t.Errorf("scoreSeam(%d, %d) = %d, want %d", c.fanInPkgs, c.impls, got, c.want)
+			}
+		})
+	}
+}
+
+// seamFanIn must exclude refs inside the interface's own definition file
+// (self-references don't demonstrate the interface being leaned on
+// elsewhere) and must dedupe by file and by package.
+func TestSeamFanIn(t *testing.T) {
+	fileToPkg := map[string]string{
+		"/repo/internal/store/store.go":  "internal/store",
+		"/repo/internal/store/sqlite.go": "internal/store",
+		"/repo/cmd/impl.go":              "cmd",
+		"/repo/internal/query/lookup.go": "internal/query",
+	}
+	defFile := "/repo/internal/store/store.go"
+
+	refs := []query.RefRow{
+		{FilePath: defFile},                          // same-file: excluded
+		{FilePath: "/repo/internal/store/sqlite.go"}, // same pkg as def, different file
+		{FilePath: "/repo/internal/store/sqlite.go"}, // duplicate file: deduped
+		{FilePath: "/repo/cmd/impl.go"},              // different pkg
+		{FilePath: "/repo/internal/query/lookup.go"}, // different pkg
+		{FilePath: "/repo/unmapped/file.go"},         // no pkg mapping: counts as a site, not a pkg
+	}
+
+	sites, pkgs := seamFanIn(refs, defFile, fileToPkg)
+	if sites != 4 {
+		t.Errorf("sites = %d, want 4 (distinct non-def files: sqlite.go, impl.go, lookup.go, unmapped/file.go)", sites)
+	}
+	if pkgs != 3 {
+		t.Errorf("pkgs = %d, want 3 (internal/store, cmd, internal/query)", pkgs)
+	}
+}
+
+func TestSeamFanIn_AllExcludedWhenOnlySelfFile(t *testing.T) {
+	defFile := "/repo/x.go"
+	refs := []query.RefRow{{FilePath: defFile}, {FilePath: defFile}}
+	sites, pkgs := seamFanIn(refs, defFile, map[string]string{"/repo/x.go": "x"})
+	if sites != 0 || pkgs != 0 {
+		t.Errorf("sites=%d pkgs=%d, want 0,0 when every ref is the def file", sites, pkgs)
+	}
+}
+
+// rankSeams must drop non-seams: zero implementations, or fan-in below the
+// "touched by only 1 caller isn't a seam" threshold.
+func TestRankSeams_FiltersNonSeams(t *testing.T) {
+	seams := []Seam{
+		{Interface: seamInterface{Name: "NoImpls"}, Impls: nil, FanInDeg: 5, FanInPkgs: 3},
+		{Interface: seamInterface{Name: "OneCaller"}, Impls: []query.SymbolRow{{Name: "T"}}, FanInDeg: 1, FanInPkgs: 1},
+		{Interface: seamInterface{Name: "RealSeam"}, Impls: []query.SymbolRow{{Name: "T"}}, FanInDeg: 2, FanInPkgs: 2},
+	}
+
+	got := rankSeams(seams)
+	if len(got) != 1 {
+		t.Fatalf("got %d seams, want 1 (only RealSeam clears both bars): %+v", len(got), got)
+	}
+	if got[0].Interface.Name != "RealSeam" {
+		t.Errorf("got %q, want RealSeam", got[0].Interface.Name)
+	}
+}
+
+// rankSeams must sort by score descending, breaking ties by name ascending
+// so output is deterministic across runs.
+func TestRankSeams_SortsByScoreThenName(t *testing.T) {
+	mk := func(name string, impls int, fanInPkgs, fanInDeg int) Seam {
+		is := make([]query.SymbolRow, impls)
+		for i := range is {
+			is[i] = query.SymbolRow{Name: "Impl"}
+		}
+		return Seam{Interface: seamInterface{Name: name}, Impls: is, FanInPkgs: fanInPkgs, FanInDeg: fanInDeg}
+	}
+
+	seams := []Seam{
+		mk("Zebra", 1, 5, 2),  // score = 5*2+1 = 11
+		mk("Alpha", 1, 5, 2),  // score = 11, ties with Zebra -> name breaks tie
+		mk("Middle", 2, 3, 2), // score = 3*2+2 = 8
+	}
+
+	got := rankSeams(seams)
+	want := []string{"Alpha", "Zebra", "Middle"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d seams, want %d", len(got), len(want))
+	}
+	for i, name := range want {
+		if got[i].Interface.Name != name {
+			t.Errorf("position %d: got %q, want %q (full order: %v)", i, got[i].Interface.Name, name, gotNames(got))
+		}
+	}
+}
+
+func TestRankSeams_ScorePopulated(t *testing.T) {
+	seams := []Seam{
+		{Interface: seamInterface{Name: "X"}, Impls: []query.SymbolRow{{Name: "T"}}, FanInPkgs: 4, FanInDeg: 3},
+	}
+	got := rankSeams(seams)
+	if len(got) != 1 {
+		t.Fatalf("got %d seams, want 1", len(got))
+	}
+	if want := scoreSeam(4, 1); got[0].Score != want {
+		t.Errorf("Score = %d, want %d", got[0].Score, want)
+	}
+}
+
+func TestRankSeams_EmptyInput(t *testing.T) {
+	got := rankSeams(nil)
+	if len(got) != 0 {
+		t.Errorf("got %d seams from nil input, want 0", len(got))
+	}
+}
+
+func gotNames(seams []Seam) []string {
+	out := make([]string, len(seams))
+	for i, s := range seams {
+		out[i] = s.Interface.Name
+	}
+	return out
+}

--- a/cmd/testdata/help/diagram-seams.golden
+++ b/cmd/testdata/help/diagram-seams.golden
@@ -1,6 +1,7 @@
-Usage: snipe diagram <command> [flags]
+Usage: snipe diagram seams [flags]
 
-Render snipe graphs as D2 diagram source
+Rank pluggable interfaces by implementation count and fan-in. Writes
+docs/diagrams/seam-map.md by default (--format d2/svg for stdout)
 
 Flags:
   -h, --help                Show context-sensitive help.
@@ -19,17 +20,4 @@ Flags:
       --select="all"        Pick top candidates by score: all, best, top3,
                             top5 (applied before --limit)
 
-Graph & Structure:
-  diagram arch [flags]
-    Package import graph trimmed to the top-N by PageRank, grouped by layer.
-    Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)
-
-  diagram flow <entry> [flags]
-    Depth-limited call graph from an entry symbol
-
-  diagram lifecycle <type>
-    Render lifecycle CRUD groups for a type as D2
-
-  diagram seams [flags]
-    Rank pluggable interfaces by implementation count and fan-in. Writes
-    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)
+      --top=20              Max ranked seams to render (0 = no cap)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -152,6 +152,10 @@ Graph & Structure:
   diagram lifecycle <type>
     Render lifecycle CRUD groups for a type as D2
 
+  diagram seams [flags]
+    Rank pluggable interfaces by implementation count and fan-in. Writes
+    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)
+
   lifecycle [<type>] [flags]
     Trace every function creating, mutating, reading, or deleting a type
 


### PR DESCRIPTION
## Summary

- Adds `snipe diagram seams` — enumerates in-repo interfaces, reuses `query.FindImplementers`/`query.FindRefs` (same lookups `snipe impl`/`snipe refs` use) to rank them as extension points.
- A seam = interface with >=1 implementation AND fan-in from >=2 distinct call-site files outside its own definition file ("touched by 1 caller isn't really a seam" — sn-l1kh.5 acceptance).
- Score = `fan_in_pkgs*2 + impl_count`, weighting fan-in higher (a seam's value comes from how widely other code depends on it, not just implementation count).
- Writes `docs/diagrams/seam-map.md` by default (`--format d2/svg` for stdout), reusing `emitDoc`/`writeDiagramDoc` + `diagram.Builder` from `cmd/diagram.go` (sn-l1kh.1) unchanged.
- New logic isolated to `cmd/seammap.go`; `cmd/commands.go` only gets the minimal Kong wiring (`Seams` field on `DiagramCmd` + `DiagramSeamsCmd` struct).

## Verification

- Ran the built binary against snipe's own index: correctly produces an empty ranked list, since this repo's two hand-declared interfaces (`Embedder`, `embeddingSaver`) are only referenced from their own definition file — an honest result, not a bug.
- `cmd/seammap_test.go`: unit tests for `scoreSeam` weighting, `seamFanIn` dedup + definition-file exclusion, `rankSeams` non-seam filtering, and deterministic score-desc/name-asc sort.
- `go test ./cmd -run TestHelpGolden -update` regenerated `diagram.golden`/`root.golden`/`diagram-seams.golden` for the new subcommand.
- `make audit` green (vet, lint 0 issues, test, race, blackbox, govulncheck).

Closes: sn-l1kh.5

## Test plan

- [x] `make audit` passes
- [x] `cmd/seammap_test.go` covers ranking logic
- [x] Manual smoke test: `snipe diagram seams` against snipe's own index writes a valid `docs/diagrams/seam-map.md`