### PR TITLE
feat(report): add snipe report v1 — HTML dashboard for humans

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -52,6 +52,7 @@ type CLI struct {
 	C4        C4Cmd        `cmd:"" name:"c4" group:"Graph & Structure:" help:"C4 architecture fact inventory: containers, datastores, external systems, flows (facts only, no rendering)"`
 	Deadcode  DeadcodeCmd  `cmd:"" group:"Graph & Structure:" help:"Report exported symbols with zero non-test references"`
 	Guard     GuardCmd     `cmd:"" group:"Graph & Structure:" help:"Assert architecture boundary rules; exit non-zero on violation"`
+	Report    ReportCmd    `cmd:"" group:"Graph & Structure:" help:"Self-contained HTML dashboard for humans: hotspot treemap, cycles, hotspots ranking, + D2 diagram placeholder slots"`
 
 	// Embeddings
 	Sim         SimCmd   `cmd:"" group:"Embeddings:" help:"Semantic similarity search"`

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -33,6 +33,7 @@ const (
 	cmdNameIndex       = "index"
 	cmdNameEmbedStatus = "embed-status"
 	cmdNameC4          = "c4"
+	cmdNameReport      = "report"
 )
 
 // Common flag/parameter names.

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/store"
+)
+
+// report.go — `snipe report`: a self-contained HTML dashboard for HUMANS,
+// aggregating snipe's own metrics (sn-qnq3, spun off sn-fhw8's D1 amendment /
+// D7 in CLAUDE.md). Distinct from sn-l1kh's per-command docs/diagrams/*.md
+// living docs: this is snipe's one deliberate multi-artifact human page.
+//
+// v1 layout: native visuals snipe renders directly from indexed data —
+// hotspot treemap (report_treemap.go), cycles, hotspots ranking table — plus
+// placeholder slots for D2 diagrams (arch/flow/lifecycle) that an EXTERNAL
+// script fills later by running `snipe diagram X | d2 -` and injecting the
+// SVG. Snipe does NOT shell out to `d2` itself here — that keeps the `d2` CLI
+// dependency out of snipe's own report path, per the ratified design (D7).
+
+var (
+	reportOut       string
+	reportEmitShell bool
+	reportTopN      int
+)
+
+// ReportCmd is the `snipe report` CLI command. Registered in cmd/cli.go next
+// to Diagram/Lifecycle/C4 (kept in its own file rather than commands.go,
+// following the C4Cmd precedent in cmd/c4.go).
+type ReportCmd struct {
+	Out       string `default:".snipe/report" help:"Output directory for report.html + manifest.json"`
+	EmitShell bool   `name:"emit-shell" default:"true" help:"Emit the HTML shell (native visuals + D2 placeholder slots) and manifest.json — v1's only supported mode"`
+	Top       int    `default:"30" help:"Top-N files in the hotspot treemap and ranking table"`
+}
+
+// Run implements kong's command interface.
+func (c *ReportCmd) Run() error {
+	reportOut = c.Out
+	reportEmitShell = c.EmitShell
+	reportTopN = c.Top
+	return runReport()
+}
+
+// reportSummary is the --format json result for `snipe report`.
+type reportSummary struct {
+	HTMLPath     string `json:"html_path"`
+	ManifestPath string `json:"manifest_path"`
+	Files        int    `json:"files"`
+	Slots        int    `json:"slots"`
+}
+
+// runReport assembles the dashboard and writes report.html + manifest.json
+// under --out. Inputs are already indexed (hotspot rows, graph_sccs,
+// per-file func counts) — this is a rendering/assembly layer, no new
+// analysis.
+func runReport() error {
+	start := time.Now()
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+
+	if !reportEmitShell {
+		return w.WriteError(cmdNameReport, &output.Error{
+			Code:    output.ErrInternal,
+			Message: "v1 only supports --emit-shell (native visuals + D2 manifest); no other mode exists yet",
+		})
+	}
+
+	s, dir, err := OpenStore(w, cmdNameReport)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	rows, _, err := loadHotspotRows(s)
+	if err != nil {
+		return w.WriteError(cmdNameReport, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Score != rows[j].Score {
+			return rows[i].Score > rows[j].Score
+		}
+		return rows[i].Path < rows[j].Path
+	})
+	if reportTopN > 0 && len(rows) > reportTopN {
+		rows = rows[:reportTopN]
+	}
+
+	funcCounts, err := fileFuncCounts(s)
+	if err != nil {
+		return w.WriteError(cmdNameReport, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+
+	items := make([]treemapItem, 0, len(rows))
+	for _, r := range rows {
+		size := float64(funcCounts[r.Path])
+		if size <= 0 {
+			// Keep the file visible even with zero recorded funcs (e.g. a
+			// pure-const/type file) rather than collapsing it to nothing.
+			size = 1
+		}
+		items = append(items, treemapItem{Path: r.Path, Size: size, Complexity: float64(r.Cyclo)})
+	}
+	boxes := layoutTreemap(items)
+
+	importSCCs, err := s.ReadSCCs(cmdNameImports)
+	if err != nil {
+		return w.WriteError(cmdNameReport, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+	callSCCs, err := s.ReadSCCs("calls")
+	if err != nil {
+		return w.WriteError(cmdNameReport, &output.Error{Code: output.ErrInternal, Message: err.Error()})
+	}
+
+	manifest := buildReportManifest(start)
+
+	htmlDoc := assembleReportHTML(
+		dir,
+		start.UTC().Format(time.RFC3339),
+		renderTreemapHTML(boxes),
+		renderCyclesHTML(cmdNameImports, groupSCCs(importSCCs)),
+		renderCyclesHTML("calls", groupSCCs(callSCCs)),
+		renderHotspotsTableHTML(rows, funcCounts),
+		renderDiagramSlotsHTML(manifest.Slots),
+	)
+
+	if err := os.MkdirAll(reportOut, 0o755); err != nil {
+		return w.WriteError(cmdNameReport, &output.Error{Code: output.ErrInternal, Message: "mkdir out: " + err.Error()})
+	}
+	htmlPath := filepath.Join(reportOut, "report.html")
+	if err := os.WriteFile(htmlPath, []byte(htmlDoc), 0o644); err != nil { //nolint:gosec // dashboard output, not sensitive
+		return w.WriteError(cmdNameReport, &output.Error{Code: output.ErrInternal, Message: "write report.html: " + err.Error()})
+	}
+	manifestPath := filepath.Join(reportOut, "manifest.json")
+	if err := writeJSONFile(manifestPath, manifest); err != nil {
+		return err
+	}
+
+	if GetOutputFormat() == output.OutputJSON {
+		resp := output.Response[reportSummary]{
+			Protocol: output.ProtocolVersion,
+			Ok:       true,
+			Results: []reportSummary{{
+				HTMLPath:     htmlPath,
+				ManifestPath: manifestPath,
+				Files:        len(rows),
+				Slots:        len(manifest.Slots),
+			}},
+			Meta: output.Meta{
+				Command:  cmdNameReport,
+				RepoRoot: dir,
+				Ms:       time.Since(start).Milliseconds(),
+				Total:    1,
+			},
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp)
+	}
+
+	fmt.Printf("report · %s + %s · %d files · %d D2 slots pending external render\n",
+		htmlPath, manifestPath, len(rows), len(manifest.Slots))
+	return nil
+}
+
+// fileFuncCounts returns per-file function+method counts (production code
+// only — _test.go excluded, matching computeFileComplexity's convention so
+// treemap sizing and the complexity coloring agree on which files count as
+// "hot"). Keyed by file_path_rel to match hotspotRow.Path's relative form.
+func fileFuncCounts(s *store.Store) (map[string]int, error) {
+	rows, err := s.DB().Query(`
+		SELECT file_path_rel, COUNT(*)
+		FROM symbols
+		WHERE kind IN ('func', 'method')
+		  AND file_path_rel IS NOT NULL
+		  AND file_path_rel NOT LIKE '%_test.go'
+		GROUP BY file_path_rel`)
+	if err != nil {
+		return nil, fmt.Errorf("query file func counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]int)
+	for rows.Next() {
+		var path string
+		var n int
+		if err := rows.Scan(&path, &n); err != nil {
+			return nil, fmt.Errorf("scan func count row: %w", err)
+		}
+		out[path] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate func count rows: %w", err)
+	}
+	return out, nil
+}
+
+// groupSCCs collapses raw graph_sccs rows into grouped components — mirrors
+// runCyclesMetrics' grouping in metrics_cycles.go (kept as a small local copy
+// rather than refactoring that file, so this change's footprint is new files
+// only); sccGroup itself is shared, since both live in package cmd.
+func groupSCCs(rows []store.SCCRow) []sccGroup {
+	groupMap := make(map[int]*sccGroup)
+	var order []int
+	for _, r := range rows {
+		g, ok := groupMap[r.SCCID]
+		if !ok {
+			g = &sccGroup{ID: r.SCCID, Size: r.SCCSize}
+			groupMap[r.SCCID] = g
+			order = append(order, r.SCCID)
+		}
+		g.Nodes = append(g.Nodes, r.NodeID)
+	}
+	groups := make([]sccGroup, 0, len(order))
+	for _, id := range order {
+		g := groupMap[id]
+		if g.Size == 1 && len(g.Nodes) == 1 {
+			g.SelfLoop = true
+		}
+		groups = append(groups, *g)
+	}
+	return groups
+}

--- a/cmd/report_html.go
+++ b/cmd/report_html.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"fmt"
+	"html"
+	"path/filepath"
+	"strings"
+)
+
+// report_html.go renders `snipe report`'s HTML shell: native visuals (treemap,
+// cycles, hotspots table) inline, plus labeled placeholder <div>s for the D2
+// diagram slots an external script fills in later (report_manifest.go lists
+// the same slots as JSON). No templating library and no JS/CSS framework —
+// D4 (token/dependency budget) applies to shipped artifacts too, and a static
+// dashboard for humans doesn't need one.
+
+// renderTreemapBoxHTML renders one treemap box as an absolutely positioned
+// div inside a 100%x100% relatively-positioned container (the caller wraps
+// the concatenated boxes in that container).
+func renderTreemapBoxHTML(b treemapBox, maxComplexity float64) string {
+	norm := 0.0
+	if maxComplexity > 0 {
+		norm = b.Complexity / maxComplexity
+	}
+	color := colorForComplexity(norm)
+	label := filepath.Base(b.Path)
+	// Skip the label on slivers too small to hold readable text — the title
+	// attribute (tooltip) still carries the full path either way.
+	showLabel := b.WPct > 6 && b.HPct > 4
+	inner := ""
+	if showLabel {
+		inner = fmt.Sprintf(`<span class="tm-label">%s</span>`, html.EscapeString(label))
+	}
+	title := fmt.Sprintf("%s — complexity %.0f, size %.0f", b.Path, b.Complexity, b.Size)
+	return fmt.Sprintf(
+		`<div class="tm-box" style="left:%.3f%%;top:%.3f%%;width:%.3f%%;height:%.3f%%;background:%s" title='%s'>%s</div>`,
+		b.XPct, b.YPct, b.WPct, b.HPct, color, html.EscapeString(title), inner,
+	)
+}
+
+// renderTreemapHTML renders the full hotspot treemap: a relatively-positioned
+// container holding one absolutely-positioned div per box. Empty input
+// renders a "no data" placeholder rather than an empty container, so the
+// shell is still valid/legible before the index has complexity data.
+func renderTreemapHTML(boxes []treemapBox) string {
+	if len(boxes) == 0 {
+		return `<div class="empty-note">(no complexity data — run &#96;snipe index&#96; to populate)</div>`
+	}
+	maxComplexity := 0.0
+	for _, b := range boxes {
+		if b.Complexity > maxComplexity {
+			maxComplexity = b.Complexity
+		}
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="treemap">`)
+	for _, box := range boxes {
+		b.WriteString(renderTreemapBoxHTML(box, maxComplexity))
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// renderCyclesHTML renders nontrivial SCCs for one graph kind ("imports" or
+// "calls") as a labeled list — deliberately plain (no graph drawing): a cycle
+// witness is a short list of node names, not worth a diagram slot.
+func renderCyclesHTML(graphKind string, groups []sccGroup) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, `<div class="cycles-group"><h3>%s graph</h3>`, html.EscapeString(graphKind))
+	if len(groups) == 0 {
+		b.WriteString(`<div class="empty-note">no nontrivial cycles</div>`)
+	} else {
+		b.WriteString(`<ol class="cycles-list">`)
+		for _, g := range groups {
+			suffix := ""
+			if g.SelfLoop {
+				suffix = " (self-loop)"
+			}
+			fmt.Fprintf(&b, `<li><span class="cycle-size">size %d%s</span><ul>`, g.Size, suffix)
+			for _, n := range g.Nodes {
+				fmt.Fprintf(&b, `<li>%s</li>`, html.EscapeString(n))
+			}
+			b.WriteString(`</ul></li>`)
+		}
+		b.WriteString(`</ol>`)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// renderHotspotsTableHTML renders the unified risk rows (same data as `snipe
+// hotspots`) as an HTML table — the ranking companion to the treemap's
+// spatial view of the same complexity×churn scores.
+func renderHotspotsTableHTML(rows []hotspotRow, funcCounts map[string]int) string {
+	var b strings.Builder
+	b.WriteString(`<table class="hotspots-table"><thead><tr>` +
+		`<th>path</th><th>risk</th><th>cyclo</th><th>cyclo max</th><th>funcs</th><th>commits</th><th>authors</th><th>fan-in</th>` +
+		`</tr></thead><tbody>`)
+	if len(rows) == 0 {
+		b.WriteString(`<tr><td colspan="8" class="empty-note">(no complexity data — run &#96;snipe index&#96; to populate)</td></tr>`)
+	}
+	for _, r := range rows {
+		fmt.Fprintf(&b,
+			`<tr><td>%s</td><td>%.2f</td><td>%d</td><td>%d</td><td>%d</td><td>%d</td><td>%d</td><td>%d</td></tr>`,
+			html.EscapeString(r.Path), r.Score, r.Cyclo, r.CycloMax, funcCounts[r.Path], r.Commits, r.Authors, r.FanIn)
+	}
+	b.WriteString(`</tbody></table>`)
+	return b.String()
+}
+
+// renderDiagramSlotsHTML renders one labeled placeholder <div> per D2 slot in
+// `slots`. Each div's id matches the manifest slot's "id" exactly (both build
+// off reportDiagramSlots) — that's the contract the external filler script
+// relies on to know which SVG goes where.
+func renderDiagramSlotsHTML(slots []reportManifestSlot) string {
+	var b strings.Builder
+	b.WriteString(`<div class="diagram-slots">`)
+	for _, s := range slots {
+		fmt.Fprintf(&b,
+			`<div class="diagram-slot" id="%s" data-artifact-type="%s">`+
+				`<div class="slot-label">%s</div>`+
+				`<div class="slot-placeholder">(pending: %s)</div>`+
+				`</div>`,
+			html.EscapeString(s.ID), html.EscapeString(s.ArtifactType),
+			html.EscapeString(s.Description), html.EscapeString(s.Command))
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+// reportCSS is the dashboard's entire stylesheet, inlined so report.html is a
+// single self-contained file — no external CSS/JS request, matches the
+// artifact-hygiene bar this codebase already holds Claude-facing output to.
+const reportCSS = `
+:root{color-scheme:light dark;--bg:#fff;--fg:#111;--muted:#666;--border:#ddd;--card:#f7f7f8}
+@media (prefers-color-scheme:dark){:root{--bg:#0f1115;--fg:#e6e6e6;--muted:#9aa0a6;--border:#2a2d33;--card:#181a1f}}
+*{box-sizing:border-box}
+body{margin:0;padding:2rem;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+h1{font-size:1.4rem;margin:0 0 .25rem}
+h2{font-size:1.1rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--border);padding-bottom:.35rem}
+h3{font-size:.95rem;margin:0 0 .5rem;color:var(--muted)}
+.subtitle{color:var(--muted);margin:0 0 1rem;font-size:.9rem}
+section{margin-bottom:2rem}
+.treemap{position:relative;width:100%;height:420px;border:1px solid var(--border);border-radius:6px;overflow:hidden}
+.tm-box{position:absolute;border:1px solid rgba(0,0,0,.15);overflow:hidden;display:flex;align-items:flex-end;padding:2px 4px}
+.tm-label{font-size:.7rem;color:#111;background:rgba(255,255,255,.75);padding:0 3px;border-radius:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+.cycles{display:flex;gap:2rem;flex-wrap:wrap}
+.cycles-group{background:var(--card);border:1px solid var(--border);border-radius:6px;padding:1rem;min-width:260px;flex:1}
+.cycles-list{margin:0;padding-left:1.2rem}
+.cycle-size{font-weight:600}
+.empty-note{color:var(--muted);font-style:italic;padding:.5rem 0}
+table.hotspots-table{border-collapse:collapse;width:100%;font-size:.85rem}
+table.hotspots-table th,table.hotspots-table td{border-bottom:1px solid var(--border);padding:.4rem .6rem;text-align:right}
+table.hotspots-table th:first-child,table.hotspots-table td:first-child{text-align:left;font-family:ui-monospace,monospace}
+table.hotspots-table thead th{color:var(--muted);font-weight:600}
+.diagram-slots{display:flex;gap:1rem;flex-wrap:wrap}
+.diagram-slot{background:var(--card);border:1px dashed var(--border);border-radius:6px;padding:1rem;min-width:220px;flex:1}
+.slot-label{font-weight:600;margin-bottom:.4rem}
+.slot-placeholder{color:var(--muted);font-size:.8rem;font-family:ui-monospace,monospace}
+footer{margin-top:3rem;color:var(--muted);font-size:.8rem}
+`
+
+// assembleReportHTML wraps every rendered section into one self-contained
+// HTML document. generatedAt/repoRoot are for the footer; the rest are the
+// pre-rendered fragments from the render* functions above.
+func assembleReportHTML(repoRoot, generatedAt, treemapHTML, importCyclesHTML, callCyclesHTML, hotspotsTableHTML, diagramSlotsHTML string) string {
+	var b strings.Builder
+	b.WriteString("<!doctype html>\n<html><head><meta charset=\"utf-8\">")
+	b.WriteString(`<meta name="viewport" content="width=device-width,initial-scale=1">`)
+	b.WriteString("<title>snipe report</title><style>")
+	b.WriteString(reportCSS)
+	b.WriteString("</style></head><body>")
+
+	fmt.Fprintf(&b, `<h1>snipe report</h1><p class="subtitle">%s &middot; generated %s</p>`,
+		html.EscapeString(repoRoot), html.EscapeString(generatedAt))
+
+	b.WriteString(`<section><h2>hotspot treemap</h2><p class="subtitle">size = function count &middot; color = complexity (green low &rarr; red high)</p>`)
+	b.WriteString(treemapHTML)
+	b.WriteString(`</section>`)
+
+	b.WriteString(`<section><h2>cycles</h2><div class="cycles">`)
+	b.WriteString(importCyclesHTML)
+	b.WriteString(callCyclesHTML)
+	b.WriteString(`</div></section>`)
+
+	b.WriteString(`<section><h2>hotspots ranking</h2>`)
+	b.WriteString(hotspotsTableHTML)
+	b.WriteString(`</section>`)
+
+	b.WriteString(`<section><h2>architecture diagrams</h2><p class="subtitle">filled by an external script running the manifest's commands (snipe does not shell out to d2 itself)</p>`)
+	b.WriteString(diagramSlotsHTML)
+	b.WriteString(`</section>`)
+
+	b.WriteString(`<footer>snipe report v1 &middot; native visuals from indexed data, D2 slots pending external render</footer>`)
+	b.WriteString(`</body></html>`)
+	return b.String()
+}

--- a/cmd/report_manifest.go
+++ b/cmd/report_manifest.go
@@ -1,0 +1,78 @@
+package cmd
+
+import "time"
+
+// reportManifestVersion is bumped whenever the manifest JSON shape changes in
+// a way an external filler script would need to notice.
+const reportManifestVersion = 1
+
+// reportSlotIDArch, reportSlotIDFlow, reportSlotIDLifecycle are the
+// placeholder-div ids shared between the manifest (report_manifest.go) and
+// the HTML shell (report_html.go) — the external script matches a manifest
+// slot's "id" to the HTML element it injects SVG into, so the two must never
+// drift; both sides build off reportDiagramSlots below.
+const (
+	reportSlotIDArch      = "diagram-arch"
+	reportSlotIDFlow      = "diagram-flow"
+	reportSlotIDLifecycle = "diagram-lifecycle"
+)
+
+// reportManifestSlot is one D2 diagram artifact `snipe report` cannot render
+// itself (sn-qnq3 design: snipe owns the shell + manifest, an external script
+// owns D2->SVG rendering, keeping the `d2` binary dependency out of snipe).
+type reportManifestSlot struct {
+	ID           string   `json:"id"`
+	ArtifactType string   `json:"artifact_type"` // arch|flow|lifecycle
+	Description  string   `json:"description"`
+	Command      string   `json:"command"`
+	ArgsRequired []string `json:"args_required,omitempty"`
+}
+
+// reportManifest is the machine-readable companion to report.html: for each
+// D2 placeholder slot in the shell, which `snipe diagram` command to run
+// (piped into `d2 -`, per the ratified sn-qnq3 design) to produce the SVG the
+// external filler script then injects into that slot's element.
+type reportManifest struct {
+	Version     int                  `json:"version"`
+	GeneratedAt string               `json:"generated_at"`
+	Slots       []reportManifestSlot `json:"slots"`
+}
+
+// reportDiagramSlots is the single source of truth for v1's three D2 slots —
+// both buildReportManifest and the HTML shell builder read from it, so a slot
+// id can never exist on one side and not the other.
+func reportDiagramSlots() []reportManifestSlot {
+	return []reportManifestSlot{
+		{
+			ID:           reportSlotIDArch,
+			ArtifactType: "arch",
+			Description:  "Package import graph, top packages by PageRank",
+			Command:      "snipe diagram arch | d2 -",
+		},
+		{
+			ID:           reportSlotIDFlow,
+			ArtifactType: "flow",
+			Description:  "Depth-limited call graph from an entry symbol",
+			Command:      "snipe diagram flow <entry-symbol> | d2 -",
+			ArgsRequired: []string{"entry-symbol"},
+		},
+		{
+			ID:           reportSlotIDLifecycle,
+			ArtifactType: "lifecycle",
+			Description:  "CRUD trace (create/mutate/read/delete) for a type",
+			Command:      "snipe diagram lifecycle <type-name> | d2 -",
+			ArgsRequired: []string{"type-name"},
+		},
+	}
+}
+
+// buildReportManifest assembles the manifest for a report generated at
+// `generatedAt`. Pure function (no I/O) so manifest shape is unit-testable
+// without an index or filesystem.
+func buildReportManifest(generatedAt time.Time) reportManifest {
+	return reportManifest{
+		Version:     reportManifestVersion,
+		GeneratedAt: generatedAt.UTC().Format(time.RFC3339),
+		Slots:       reportDiagramSlots(),
+	}
+}

--- a/cmd/report_manifest_test.go
+++ b/cmd/report_manifest_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildReportManifestShape(t *testing.T) {
+	ts := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	m := buildReportManifest(ts)
+
+	if m.Version != reportManifestVersion {
+		t.Errorf("Version = %d, want %d", m.Version, reportManifestVersion)
+	}
+	if m.GeneratedAt != "2026-08-01T12:00:00Z" {
+		t.Errorf("GeneratedAt = %q, want RFC3339 UTC timestamp", m.GeneratedAt)
+	}
+	if len(m.Slots) != 3 {
+		t.Fatalf("got %d slots, want 3 (arch, flow, lifecycle)", len(m.Slots))
+	}
+
+	wantTypes := map[string]bool{"arch": false, "flow": false, "lifecycle": false}
+	for _, s := range m.Slots {
+		if s.ID == "" {
+			t.Errorf("slot %+v has empty ID", s)
+		}
+		if s.Command == "" {
+			t.Errorf("slot %s has empty Command", s.ID)
+		}
+		if _, ok := wantTypes[s.ArtifactType]; !ok {
+			t.Errorf("slot %s has unexpected ArtifactType %q", s.ID, s.ArtifactType)
+		}
+		wantTypes[s.ArtifactType] = true
+	}
+	for typ, seen := range wantTypes {
+		if !seen {
+			t.Errorf("no slot found for artifact type %q", typ)
+		}
+	}
+}
+
+// TestReportManifestCommandsMentionD2Pipe locks in the sn-qnq3 design: snipe
+// does not shell out to `d2` itself, so every manifest command must be a
+// `snipe diagram ...` invocation the EXTERNAL script pipes into `d2 -`.
+func TestReportManifestCommandsMentionD2Pipe(t *testing.T) {
+	m := buildReportManifest(time.Now())
+	for _, s := range m.Slots {
+		if !strings.Contains(s.Command, "snipe diagram") || !strings.Contains(s.Command, "| d2 -") {
+			t.Errorf("slot %s command %q should run `snipe diagram ...` piped into `d2 -`", s.ID, s.Command)
+		}
+	}
+}
+
+// TestReportManifestArgsRequiredMatchesTemplate ensures any slot declaring
+// ArgsRequired actually has a placeholder token in its command — a slot that
+// claims an arg is needed but whose command has nothing to fill in would
+// silently mislead the external filler script.
+func TestReportManifestArgsRequiredMatchesTemplate(t *testing.T) {
+	m := buildReportManifest(time.Now())
+	for _, s := range m.Slots {
+		for _, arg := range s.ArgsRequired {
+			token := "<" + arg + ">"
+			if !strings.Contains(s.Command, token) {
+				t.Errorf("slot %s declares arg %q but command %q has no %q placeholder", s.ID, arg, s.Command, token)
+			}
+		}
+	}
+}
+
+// TestReportManifestSlotIDsMatchHTMLSlots pins the manifest<->HTML shell
+// contract: every slot id the manifest lists must appear as an `id="..."` in
+// the rendered diagram-slots HTML, or the external script has nothing to
+// inject the SVG into.
+func TestReportManifestSlotIDsMatchHTMLSlots(t *testing.T) {
+	m := buildReportManifest(time.Now())
+	html := renderDiagramSlotsHTML(m.Slots)
+	for _, s := range m.Slots {
+		want := `id="` + s.ID + `"`
+		if !strings.Contains(html, want) {
+			t.Errorf("manifest slot %s has no matching %s in the rendered HTML shell", s.ID, want)
+		}
+	}
+}
+
+// TestBuildReportManifestJSONRoundTrip guards the "machine-readable manifest"
+// acceptance criterion directly: the struct must marshal to valid JSON an
+// external script can parse (field names as documented, not zero-valued away).
+func TestBuildReportManifestJSONRoundTrip(t *testing.T) {
+	m := buildReportManifest(time.Now())
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	for _, field := range []string{"version", "generated_at", "slots"} {
+		if _, ok := decoded[field]; !ok {
+			t.Errorf("manifest JSON missing field %q: %s", field, data)
+		}
+	}
+	slots, ok := decoded["slots"].([]interface{})
+	if !ok || len(slots) != 3 {
+		t.Fatalf("manifest JSON slots = %v, want array of 3", decoded["slots"])
+	}
+}

--- a/cmd/report_treemap.go
+++ b/cmd/report_treemap.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"math"
+	"sort"
+)
+
+// treemapItem is one file going into the hotspot treemap: Size drives box
+// area (v1: function count — cheap, always available from the index, unlike
+// filesystem LOC which would require a second disk pass), Complexity drives
+// box color (summed McCabe complexity, matching hotspotRow.Cyclo).
+type treemapItem struct {
+	Path       string
+	Size       float64
+	Complexity float64
+}
+
+// treemapBox is one placed rectangle, in percent-of-canvas coordinates
+// (0..100) so the renderer can emit plain width/height/left/top CSS with no
+// further math — a hand-rolled treemap needs no charting library (sn-qnq3).
+type treemapBox struct {
+	Path             string
+	XPct, YPct       float64
+	WPct, HPct       float64
+	Size, Complexity float64
+	Color            string
+}
+
+// layoutTreemap arranges items into non-overlapping boxes filling a 100x100
+// percentage canvas using the squarified treemap algorithm (Bruls, Huizing &
+// van Wijk, "Squarified Treemaps", 2000): items are sorted by size descending
+// and packed into rows chosen to keep each box's aspect ratio close to 1,
+// which reads far better than naively slicing proportional strips when file
+// sizes vary widely (a few huge files next to a long tail of tiny ones).
+func layoutTreemap(items []treemapItem) []treemapBox {
+	if len(items) == 0 {
+		return nil
+	}
+	sorted := make([]treemapItem, len(items))
+	copy(sorted, items)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Size != sorted[j].Size {
+			return sorted[i].Size > sorted[j].Size
+		}
+		return sorted[i].Path < sorted[j].Path
+	})
+
+	var total float64
+	for _, it := range sorted {
+		total += it.Size
+	}
+	if total <= 0 {
+		// Degenerate input (all-zero sizes): fall back to equal weighting so
+		// the canvas still fills instead of collapsing to zero-area boxes.
+		for i := range sorted {
+			sorted[i].Size = 1
+		}
+		total = float64(len(sorted))
+	}
+
+	const canvasW, canvasH = 100.0, 100.0
+	area := canvasW * canvasH
+	scaled := make([]treemapItem, len(sorted))
+	for i, it := range sorted {
+		scaled[i] = it
+		scaled[i].Size = it.Size / total * area
+	}
+
+	return squarify(scaled, canvasW, canvasH)
+}
+
+// squarify iteratively grows a "row" of items one at a time as long as doing
+// so improves (or does not worsen) the worst aspect ratio in the row, then
+// lays that row out along the shorter side of the remaining rectangle and
+// recurses on what's left — the standard greedy squarify loop, written
+// iteratively (rather than the paper's recursion) to keep it easy to read
+// and to unit test in isolation.
+func squarify(items []treemapItem, w, h float64) []treemapBox {
+	var boxes []treemapBox
+	remaining := items
+	x, y, rw, rh := 0.0, 0.0, w, h
+
+	for len(remaining) > 0 {
+		shortSide := math.Min(rw, rh)
+		row := []treemapItem{remaining[0]}
+		best := worstRatio(row, shortSide)
+		i := 1
+		for i < len(remaining) {
+			candidate := append(append([]treemapItem{}, row...), remaining[i])
+			ratio := worstRatio(candidate, shortSide)
+			if ratio > best {
+				break
+			}
+			row = candidate
+			best = ratio
+			i++
+		}
+		remaining = remaining[i:]
+
+		rowBoxes, nx, ny, nw, nh := layoutRow(row, x, y, rw, rh)
+		boxes = append(boxes, rowBoxes...)
+		x, y, rw, rh = nx, ny, nw, nh
+	}
+	return boxes
+}
+
+// worstRatio computes the worst (largest) box aspect ratio that would result
+// from laying `row` out along a band of thickness `side` — the formula from
+// the squarified-treemaps paper: max(side²·maxArea/sum², sum²/(side²·minArea)).
+// Lower is better (1.0 = every box in the row is a perfect square).
+func worstRatio(row []treemapItem, side float64) float64 {
+	if len(row) == 0 || side <= 0 {
+		return math.Inf(1)
+	}
+	var sum, maxV float64
+	minV := math.Inf(1)
+	for _, it := range row {
+		sum += it.Size
+		if it.Size > maxV {
+			maxV = it.Size
+		}
+		if it.Size < minV {
+			minV = it.Size
+		}
+	}
+	if sum <= 0 || minV <= 0 {
+		return math.Inf(1)
+	}
+	s2 := side * side
+	sum2 := sum * sum
+	return math.Max(s2*maxV/sum2, sum2/(s2*minV))
+}
+
+// layoutRow places one completed row into rectangle (x,y,w,h), banding along
+// whichever side is shorter (so boxes trend toward square, not sliver-thin),
+// and returns the placed boxes plus the rectangle still remaining afterward.
+func layoutRow(row []treemapItem, x, y, w, h float64) ([]treemapBox, float64, float64, float64, float64) {
+	var rowArea float64
+	for _, it := range row {
+		rowArea += it.Size
+	}
+	boxes := make([]treemapBox, 0, len(row))
+
+	if w >= h {
+		// Band is a column on the left, full height h, stacking items top-to-bottom.
+		colW := 0.0
+		if h > 0 {
+			colW = rowArea / h
+		}
+		yy := y
+		for _, it := range row {
+			itemH := 0.0
+			if colW > 0 {
+				itemH = it.Size / colW
+			}
+			boxes = append(boxes, treemapBox{
+				Path: it.Path, XPct: x, YPct: yy, WPct: colW, HPct: itemH,
+				Size: it.Size, Complexity: it.Complexity,
+			})
+			yy += itemH
+		}
+		return boxes, x + colW, y, w - colW, h
+	}
+
+	// Band is a row along the top, full width w, placing items left-to-right.
+	rowH := 0.0
+	if w > 0 {
+		rowH = rowArea / w
+	}
+	xx := x
+	for _, it := range row {
+		itemW := 0.0
+		if rowH > 0 {
+			itemW = it.Size / rowH
+		}
+		boxes = append(boxes, treemapBox{
+			Path: it.Path, XPct: xx, YPct: y, WPct: itemW, HPct: rowH,
+			Size: it.Size, Complexity: it.Complexity,
+		})
+		xx += itemW
+	}
+	return boxes, x, y + rowH, w, h - rowH
+}
+
+// treemapColorScale is a green→yellow→red 3-stop scale (low→high complexity),
+// picked for the same reason `snipe hotspots`' ⚑ markers are terse: a glance
+// should show risk concentration without a legend lookup.
+var treemapColorScale = []struct {
+	stop  float64
+	color string
+}{
+	{0.0, "#4ade80"}, // green  — low complexity
+	{0.5, "#facc15"}, // yellow — medium
+	{1.0, "#ef4444"}, // red    — high
+}
+
+// colorForComplexity maps a normalized complexity value (0..1, this file's
+// share of the hottest file in the report) to a hex color by linear
+// interpolation between the nearest two scale stops.
+func colorForComplexity(norm float64) string {
+	if norm < 0 {
+		norm = 0
+	}
+	if norm > 1 {
+		norm = 1
+	}
+	for i := 0; i < len(treemapColorScale)-1; i++ {
+		lo, hi := treemapColorScale[i], treemapColorScale[i+1]
+		if norm >= lo.stop && norm <= hi.stop {
+			span := hi.stop - lo.stop
+			t := 0.0
+			if span > 0 {
+				t = (norm - lo.stop) / span
+			}
+			return lerpHexColor(lo.color, hi.color, t)
+		}
+	}
+	return treemapColorScale[len(treemapColorScale)-1].color
+}
+
+// lerpHexColor linearly interpolates two "#rrggbb" colors at t in [0,1].
+func lerpHexColor(a, b string, t float64) string {
+	ar, ag, ab := hexToRGB(a)
+	br, bg, bb := hexToRGB(b)
+	r := lerpByte(ar, br, t)
+	g := lerpByte(ag, bg, t)
+	bl := lerpByte(ab, bb, t)
+	return rgbToHex(r, g, bl)
+}
+
+func lerpByte(a, b uint8, t float64) uint8 {
+	v := float64(a) + (float64(b)-float64(a))*t
+	if v < 0 {
+		v = 0
+	}
+	if v > 255 {
+		v = 255
+	}
+	return uint8(math.Round(v))
+}
+
+func hexToRGB(s string) (r, g, b uint8) {
+	if len(s) != 7 || s[0] != '#' {
+		return 0, 0, 0
+	}
+	parse := func(h string) uint8 {
+		var v int
+		for _, c := range h {
+			v <<= 4
+			switch {
+			case c >= '0' && c <= '9':
+				v |= int(c - '0')
+			case c >= 'a' && c <= 'f':
+				v |= int(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				v |= int(c-'A') + 10
+			}
+		}
+		return uint8(v)
+	}
+	return parse(s[1:3]), parse(s[3:5]), parse(s[5:7])
+}
+
+func rgbToHex(r, g, b uint8) string {
+	const hexDigits = "0123456789abcdef"
+	buf := [7]byte{'#'}
+	buf[1] = hexDigits[r>>4]
+	buf[2] = hexDigits[r&0xf]
+	buf[3] = hexDigits[g>>4]
+	buf[4] = hexDigits[g&0xf]
+	buf[5] = hexDigits[b>>4]
+	buf[6] = hexDigits[b&0xf]
+	return string(buf[:])
+}

--- a/cmd/report_treemap_test.go
+++ b/cmd/report_treemap_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"math"
+	"testing"
+)
+
+// totalArea sums box areas (in percent-of-canvas units) — should equal the
+// full 100x100 canvas regardless of how many items or how skewed their sizes.
+func totalArea(boxes []treemapBox) float64 {
+	var sum float64
+	for _, b := range boxes {
+		sum += b.WPct * b.HPct
+	}
+	return sum
+}
+
+func TestLayoutTreemapEmpty(t *testing.T) {
+	if boxes := layoutTreemap(nil); boxes != nil {
+		t.Fatalf("layoutTreemap(nil) = %v, want nil", boxes)
+	}
+	if boxes := layoutTreemap([]treemapItem{}); boxes != nil {
+		t.Fatalf("layoutTreemap([]) = %v, want nil", boxes)
+	}
+}
+
+func TestLayoutTreemapSingleItemFillsCanvas(t *testing.T) {
+	boxes := layoutTreemap([]treemapItem{{Path: "a.go", Size: 42, Complexity: 5}})
+	if len(boxes) != 1 {
+		t.Fatalf("got %d boxes, want 1", len(boxes))
+	}
+	b := boxes[0]
+	if b.WPct != 100 || b.HPct != 100 || b.XPct != 0 || b.YPct != 0 {
+		t.Errorf("single item should fill the whole canvas, got %+v", b)
+	}
+}
+
+func TestLayoutTreemapCoversFullArea(t *testing.T) {
+	items := []treemapItem{
+		{Path: "huge.go", Size: 500, Complexity: 90},
+		{Path: "big.go", Size: 200, Complexity: 40},
+		{Path: "medium.go", Size: 80, Complexity: 20},
+		{Path: "small.go", Size: 10, Complexity: 2},
+		{Path: "tiny.go", Size: 1, Complexity: 1},
+	}
+	boxes := layoutTreemap(items)
+	if len(boxes) != len(items) {
+		t.Fatalf("got %d boxes, want %d", len(boxes), len(items))
+	}
+	area := totalArea(boxes)
+	if math.Abs(area-10000) > 0.01 { // 100 x 100 canvas
+		t.Errorf("total area = %.4f, want ~10000 (full canvas)", area)
+	}
+	for _, b := range boxes {
+		if b.WPct <= 0 || b.HPct <= 0 {
+			t.Errorf("box %s has non-positive dimension: %+v", b.Path, b)
+		}
+		if b.XPct < 0 || b.YPct < 0 || b.XPct+b.WPct > 100.0001 || b.YPct+b.HPct > 100.0001 {
+			t.Errorf("box %s escapes canvas bounds: %+v", b.Path, b)
+		}
+	}
+}
+
+// TestLayoutTreemapProportional checks that a box twice the size of another
+// (same total weight class) gets roughly twice the area — the whole point of
+// sizing by func-count/complexity is that bigger files read as bigger boxes.
+func TestLayoutTreemapProportional(t *testing.T) {
+	items := []treemapItem{
+		{Path: "a.go", Size: 20},
+		{Path: "b.go", Size: 10},
+	}
+	boxes := layoutTreemap(items)
+	byPath := map[string]treemapBox{}
+	for _, b := range boxes {
+		byPath[b.Path] = b
+	}
+	areaA := byPath["a.go"].WPct * byPath["a.go"].HPct
+	areaB := byPath["b.go"].WPct * byPath["b.go"].HPct
+	ratio := areaA / areaB
+	if math.Abs(ratio-2.0) > 0.01 {
+		t.Errorf("area ratio = %.4f, want ~2.0 (a.go is 2x b.go's size)", ratio)
+	}
+}
+
+func TestLayoutTreemapZeroSizesFallBackToEqualWeight(t *testing.T) {
+	items := []treemapItem{
+		{Path: "a.go", Size: 0},
+		{Path: "b.go", Size: 0},
+	}
+	boxes := layoutTreemap(items)
+	if len(boxes) != 2 {
+		t.Fatalf("got %d boxes, want 2", len(boxes))
+	}
+	area := totalArea(boxes)
+	if math.Abs(area-10000) > 0.01 {
+		t.Errorf("degenerate all-zero input should still fill the canvas, area=%.4f", area)
+	}
+}
+
+func TestWorstRatioPerfectSquareIsOne(t *testing.T) {
+	// A single item whose area exactly matches a square side gives ratio 1.
+	row := []treemapItem{{Size: 100}}
+	got := worstRatio(row, 10) // side=10 -> area 100 -> perfect square
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("worstRatio = %.6f, want 1.0 for a perfect square", got)
+	}
+}
+
+func TestWorstRatioEmptyRowIsInfinite(t *testing.T) {
+	if got := worstRatio(nil, 10); !math.IsInf(got, 1) {
+		t.Errorf("worstRatio(nil, 10) = %v, want +Inf", got)
+	}
+	if got := worstRatio([]treemapItem{{Size: 5}}, 0); !math.IsInf(got, 1) {
+		t.Errorf("worstRatio(_, 0) = %v, want +Inf", got)
+	}
+}
+
+func TestColorForComplexityBounds(t *testing.T) {
+	if c := colorForComplexity(0); c != "#4ade80" {
+		t.Errorf("colorForComplexity(0) = %s, want green stop #4ade80", c)
+	}
+	if c := colorForComplexity(1); c != "#ef4444" {
+		t.Errorf("colorForComplexity(1) = %s, want red stop #ef4444", c)
+	}
+	// Out-of-range inputs clamp rather than extrapolate into invalid hex.
+	if c := colorForComplexity(-5); c != "#4ade80" {
+		t.Errorf("colorForComplexity(-5) = %s, want clamped to green", c)
+	}
+	if c := colorForComplexity(5); c != "#ef4444" {
+		t.Errorf("colorForComplexity(5) = %s, want clamped to red", c)
+	}
+}
+
+func TestColorForComplexityMidpointIsYellow(t *testing.T) {
+	if c := colorForComplexity(0.5); c != "#facc15" {
+		t.Errorf("colorForComplexity(0.5) = %s, want yellow stop #facc15", c)
+	}
+}
+
+func TestHexRGBRoundTrip(t *testing.T) {
+	for _, hex := range []string{"#4ade80", "#facc15", "#ef4444", "#000000", "#ffffff"} {
+		r, g, b := hexToRGB(hex)
+		got := rgbToHex(r, g, b)
+		if got != hex {
+			t.Errorf("hexToRGB/rgbToHex round trip: %s -> %s", hex, got)
+		}
+	}
+}

--- a/cmd/testdata/help/report.golden
+++ b/cmd/testdata/help/report.golden
@@ -1,0 +1,28 @@
+Usage: snipe report [flags]
+
+Self-contained HTML dashboard for humans: hotspot treemap, cycles, hotspots
+ranking, + D2 diagram placeholder slots
+
+Flags:
+  -h, --help                   Show context-sensitive help.
+      --limit=10               Cap results returned (applied after --select)
+      --offset=0               Pagination offset
+      --context=2              Context lines around match
+      --no-body                Exclude function body
+      --no-siblings            Exclude sibling declarations
+      --signature-only         Return only signature (no body, no context)
+      --max-tokens=0           Token budget (0 = unlimited)
+      --format="concise"       concise (LLM default) | detailed | summary | json
+                               (stable, for tooling) | human (TTY)
+      --kg-hints               Include Orca KG hints
+      --no-suggestions         Suppress next-step suggestions in Claude output
+      --timeout=DURATION       Timeout for command (e.g., 30s, 5m)
+      --select="all"           Pick top candidates by score: all, best, top3,
+                               top5 (applied before --limit)
+
+      --out=".snipe/report"    Output directory for report.html + manifest.json
+      --emit-shell             Emit the HTML shell (native visuals + D2
+                               placeholder slots) and manifest.json — v1's only
+                               supported mode
+      --top=30                 Top-N files in the hotspot treemap and ranking
+                               table

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -165,6 +165,10 @@ Graph & Structure:
   guard [<spec>] [flags]
     Assert architecture boundary rules; exit non-zero on violation
 
+  report [flags]
+    Self-contained HTML dashboard for humans: hotspot treemap, cycles, hotspots
+    ranking, + D2 diagram placeholder slots
+
 Embeddings:
   sim [<query>] [flags]
     Semantic similarity search


### PR DESCRIPTION
## Summary

- New standalone command `snipe report --emit-shell` — a self-contained HTML dashboard for humans, distinct from sn-l1kh's per-command `docs/diagrams/*.md` living docs.
- Native visuals rendered directly from indexed data (no charting library): a hand-rolled squarified-treemap of hotspots (size = function count, color = summed complexity), cycles from `graph_sccs`, and a hotspots ranking table.
- D2 diagram artifacts (arch/flow/lifecycle) are left as labeled placeholder `<div>` slots + a `manifest.json` listing the `snipe diagram X | d2 -` commands an external script should run to fill them — snipe itself never shells out to `d2` (ratified sn-fhw8/D7 design).
- Registered as `Report ReportCmd` in `cmd/cli.go` (one field) + `cmdNameReport` in `cmd/constants.go` (one constant); everything else lives in new `cmd/report*.go` files.

## Test plan

- [x] `go test ./cmd/...` — full package passes, including new treemap-layout and manifest-generation unit tests
- [x] `make audit` — green (vet, lint, race, blackbox, govulncheck)
- [x] Manual smoke test against snipe's own index: `snipe report --emit-shell --top=15` produces a valid `report.html` (treemap boxes tile the full canvas, no overlaps) + `manifest.json` (3 slots, ids match the HTML shell's placeholder divs)
- [x] `go test ./cmd -run TestHelpGolden` — root + new `report` help goldens regenerated and green

Closes: sn-qnq3