### PR TITLE
feat(telemetry): enrich usage.jsonl with arg, rung, candidate count, session key

### DIFF
--- a/cmd/def.go
+++ b/cmd/def.go
@@ -56,6 +56,10 @@ func runDef(args []string) error {
 	}
 	defer s.Close()
 
+	// Computed once and reused on both the error path (WriteErrorWithMeta,
+	// sn-r1do.1) and the success path's Meta, instead of querying twice.
+	idxState := query.CheckIndexState(s.DB(), dir, Version)
+
 	var symbolID string
 	var queryInfo map[string]string
 	var decisionPath []string
@@ -65,7 +69,7 @@ func runDef(args []string) error {
 		// Resolve position
 		pos, err := query.ParsePosition(defAt)
 		if err != nil {
-			return w.WriteError(cmdNameDef, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameDef, defAt, decisionPath, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: err.Error(),
 			})
@@ -78,7 +82,7 @@ func runDef(args []string) error {
 
 		symbolID, err = query.ResolvePosition(s.DB(), pos)
 		if err != nil {
-			return w.WriteError(cmdNameDef, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameDef, defAt, decisionPath, idxState, 0, &output.Error{
 				Code:    output.ErrNotFound,
 				Message: "no symbol found at " + defAt,
 			})
@@ -106,7 +110,7 @@ func runDef(args []string) error {
 				// This looks like file:symbol syntax
 				symbols, err := query.LookupByNameInFile(s.DB(), symbolPart, filePart)
 				if err != nil {
-					return w.WriteError(cmdNameDef, &output.Error{
+					return w.WriteErrorWithMeta(cmdNameDef, name, decisionPath, idxState, 0, &output.Error{
 						Code:    output.ErrInternal,
 						Message: err.Error(),
 					})
@@ -122,7 +126,7 @@ func runDef(args []string) error {
 						s := &symbols[i]
 						candidates[i] = s.ToCandidate()
 					}
-					return w.WriteError(cmdNameDef, output.NewAmbiguousError(name, candidates))
+					return w.WriteErrorWithMeta(cmdNameDef, name, decisionPath, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 				}
 				// Fall through to regular lookup if not found
 			}
@@ -131,7 +135,7 @@ func runDef(args []string) error {
 		// Look up by name
 		symbols, err := query.LookupByName(s.DB(), name)
 		if err != nil {
-			return w.WriteError(cmdNameDef, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameDef, name, decisionPath, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: err.Error(),
 			})
@@ -143,9 +147,9 @@ func runDef(args []string) error {
 			suggestions, err := query.FindSimilarSymbols(s.DB(), name, maxDist, 3)
 			if err != nil {
 				// If fuzzy search fails, just return the basic error
-				return w.WriteError(cmdNameDef, output.NewNotFoundError(name))
+				return w.WriteErrorWithMeta(cmdNameDef, name, decisionPath, idxState, 0, output.NewNotFoundError(name))
 			}
-			return w.WriteError(cmdNameDef, output.NewNotFoundError(name, suggestions...))
+			return w.WriteErrorWithMeta(cmdNameDef, name, decisionPath, idxState, len(suggestions), output.NewNotFoundError(name, suggestions...))
 		}
 
 		if len(symbols) > 1 {
@@ -164,7 +168,7 @@ func runDef(args []string) error {
 				s := &symbols[i]
 				candidates[i] = s.ToCandidate()
 			}
-			return w.WriteError(cmdNameDef, output.NewAmbiguousError(name, candidates))
+			return w.WriteErrorWithMeta(cmdNameDef, name, decisionPath, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 		}
 
 		symbolID = symbols[0].ID
@@ -175,16 +179,17 @@ func runDef(args []string) error {
 
 lookup:
 	// Get the symbol details
+	lookupArg := output.Meta{Query: queryInfo}.PrimaryQueryArg()
 	sym, err := query.LookupByID(s.DB(), symbolID)
 	if err != nil {
-		return w.WriteError(cmdNameDef, &output.Error{
+		return w.WriteErrorWithMeta(cmdNameDef, lookupArg, decisionPath, idxState, 0, &output.Error{
 			Code:    output.ErrInternal,
 			Message: err.Error(),
 		})
 	}
 
 	if sym == nil {
-		return w.WriteError(cmdNameDef, &output.Error{
+		return w.WriteErrorWithMeta(cmdNameDef, lookupArg, decisionPath, idxState, 0, &output.Error{
 			Code:    output.ErrNotFound,
 			Message: fmt.Sprintf("symbol %s not found", symbolID),
 		})
@@ -308,7 +313,7 @@ lookup:
 			Command:       cmdNameDef,
 			Query:         queryInfo,
 			RepoRoot:      dir,
-			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			IndexState:    idxState,
 			Degraded:      degraded,
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         len(results),
@@ -331,9 +336,11 @@ func runDefInPkg(w *output.Writer, start time.Time, name string, withBody bool, 
 	}
 	defer s.Close()
 
+	idxState := query.CheckIndexState(s.DB(), dir, Version)
+
 	symbols, err := query.LookupByNameInPkg(s.DB(), name, defPkg)
 	if err != nil {
-		return w.WriteError(cmdNameDef, &output.Error{
+		return w.WriteErrorWithMeta(cmdNameDef, name, nil, idxState, 0, &output.Error{
 			Code:    output.ErrInternal,
 			Message: err.Error(),
 		})
@@ -346,7 +353,7 @@ func runDefInPkg(w *output.Writer, start time.Time, name string, withBody bool, 
 			sym := &pkgSyms[i]
 			names[i] = sym.Name
 		}
-		return w.WriteError(cmdNameDef, output.NewNotFoundError(name+" in pkg "+defPkg, names...))
+		return w.WriteErrorWithMeta(cmdNameDef, name, nil, idxState, len(names), output.NewNotFoundError(name+" in pkg "+defPkg, names...))
 	}
 
 	if len(symbols) > 1 {
@@ -355,7 +362,7 @@ func runDefInPkg(w *output.Writer, start time.Time, name string, withBody bool, 
 			sym := &symbols[i]
 			candidates[i] = sym.ToCandidate()
 		}
-		return w.WriteError(cmdNameDef, output.NewAmbiguousError(name, candidates))
+		return w.WriteErrorWithMeta(cmdNameDef, name, nil, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 	}
 
 	sym := &symbols[0]
@@ -389,7 +396,7 @@ func runDefInPkg(w *output.Writer, start time.Time, name string, withBody bool, 
 			Command:       cmdNameDef,
 			Query:         map[string]string{flagSymbol: name, flagPkg: defPkg},
 			RepoRoot:      dir,
-			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			IndexState:    idxState,
 			Degraded:      degraded,
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         1,

--- a/cmd/metrics_usage.go
+++ b/cmd/metrics_usage.go
@@ -37,7 +37,8 @@ func runUsageMetrics() error {
 	}
 	byCmd := make(map[string]*agg)
 	total, totalErr := 0, 0
-	for _, r := range recs {
+	for i := range recs {
+		r := &recs[i]
 		a := byCmd[r.Command]
 		if a == nil {
 			a = &agg{}

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -41,6 +41,10 @@ func runPack(args []string) error {
 	}
 	defer s.Close()
 
+	// Computed once and reused on both the error path (WriteErrorWithMeta,
+	// sn-r1do.1) and the success path's Meta.
+	idxState := query.CheckIndexState(s.DB(), dir, Version)
+
 	opts := packOpts{
 		withBody:     withBody,
 		withSiblings: withSiblings,
@@ -67,14 +71,14 @@ func runPack(args []string) error {
 	}
 
 	// Single-symbol mode
-	symbolID, queryInfo, err := resolvePackSymbol(w, s, dir, args, packAt)
+	symbolID, queryInfo, err := resolvePackSymbol(w, s, dir, args, packAt, idxState)
 	if err != nil {
 		return err
 	}
 
 	packResult, degraded, allResults, err := buildPackForSymbol(s, dir, symbolID, opts)
 	if err != nil {
-		return w.WriteError(cmdNamePack, &output.Error{
+		return w.WriteErrorWithMeta(cmdNamePack, output.Meta{Query: queryInfo}.PrimaryQueryArg(), nil, idxState, 0, &output.Error{
 			Code:    output.ErrInternal,
 			Message: err.Error(),
 		})
@@ -92,7 +96,7 @@ func runPack(args []string) error {
 			Command:       cmdNamePack,
 			Query:         queryInfo,
 			RepoRoot:      dir,
-			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			IndexState:    idxState,
 			Degraded:      degraded,
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         1,
@@ -106,17 +110,19 @@ func runPack(args []string) error {
 
 // runPackMulti handles multi-ID mode: snipe pack id1 id2 id3
 func runPackMulti(w *output.Writer, s *store.Store, dir string, args []string, opts packOpts, start time.Time) error {
+	idxState := query.CheckIndexState(s.DB(), dir, Version)
+
 	// Validate all args are hex IDs
 	ids := make([]string, 0, len(args))
 	for _, arg := range args {
 		if len(arg) != 16 {
-			return w.WriteError(cmdNamePack, &output.Error{
+			return w.WriteErrorWithMeta(cmdNamePack, arg, nil, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: fmt.Sprintf("multi-ID mode requires 16-char hex IDs, got %q", arg),
 			})
 		}
 		if _, err := hex.DecodeString(arg); err != nil {
-			return w.WriteError(cmdNamePack, &output.Error{
+			return w.WriteErrorWithMeta(cmdNamePack, arg, nil, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: fmt.Sprintf("invalid hex ID %q", arg),
 			})
@@ -154,7 +160,7 @@ func runPackMulti(w *output.Writer, s *store.Store, dir string, args []string, o
 			Command:       cmdNamePack,
 			Query:         queryInfo,
 			RepoRoot:      dir,
-			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			IndexState:    idxState,
 			Degraded:      allDegraded,
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         len(allPackResults),
@@ -173,12 +179,13 @@ type packOpts struct {
 	contextLines int
 }
 
-// resolvePackSymbol resolves args/--at into a symbol ID.
-func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []string, at string) (string, map[string]string, error) {
+// resolvePackSymbol resolves args/--at into a symbol ID. idxState is threaded
+// through purely for usage.jsonl enrichment on the error path (sn-r1do.1).
+func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []string, at string, idxState output.IndexState) (string, map[string]string, error) {
 	if at != "" {
 		pos, err := query.ParsePosition(at)
 		if err != nil {
-			return "", nil, w.WriteError(cmdNamePack, &output.Error{
+			return "", nil, w.WriteErrorWithMeta(cmdNamePack, at, nil, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: err.Error(),
 			})
@@ -188,7 +195,7 @@ func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []stri
 		}
 		symbolID, err := query.ResolvePosition(s.DB(), pos)
 		if err != nil {
-			return "", nil, w.WriteError(cmdNamePack, &output.Error{
+			return "", nil, w.WriteErrorWithMeta(cmdNamePack, at, nil, idxState, 0, &output.Error{
 				Code:    output.ErrNotFound,
 				Message: err.Error(),
 			})
@@ -212,7 +219,7 @@ func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []stri
 		if symbolPart != "" && !strings.Contains(symbolPart, ":") {
 			symbols, err := query.LookupByNameInFile(s.DB(), symbolPart, filePart)
 			if err != nil {
-				return "", nil, w.WriteError(cmdNamePack, &output.Error{
+				return "", nil, w.WriteErrorWithMeta(cmdNamePack, name, nil, idxState, 0, &output.Error{
 					Code:    output.ErrInternal,
 					Message: err.Error(),
 				})
@@ -226,7 +233,7 @@ func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []stri
 					sym := &symbols[i]
 					candidates[i] = sym.ToCandidate()
 				}
-				return "", nil, w.WriteError(cmdNamePack, output.NewAmbiguousError(name, candidates))
+				return "", nil, w.WriteErrorWithMeta(cmdNamePack, name, nil, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 			}
 		}
 	}
@@ -234,7 +241,7 @@ func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []stri
 	// Look up by name
 	symbols, err := query.LookupByName(s.DB(), name)
 	if err != nil {
-		return "", nil, w.WriteError(cmdNamePack, &output.Error{
+		return "", nil, w.WriteErrorWithMeta(cmdNamePack, name, nil, idxState, 0, &output.Error{
 			Code:    output.ErrInternal,
 			Message: err.Error(),
 		})
@@ -244,9 +251,9 @@ func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []stri
 		maxDist := query.DefaultMaxDistance(name)
 		suggestions, sErr := query.FindSimilarSymbols(s.DB(), name, maxDist, 3)
 		if sErr != nil {
-			return "", nil, w.WriteError(cmdNamePack, output.NewNotFoundError(name))
+			return "", nil, w.WriteErrorWithMeta(cmdNamePack, name, nil, idxState, 0, output.NewNotFoundError(name))
 		}
-		return "", nil, w.WriteError(cmdNamePack, output.NewNotFoundError(name, suggestions...))
+		return "", nil, w.WriteErrorWithMeta(cmdNamePack, name, nil, idxState, len(suggestions), output.NewNotFoundError(name, suggestions...))
 	}
 
 	if len(symbols) > 1 {
@@ -255,7 +262,7 @@ func resolvePackSymbol(w *output.Writer, s *store.Store, dir string, args []stri
 			sym := &symbols[i]
 			candidates[i] = sym.ToCandidate()
 		}
-		return "", nil, w.WriteError(cmdNamePack, output.NewAmbiguousError(name, candidates))
+		return "", nil, w.WriteErrorWithMeta(cmdNamePack, name, nil, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 	}
 
 	return symbols[0].ID, map[string]string{flagSymbol: name}, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -486,6 +486,7 @@ func OpenStore(w *output.Writer, cmdName string) (*store.Store, string, error) {
 	if root != "" {
 		telemetry.SetRoot(root)
 		telemetry.SetCaller(caller)
+		telemetry.SetSessionKey(telemetry.ResolveSessionKey(root))
 	}
 	if root == "" {
 		root = cwd // fallback: not in a git/go.mod repo, use CWD

--- a/cmd/sym.go
+++ b/cmd/sym.go
@@ -41,6 +41,10 @@ func runSym(args []string) error {
 	}
 	defer s.Close()
 
+	// Computed once and reused on both the error path (WriteErrorWithMeta,
+	// sn-r1do.1) and the success path's Meta.
+	idxState := query.CheckIndexState(s.DB(), dir, Version)
+
 	var symbolID string
 	var queryInfo map[string]string
 
@@ -48,7 +52,7 @@ func runSym(args []string) error {
 		// Resolve position
 		pos, err := query.ParsePosition(symAt)
 		if err != nil {
-			return w.WriteError(cmdNameSym, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameSym, symAt, nil, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: err.Error(),
 			})
@@ -61,7 +65,7 @@ func runSym(args []string) error {
 
 		symbolID, err = query.ResolvePosition(s.DB(), pos)
 		if err != nil {
-			return w.WriteError(cmdNameSym, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameSym, symAt, nil, idxState, 0, &output.Error{
 				Code:    output.ErrNotFound,
 				Message: err.Error(),
 			})
@@ -83,7 +87,7 @@ func runSym(args []string) error {
 			_, lim, off, _, _, _ := GetOutputConfig()
 			symbols, err := query.FindSymbolsInFile(s.DB(), name, lim, off)
 			if err != nil {
-				return w.WriteError(cmdNameSym, &output.Error{
+				return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, 0, &output.Error{
 					Code:    output.ErrInternal,
 					Message: err.Error(),
 				})
@@ -94,13 +98,13 @@ func runSym(args []string) error {
 					sym := &symbols[i]
 					candidates[i] = sym.ToCandidate()
 				}
-				return w.WriteError(cmdNameSym, &output.Error{
+				return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, len(candidates), &output.Error{
 					Code:       output.ErrFileListing,
 					Message:    fmt.Sprintf("%s (%d symbols)", name, len(candidates)),
 					Candidates: candidates,
 				})
 			}
-			return w.WriteError(cmdNameSym, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, 0, &output.Error{
 				Code:    output.ErrNotFound,
 				Message: "no symbols found in " + name,
 			})
@@ -113,7 +117,7 @@ func runSym(args []string) error {
 			if symbolPart != "" && !strings.Contains(symbolPart, ":") {
 				symbols, err := query.LookupByNameInFile(s.DB(), symbolPart, filePart)
 				if err != nil {
-					return w.WriteError(cmdNameSym, &output.Error{
+					return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, 0, &output.Error{
 						Code:    output.ErrInternal,
 						Message: err.Error(),
 					})
@@ -128,7 +132,7 @@ func runSym(args []string) error {
 						s := &symbols[i]
 						candidates[i] = s.ToCandidate()
 					}
-					return w.WriteError(cmdNameSym, output.NewAmbiguousError(name, candidates))
+					return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 				}
 			}
 		}
@@ -136,7 +140,7 @@ func runSym(args []string) error {
 		// Look up by name
 		symbols, err := query.LookupByName(s.DB(), name)
 		if err != nil {
-			return w.WriteError(cmdNameSym, &output.Error{
+			return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, 0, &output.Error{
 				Code:    output.ErrInternal,
 				Message: err.Error(),
 			})
@@ -146,9 +150,9 @@ func runSym(args []string) error {
 			maxDist := query.DefaultMaxDistance(name)
 			suggestions, err := query.FindSimilarSymbols(s.DB(), name, maxDist, 3)
 			if err != nil {
-				return w.WriteError(cmdNameSym, output.NewNotFoundError(name))
+				return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, 0, output.NewNotFoundError(name))
 			}
-			return w.WriteError(cmdNameSym, output.NewNotFoundError(name, suggestions...))
+			return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, len(suggestions), output.NewNotFoundError(name, suggestions...))
 		}
 
 		if len(symbols) > 1 {
@@ -157,7 +161,7 @@ func runSym(args []string) error {
 				s := &symbols[i]
 				candidates[i] = s.ToCandidate()
 			}
-			return w.WriteError(cmdNameSym, output.NewAmbiguousError(name, candidates))
+			return w.WriteErrorWithMeta(cmdNameSym, name, nil, idxState, len(candidates), output.NewAmbiguousError(name, candidates))
 		}
 
 		symbolID = symbols[0].ID
@@ -166,16 +170,17 @@ func runSym(args []string) error {
 
 lookup:
 	// Get the symbol details
+	lookupArg := output.Meta{Query: queryInfo}.PrimaryQueryArg()
 	sym, err := query.LookupByID(s.DB(), symbolID)
 	if err != nil {
-		return w.WriteError(cmdNameSym, &output.Error{
+		return w.WriteErrorWithMeta(cmdNameSym, lookupArg, nil, idxState, 0, &output.Error{
 			Code:    output.ErrInternal,
 			Message: err.Error(),
 		})
 	}
 
 	if sym == nil {
-		return w.WriteError(cmdNameSym, &output.Error{
+		return w.WriteErrorWithMeta(cmdNameSym, lookupArg, nil, idxState, 0, &output.Error{
 			Code:    output.ErrNotFound,
 			Message: fmt.Sprintf("symbol %s not found", symbolID),
 		})
@@ -349,7 +354,7 @@ lookup:
 			Command:       cmdNameSym,
 			Query:         queryInfo,
 			RepoRoot:      dir,
-			IndexState:    query.CheckIndexState(s.DB(), dir, Version),
+			IndexState:    idxState,
 			Degraded:      degraded,
 			Ms:            time.Since(start).Milliseconds(),
 			Total:         1,

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -76,7 +76,21 @@ func NewWriter(out io.Writer, format OutputFormat) *Writer {
 // WriteResponse writes a response in the configured format.
 func (w *Writer) WriteResponse(resp any) error {
 	if m, ok := resp.(interface{ TelemetryCommand() string }); ok {
-		telemetry.Emit(m.TelemetryCommand(), "ok", time.Since(w.start).Milliseconds())
+		f := telemetry.Fields{
+			Command: m.TelemetryCommand(),
+			Outcome: "ok",
+			Ms:      time.Since(w.start).Milliseconds(),
+		}
+		// TelemetryMeta is the escape hatch Response[T] implements alongside
+		// TelemetryCommand/IsOk (sn-r1do.1) — the Writer sees only `resp any`,
+		// so it type-asserts for arg/rung/decision-path rather than knowing
+		// every Response[T] instantiation.
+		if tm, ok := resp.(interface {
+			TelemetryMeta() (string, string, []string, string)
+		}); ok {
+			f.Arg, f.Rung, f.TriedRungs, f.IndexState = tm.TelemetryMeta()
+		}
+		telemetry.Emit(f)
 	}
 	if r, ok := resp.(interface{ IsOk() bool }); ok && !r.IsOk() {
 		processErrored = true
@@ -943,10 +957,36 @@ func shortPkg(p string) string {
 	return p
 }
 
-// WriteError writes an error response
+// WriteError writes an error response. It carries no query arg or
+// decision-path — callers that have one in scope at the error site (def, sym,
+// pack per sn-r1do.1's verify line) should call WriteErrorWithMeta instead so
+// usage.jsonl's NOT_FOUND/AMBIGUOUS_SYMBOL rows aren't arg-blind. This stays
+// a thin wrapper so the dozens of call sites elsewhere keep compiling
+// unchanged (additive migration, not a forced repo-wide edit).
 func (w *Writer) WriteError(command string, err *Error) error {
+	return w.WriteErrorWithMeta(command, "", nil, "", 0, err)
+}
+
+// WriteErrorWithMeta writes an error response, enriching usage.jsonl with the
+// query arg, the decision-path tried so far, the index state at error time,
+// and candidateCount (sn-r1do.1). candidateCount is an explicit parameter
+// rather than len(err.Candidates) because the "did you mean" suggestions on
+// a NOT_FOUND error (NewNotFoundError's variadic strings) never populate
+// Candidates — that field is AMBIGUOUS_SYMBOL-only ([]Candidate, full
+// structs). Callers pass whichever count they actually have in scope; 0 when
+// neither applies.
+func (w *Writer) WriteErrorWithMeta(command, arg string, decisionPath []string, indexState IndexState, candidateCount int, err *Error) error {
 	processErrored = true
-	telemetry.Emit(command, err.Code, time.Since(w.start).Milliseconds())
+	telemetry.Emit(telemetry.Fields{
+		Command:        command,
+		Outcome:        err.Code,
+		Ms:             time.Since(w.start).Milliseconds(),
+		Arg:            arg,
+		Rung:           telemetry.ClassifyRung(decisionPath, nil, err.Code),
+		CandidateCount: candidateCount,
+		IndexState:     string(indexState),
+		TriedRungs:     decisionPath,
+	})
 	if err.Next == nil {
 		err.Next = DefaultNextForCode(err.Code)
 	}

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/dkoosis/snipe/internal/telemetry"
 )
 
 // ProtocolVersion is the snipe wire protocol version.
@@ -49,6 +51,16 @@ func (r Response[T]) IsOk() bool {
 	return r.Ok
 }
 
+// TelemetryMeta exposes the fields the usage.jsonl sink needs (sn-r1do.1)
+// without the Writer needing to know every Response[T] instantiation — same
+// escape-hatch pattern as TelemetryCommand/IsOk above. Only meaningful on the
+// success path: WriteError carries its own arg/decision-path/candidate-count
+// through WriteErrorWithMeta instead, since an *Error has no Meta to read.
+func (r Response[T]) TelemetryMeta() (arg, rung string, triedRungs []string, indexState string) {
+	rung = telemetry.ClassifyRung(r.Meta.DecisionPath, r.Meta.Degraded, "ok")
+	return r.Meta.PrimaryQueryArg(), rung, r.Meta.DecisionPath, string(r.Meta.IndexState)
+}
+
 // Suggestion provides actionable next steps for LLM consumers
 type Suggestion struct {
 	Command     string `json:"command"`             // The suggested snipe command
@@ -75,6 +87,23 @@ type Meta struct {
 	DecisionPath  []string          `json:"decision_path,omitempty"` // Resolution strategy trace
 	StaleFiles    []string          `json:"stale_files,omitempty"`   // Files changed since last index
 	PkgDoc        string            `json:"pkg_doc,omitempty"`       // Package-level doc comment (set by `pkg`)
+}
+
+// queryArgPriority orders Meta.Query keys from "what Claude is looking for"
+// to "how it scoped the search" — PrimaryQueryArg picks the first key present
+// so usage.jsonl logs one representative arg per row (sn-r1do.1) instead of
+// a whole map.
+var queryArgPriority = []string{"symbol", "pattern", "package", "pkg", "ids", "file"}
+
+// PrimaryQueryArg reduces Meta.Query to the single query string telemetry
+// wants. Returns "" if Query is empty/nil/all-blank.
+func (m Meta) PrimaryQueryArg() string {
+	for _, k := range queryArgPriority {
+		if v, ok := m.Query[k]; ok && v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // DegradedNoEmbed is the stable degraded-marker token emitted (as `! noembed`

--- a/internal/output/types_test.go
+++ b/internal/output/types_test.go
@@ -2,8 +2,12 @@ package output
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dkoosis/snipe/internal/telemetry"
 )
 
 func TestResponseMarshal(t *testing.T) {
@@ -839,5 +843,140 @@ func TestNewNotFoundError_RoutesToSearch(t *testing.T) {
 	}
 	if want := `snipe search "FooBar"`; err.Next.Command != want {
 		t.Errorf("Next.Command = %q, want %q", err.Next.Command, want)
+	}
+}
+
+// qSymbolKey/qFileKey are test-local aliases for the "symbol"/"file"
+// Meta.Query map keys, shared across this file's telemetry-enrichment tests
+// to avoid tipping the package's goconst literal-count threshold (struct-tag
+// occurrences like `json:"file"` don't count, but bare-string map keys do).
+const (
+	qSymbolKey = "symbol"
+	qFileKey   = "file"
+)
+
+// TestPrimaryQueryArg_PriorityOrder guards the sn-r1do.1 priority list:
+// "what Claude is looking for" (symbol/pattern) outranks "how it scoped the
+// search" (package/pkg/ids/file) when Meta.Query carries multiple keys.
+func TestPrimaryQueryArg_PriorityOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		query map[string]string
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"symbol alone", map[string]string{qSymbolKey: "Foo"}, "Foo"},
+		{"symbol beats pattern", map[string]string{qSymbolKey: "Foo", "pattern": "bar"}, "Foo"},
+		{"pattern beats package", map[string]string{"pattern": "bar", "package": "pkg"}, "bar"},
+		{"package beats pkg", map[string]string{"package": "pkg1", "pkg": "pkg2"}, "pkg1"},
+		{"pkg beats ids", map[string]string{"pkg": "pkg2", "ids": "a,b"}, "pkg2"},
+		{"ids beats file", map[string]string{"ids": "a,b", qFileKey: "f.go"}, "a,b"},
+		{"file alone", map[string]string{qFileKey: "f.go"}, "f.go"},
+		{"blank value skipped", map[string]string{qSymbolKey: "", "pattern": "bar"}, "bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Meta{Query: tt.query}
+			if got := m.PrimaryQueryArg(); got != tt.want {
+				t.Errorf("PrimaryQueryArg() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResponseTelemetryMeta_ClassifiesRung guards the WriteResponse escape
+// hatch (sn-r1do.1): Response[T].TelemetryMeta must surface the primary arg
+// and classify the rung from Meta.DecisionPath/Degraded consistently with
+// telemetry.ClassifyRung.
+func TestResponseTelemetryMeta_ClassifiesRung(t *testing.T) {
+	resp := Response[Result]{
+		Meta: Meta{
+			Query:        map[string]string{qSymbolKey: "Foo"},
+			DecisionPath: []string{"lookup:name_select"},
+			IndexState:   IndexFresh,
+		},
+	}
+	arg, rung, tried, idxState := resp.TelemetryMeta()
+	if arg != "Foo" {
+		t.Errorf("arg = %q, want %q", arg, "Foo")
+	}
+	if rung != telemetry.RungMethod {
+		t.Errorf("rung = %q, want %q", rung, telemetry.RungMethod)
+	}
+	if len(tried) != 1 || tried[0] != "lookup:name_select" {
+		t.Errorf("tried = %v, want [lookup:name_select]", tried)
+	}
+	if idxState != string(IndexFresh) {
+		t.Errorf("idxState = %q, want %q", idxState, IndexFresh)
+	}
+}
+
+// TestWriteErrorWithMeta_EmitsCandidateCountAndArg drives an AMBIGUOUS_SYMBOL
+// error through WriteErrorWithMeta and confirms the usage.jsonl row carries
+// arg, rung=notfound, and candidate_count == len(err.Candidates) — the bead's
+// own AC verify line ("a NOT_FOUND row shows ... candidate_count").
+func TestWriteErrorWithMeta_EmitsCandidateCountAndArg(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".snipe"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	telemetry.SetRoot(root)
+	t.Cleanup(func() { telemetry.SetRoot("") })
+
+	candidates := []Candidate{
+		{ID: "a", Name: "Config", File: "a/config.go", Kind: "type"},
+		{ID: "b", Name: "Config", File: "b/config.go", Kind: "type"},
+	}
+	w := NewWriter(&strings.Builder{}, OutputClaude)
+	_ = w.WriteErrorWithMeta("def", "Config", []string{"lookup:name"}, IndexFresh, len(candidates), NewAmbiguousError("Config", candidates))
+
+	recs, err := telemetry.ReadAll(root)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d usage.jsonl rows, want 1", len(recs))
+	}
+	r := recs[0]
+	if r.Arg != "Config" {
+		t.Errorf("Arg = %q, want %q", r.Arg, "Config")
+	}
+	if r.Rung != telemetry.RungNotFound {
+		t.Errorf("Rung = %q, want %q", r.Rung, telemetry.RungNotFound)
+	}
+	if r.CandidateCount != 2 {
+		t.Errorf("CandidateCount = %d, want 2", r.CandidateCount)
+	}
+	if r.Outcome != ErrAmbiguousSymbol {
+		t.Errorf("Outcome = %q, want %q", r.Outcome, ErrAmbiguousSymbol)
+	}
+}
+
+// TestWriteErrorWithMeta_NotFoundDidYouMeanCandidateCount guards the gap this
+// bead exists to close: NewNotFoundError's "did you mean" suggestions are
+// plain strings, not []Candidate (that field is AMBIGUOUS_SYMBOL-only), so
+// candidate_count for a fuzzy-suggested NOT_FOUND must come from an explicit
+// caller-supplied count, not len(err.Candidates) (which is always 0 here).
+func TestWriteErrorWithMeta_NotFoundDidYouMeanCandidateCount(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".snipe"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	telemetry.SetRoot(root)
+	t.Cleanup(func() { telemetry.SetRoot("") })
+
+	suggestions := []string{"ClassifyRung"}
+	w := NewWriter(&strings.Builder{}, OutputClaude)
+	_ = w.WriteErrorWithMeta("def", "ClasifyRung", nil, IndexFresh, len(suggestions), NewNotFoundError("ClasifyRung", suggestions...))
+
+	recs, err := telemetry.ReadAll(root)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d usage.jsonl rows, want 1", len(recs))
+	}
+	if recs[0].CandidateCount != 1 {
+		t.Errorf("CandidateCount = %d, want 1 (from the did-you-mean suggestion, not err.Candidates which is empty here)", recs[0].CandidateCount)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -7,25 +7,66 @@ package telemetry
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
 
 var (
-	mu     sync.Mutex
-	path   string
-	caller string
+	mu         sync.Mutex
+	path       string
+	caller     string
+	sessionKey string
 )
+
+// Rung is one of the six canonical resolution-strategy buckets emitted on
+// every usage.jsonl row (sn-r1do.1, D2's bare→exact→CI→method→fuzzy→semantic
+// cascade). Downstream consumers (ferret, sn-r1do.2/.3) key on this exact
+// vocabulary — do not introduce new values without updating this comment and
+// those consumers.
+const (
+	RungExact           = "exact"
+	RungCaseInsensitive = "caseinsensitive"
+	RungMethod          = "method"
+	RungFuzzy           = "fuzzy"
+	RungSemantic        = "semantic"
+	RungNotFound        = "notfound"
+)
+
+// ciMatchDegradedMarker mirrors output.DegradedCIMatch as a literal to avoid
+// an import cycle (internal/output already imports internal/telemetry for
+// Emit, so telemetry cannot import output back).
+const ciMatchDegradedMarker = "ci-match"
 
 // Record is one usage event. Outcome is "ok" or the error code.
 type Record struct {
-	TS      string `json:"ts"`
-	Command string `json:"cmd"`
-	Outcome string `json:"outcome"`
-	Ms      int64  `json:"ms"`
-	Caller  string `json:"caller,omitempty"`
+	TS             string   `json:"ts"`
+	Command        string   `json:"cmd"`
+	Outcome        string   `json:"outcome"`
+	Ms             int64    `json:"ms"`
+	Caller         string   `json:"caller,omitempty"`
+	Arg            string   `json:"arg,omitempty"`
+	Rung           string   `json:"rung,omitempty"`
+	CandidateCount int      `json:"candidate_count,omitempty"`
+	IndexState     string   `json:"index_state,omitempty"`
+	SessionKey     string   `json:"session_key,omitempty"`
+	TriedRungs     []string `json:"tried_rungs,omitempty"` // raw decision-path trace, verbatim
+}
+
+// Fields is the input to Emit — a struct rather than positional args because
+// the row now carries eight-plus values (sn-r1do.1).
+type Fields struct {
+	Command        string
+	Outcome        string
+	Ms             int64
+	Arg            string
+	Rung           string
+	CandidateCount int
+	IndexState     string
+	TriedRungs     []string
 }
 
 // SetRoot points the sink at <root>/.snipe/usage.jsonl. Called once the
@@ -43,36 +84,109 @@ func SetCaller(c string) {
 	caller = c
 }
 
+// SetSessionKey tags subsequent events with a session join-key, so an
+// external miner (ferret, sn-r1do.2) can group rows from one invocation
+// stream without re-deriving the key itself.
+func SetSessionKey(k string) {
+	mu.Lock()
+	defer mu.Unlock()
+	sessionKey = k
+}
+
+// ResolveSessionKey derives a session join-key: the Claude Code session id
+// when running as a Claude Code subprocess (verified live env var, not a
+// guess), else a synthetic cwd+time-bucket fallback for direct-terminal/CI
+// use. Best-effort — not required to distinguish every standalone session
+// precisely, only to avoid dropping the field entirely.
+func ResolveSessionKey(root string) string {
+	if v := os.Getenv("CLAUDE_CODE_SESSION_ID"); v != "" {
+		return v
+	}
+	// 5-minute time bucket: long enough to keep one human/CI debugging burst
+	// together, short enough not to smear separate sessions hours apart into
+	// one key. No usage-distribution data exists yet to tune this further —
+	// revisit once sn-r1do.3's mining pass has real numbers.
+	return fmt.Sprintf("%s@%d", root, time.Now().Unix()/300)
+}
+
+// ClassifyRung reduces a decision-path trace (plus the degraded-marker list
+// and outcome) to one of the six canonical rung tokens. Pure, total,
+// panic-free: telemetry must never break a query.
+//
+// Any outcome other than "ok" classifies as RungNotFound — the six-value
+// vocabulary does not distinguish NOT_FOUND from AMBIGUOUS_SYMBOL or other
+// error codes; the row's Outcome field already carries that distinction.
+//
+// On the "ok" path: an empty/unrecognized trace defaults to RungExact —
+// decisionPath is only populated on fallback paths today (cmd/def.go,
+// cmd/search.go), so silence means the literal query was served, mirroring
+// the existing DegradedCIMatch/D4 convention (silence = served).
+//
+// Augment-path tokens (name_augment:*, sim_augment:*) that follow an already
+// -served exact/fuzzy hit are deliberately not special-cased: Rung describes
+// "the deepest resolution work that ran" for this row, not strictly "what
+// answered result #1." Callers needing the precise sequence read TriedRungs.
+func ClassifyRung(decisionPath, degraded []string, outcome string) string {
+	if outcome != "ok" {
+		return RungNotFound
+	}
+	for _, d := range degraded {
+		if d == ciMatchDegradedMarker {
+			return RungCaseInsensitive
+		}
+	}
+	for i := len(decisionPath) - 1; i >= 0; i-- {
+		tok := decisionPath[i]
+		switch {
+		case strings.HasPrefix(tok, "sim:"), strings.HasPrefix(tok, "sim_augment:"):
+			return RungSemantic
+		case strings.HasPrefix(tok, "index_fallback:"), strings.HasPrefix(tok, "name_augment:"), strings.HasPrefix(tok, "rg:"):
+			return RungFuzzy
+		case tok == "lookup:name_select", strings.HasPrefix(tok, "lookup:file_qualified"):
+			return RungMethod
+		case tok == "lookup:name", tok == "lookup:id", tok == "lookup:position":
+			return RungExact
+		}
+	}
+	return RungExact
+}
+
 // Emit appends one event. No-op when unconfigured or disabled.
-func Emit(command, outcome string, ms int64) {
+func Emit(f Fields) {
 	if os.Getenv("SNIPE_NO_TELEMETRY") != "" {
 		return
 	}
 	mu.Lock()
-	p, c := path, caller
+	p, c, sk := path, caller, sessionKey
 	mu.Unlock()
 	if p == "" {
 		return
 	}
 
 	rec := Record{
-		TS:      time.Now().Format(time.RFC3339),
-		Command: command,
-		Outcome: outcome,
-		Ms:      ms,
-		Caller:  c,
+		TS:             time.Now().Format(time.RFC3339),
+		Command:        f.Command,
+		Outcome:        f.Outcome,
+		Ms:             f.Ms,
+		Caller:         c,
+		Arg:            f.Arg,
+		Rung:           f.Rung,
+		CandidateCount: f.CandidateCount,
+		IndexState:     f.IndexState,
+		SessionKey:     sk,
+		TriedRungs:     f.TriedRungs,
 	}
 	line, err := json.Marshal(rec)
 	if err != nil {
 		return
 	}
 
-	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) // #nosec G304 -- path derived from project root
+	fh, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) // #nosec G304 -- path derived from project root
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	_, _ = f.Write(append(line, '\n'))
+	defer fh.Close()
+	_, _ = fh.Write(append(line, '\n'))
 }
 
 // ReadAll loads every record from <root>/.snipe/usage.jsonl, skipping

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -13,11 +13,12 @@ func TestEmitAndReadAll_RoundTrip(t *testing.T) {
 	}
 	SetRoot(root)
 	SetCaller("test")
-	t.Cleanup(func() { SetRoot(""); SetCaller("") })
+	SetSessionKey("sess-abc")
+	t.Cleanup(func() { SetRoot(""); SetCaller(""); SetSessionKey("") })
 
-	Emit("def", "ok", 12)
-	Emit("def", "NOT_FOUND", 3)
-	Emit("pack", "ok", 40)
+	Emit(Fields{Command: "def", Outcome: "ok", Ms: 12, Arg: "Foo", Rung: RungExact, IndexState: "fresh"})
+	Emit(Fields{Command: "def", Outcome: "NOT_FOUND", Ms: 3, Arg: "Fooo", Rung: RungNotFound, CandidateCount: 2, TriedRungs: []string{"lookup:name"}})
+	Emit(Fields{Command: "pack", Outcome: "ok", Ms: 40, Arg: "Bar", Rung: RungFuzzy})
 
 	recs, err := ReadAll(root)
 	if err != nil {
@@ -29,8 +30,30 @@ func TestEmitAndReadAll_RoundTrip(t *testing.T) {
 	if recs[0].Command != "def" || recs[0].Outcome != "ok" || recs[0].Caller != "test" {
 		t.Errorf("first record = %+v", recs[0])
 	}
+	if recs[0].Arg != "Foo" {
+		t.Errorf("first record Arg = %q, want %q", recs[0].Arg, "Foo")
+	}
+	if recs[0].Rung != RungExact {
+		t.Errorf("first record Rung = %q, want %q", recs[0].Rung, RungExact)
+	}
+	if recs[0].SessionKey != "sess-abc" {
+		t.Errorf("first record SessionKey = %q, want %q", recs[0].SessionKey, "sess-abc")
+	}
+	if recs[0].IndexState != "fresh" {
+		t.Errorf("first record IndexState = %q, want %q", recs[0].IndexState, "fresh")
+	}
+
 	if recs[1].Outcome != "NOT_FOUND" {
 		t.Errorf("second outcome = %q, want NOT_FOUND", recs[1].Outcome)
+	}
+	if recs[1].Rung != RungNotFound {
+		t.Errorf("second record Rung = %q, want %q", recs[1].Rung, RungNotFound)
+	}
+	if recs[1].CandidateCount != 2 {
+		t.Errorf("second record CandidateCount = %d, want 2", recs[1].CandidateCount)
+	}
+	if len(recs[1].TriedRungs) != 1 || recs[1].TriedRungs[0] != "lookup:name" {
+		t.Errorf("second record TriedRungs = %v, want [lookup:name]", recs[1].TriedRungs)
 	}
 }
 
@@ -56,6 +79,37 @@ not json at all
 	}
 }
 
+// TestReadAll_BackwardCompat_PreEnrichmentLines guards the AC's "no schema
+// break" requirement (sn-r1do.1): a usage.jsonl written by a pre-enrichment
+// binary (only ts/cmd/outcome/ms/caller — sn-g0d.7's shape) must still parse
+// cleanly, with every new field simply zero-valued.
+func TestReadAll_BackwardCompat_PreEnrichmentLines(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".snipe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"ts":"2026-06-12T10:00:00Z","cmd":"def","outcome":"ok","ms":5,"caller":"orca"}
+`
+	if err := os.WriteFile(filepath.Join(dir, "usage.jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recs, err := ReadAll(root)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1", len(recs))
+	}
+	r := recs[0]
+	if r.Command != "def" || r.Outcome != "ok" || r.Ms != 5 || r.Caller != "orca" {
+		t.Errorf("pre-enrichment fields not preserved: %+v", r)
+	}
+	if r.Arg != "" || r.Rung != "" || r.CandidateCount != 0 || r.IndexState != "" || r.SessionKey != "" || r.TriedRungs != nil {
+		t.Errorf("enrichment fields should zero-value on an old-shaped line, got %+v", r)
+	}
+}
+
 func TestEmit_DisabledByEnv(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".snipe"), 0o755); err != nil {
@@ -65,9 +119,65 @@ func TestEmit_DisabledByEnv(t *testing.T) {
 	t.Cleanup(func() { SetRoot("") })
 	t.Setenv("SNIPE_NO_TELEMETRY", "1")
 
-	Emit("def", "ok", 1)
+	Emit(Fields{Command: "def", Outcome: "ok", Ms: 1})
 
 	if _, err := os.Stat(filepath.Join(root, ".snipe", "usage.jsonl")); !os.IsNotExist(err) {
 		t.Error("usage.jsonl should not exist when SNIPE_NO_TELEMETRY is set")
+	}
+}
+
+// TestClassifyRung_AllSixValues exercises ClassifyRung against decision-path
+// shapes actually emitted by cmd/def.go and cmd/search.go (not guessed —
+// verified by reading those files, sn-r1do.1 plan §2).
+func TestClassifyRung_AllSixValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		decisionPath []string
+		degraded     []string
+		outcome      string
+		want         string
+	}{
+		{"silent exact (def lookup:name)", []string{"lookup:name"}, nil, "ok", RungExact},
+		{"silent exact (empty path)", nil, nil, "ok", RungExact},
+		{"lookup:id", []string{"lookup:id"}, nil, "ok", RungExact},
+		{"lookup:position", []string{"lookup:position"}, nil, "ok", RungExact},
+		{"ci-match degraded marker wins", nil, []string{"ci-match"}, "ok", RungCaseInsensitive},
+		{"lookup:name_select", []string{"lookup:name_select"}, nil, "ok", RungMethod},
+		{"lookup:file_qualified", []string{"lookup:file_qualified"}, nil, "ok", RungMethod},
+		{"search index_fallback", []string{"rg:0_results", "index_fallback:3_results"}, nil, "ok", RungFuzzy},
+		{"search name_augment", []string{"name_augment:2_added"}, nil, "ok", RungFuzzy},
+		{"search sim fallback", []string{"rg:0_results", "sim:2_results:40ms"}, nil, "ok", RungSemantic},
+		{"search sim_augment", []string{"sim_augment:1_added:12ms"}, nil, "ok", RungSemantic},
+		{"not found", nil, nil, "NOT_FOUND", RungNotFound},
+		{"ambiguous symbol", nil, nil, "AMBIGUOUS_SYMBOL", RungNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyRung(tt.decisionPath, tt.degraded, tt.outcome)
+			if got != tt.want {
+				t.Errorf("ClassifyRung(%v, %v, %q) = %q, want %q", tt.decisionPath, tt.degraded, tt.outcome, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveSessionKey_EnvVarWins confirms the CLAUDE_CODE_SESSION_ID env
+// var is used verbatim when present (sn-r1do.1 §4) — the fallback bucket
+// path must not run when it's set.
+func TestResolveSessionKey_EnvVarWins(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "cc-session-123")
+	got := ResolveSessionKey("/some/root")
+	if got != "cc-session-123" {
+		t.Errorf("ResolveSessionKey = %q, want %q", got, "cc-session-123")
+	}
+}
+
+// TestResolveSessionKey_FallbackIncludesRoot guards the synthetic
+// cwd+time-bucket fallback used outside Claude Code (direct terminal/CI).
+func TestResolveSessionKey_FallbackIncludesRoot(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	got := ResolveSessionKey("/some/root")
+	if len(got) <= len("/some/root") {
+		t.Errorf("ResolveSessionKey fallback = %q, want it to embed root %q", got, "/some/root")
 	}
 }


### PR DESCRIPTION
## Summary

- usage.jsonl gains per-row `arg`, `rung`, `tried_rungs`, `candidate_count`, `index_state`, `session_key` — foundation bead of epic sn-r1do (instrument snipe queries → mine friction → improve resolver, offline).
- `rung` is classified via a new `telemetry.ClassifyRung(decisionPath, degraded, outcome)` against the D2 cascade vocabulary (exact/caseinsensitive/method/fuzzy/semantic/notfound), reusing the existing `Meta.DecisionPath`/`Meta.Degraded` signals already computed in cmd/def.go and cmd/search.go — no new tracking invented.
- `session_key` uses `CLAUDE_CODE_SESSION_ID` when present (verified live in a Claude Code subprocess), else a `cwd@5min-bucket` fallback for direct-terminal/CI use.
- `telemetry.Emit` moves from positional args to a `Fields` struct (internal Go API change only, not a JSON change). `WriteError` gains a `WriteErrorWithMeta` sibling; `def`/`sym`/`pack` — the bead's own verify targets — route their NOT_FOUND/AMBIGUOUS_SYMBOL error sites through it so those rows carry the query arg, decision-path, and candidate count. `WriteError` itself stays a stable thin wrapper (0-valued extras) so the ~25 other call sites elsewhere keep compiling unchanged.
- Existing fields (`ts`,`cmd`,`outcome`,`ms`,`caller`) are untouched; all new fields are additive/`omitempty` — no schema break (covered by `TestReadAll_BackwardCompat_PreEnrichmentLines`).

## Pre-existing bug found during verification (not fixed here)

`pack`'s `resolvePackSymbol` double-emits an error (and now a duplicate usage.jsonl row) on NOT_FOUND/AMBIGUOUS_SYMBOL: `WriteError`'s return value is the `io.WriteString` error from rendering, not the semantic `*output.Error`, so the caller's `if err != nil { return err }` doesn't short-circuit and execution falls through to a second lookup that fails again. Confirmed present on `main` (commit 445390f) before this change — unrelated to this bead, left unfixed to keep this PR's blast radius to instrumentation only. Filed as sn-tba4.

## Test plan

- [x] `make check` green (vet + lint + test)
- [x] `TestEmitAndReadAll_RoundTrip` extended for all new fields
- [x] `TestClassifyRung_AllSixValues` — table-driven over real decision-path shapes from cmd/def.go and cmd/search.go
- [x] `TestReadAll_BackwardCompat_PreEnrichmentLines` — old-shaped usage.jsonl line still parses cleanly
- [x] `TestPrimaryQueryArg_PriorityOrder`, `TestResponseTelemetryMeta_ClassifiesRung`
- [x] `TestWriteErrorWithMeta_EmitsCandidateCountAndArg`, `TestWriteErrorWithMeta_NotFoundDidYouMeanCandidateCount`
- [x] Manual verify: ran `def`/`sym`/`pack` against a hit, a close typo, and a totally absent symbol on this repo's own index — confirmed distinct `arg`/`rung` per row and `candidate_count` populated exactly when did-you-mean suggestions fire

Closes: sn-r1do.1