### PR TITLE
feat(diagram): datastore access map — schema + read/write packages per store

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -395,10 +395,11 @@ func (c *SensitiveCmd) Run() error {
 type DiagramCmd struct {
 	// diagram reuses the global --format flag (d2 default, or svg). It cannot
 	// redeclare --format because the global flag is embedded on every command.
-	Arch      DiagramArchCmd      `cmd:"" help:"Package import graph trimmed to the top-N by PageRank, grouped by layer. Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)"`
-	Flow      DiagramFlowCmd      `cmd:"" help:"Depth-limited call graph from an entry symbol"`
-	Lifecycle DiagramLifecycleCmd `cmd:"" help:"Render lifecycle CRUD groups for a type as D2"`
-	Seams     DiagramSeamsCmd     `cmd:"" help:"Rank pluggable interfaces by implementation count and fan-in. Writes docs/diagrams/seam-map.md by default (--format d2/svg for stdout)"`
+	Arch       DiagramArchCmd       `cmd:"" help:"Package import graph trimmed to the top-N by PageRank, grouped by layer. Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)"`
+	Flow       DiagramFlowCmd       `cmd:"" help:"Depth-limited call graph from an entry symbol"`
+	Lifecycle  DiagramLifecycleCmd  `cmd:"" help:"Render lifecycle CRUD groups for a type as D2"`
+	Seams      DiagramSeamsCmd      `cmd:"" help:"Rank pluggable interfaces by implementation count and fan-in. Writes docs/diagrams/seam-map.md by default (--format d2/svg for stdout)"`
+	Datastores DiagramDatastoresCmd `cmd:"" name:"datastore-map" help:"Datastore access map: schema + read/write packages per detected store. Writes docs/diagrams/datastore-map.md by default (--format d2/svg for stdout)"`
 }
 
 // AfterApply maps the global --format into the diagram package var. Unset
@@ -454,6 +455,12 @@ type DiagramSeamsCmd struct {
 func (c *DiagramSeamsCmd) Run() error {
 	diagramSeamsTopN = c.Top
 	return runDiagramSeams()
+}
+
+type DiagramDatastoresCmd struct{}
+
+func (c *DiagramDatastoresCmd) Run() error {
+	return runDiagramDatastores()
 }
 
 type LifecycleCmd struct {

--- a/cmd/datastoremap.go
+++ b/cmd/datastoremap.go
@@ -1,0 +1,353 @@
+package cmd
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dkoosis/snipe/internal/c4"
+	"github.com/dkoosis/snipe/internal/context"
+	"github.com/dkoosis/snipe/internal/datastoremap"
+	"github.com/dkoosis/snipe/internal/diagram"
+	"github.com/dkoosis/snipe/internal/lifecycle"
+	"github.com/dkoosis/snipe/internal/output"
+	"github.com/dkoosis/snipe/internal/query"
+)
+
+// datastoreListCap bounds how many read/write entries the text summary lists
+// per store before truncating with a "+N more" marker — a busy store's
+// touchpoint list shouldn't blow out the doc's token budget.
+const datastoreListCap = 25
+
+// storeHandleNames are common names for the exported type that represents a
+// package's persistence handle. When a datastore's package declares one of
+// these, lifecycle classification runs against it specifically rather than
+// every exported type in the package — the handle type is what callers
+// actually construct/pass around to read or write the store, so its refs are
+// the real access surface. Falls back to every exported type when none of
+// these names match (see pickStoreTypes).
+var storeHandleNames = map[string]bool{
+	"store":      true,
+	"db":         true,
+	"database":   true,
+	"client":     true,
+	"repo":       true,
+	"repository": true,
+	"conn":       true,
+	"connection": true,
+	"handle":     true,
+}
+
+// pkgType is the minimal symbol shape findPackageTypes needs — deliberately
+// narrower than query.SymbolRow since this command only classifies by name.
+type pkgType struct {
+	ID   string
+	Name string
+}
+
+// pickStoreTypes narrows a package's exported types to its persistence
+// handle(s) by name (case-insensitive) — see storeHandleNames. Deliberately
+// does NOT fall back to "every exported type" when nothing matches: c4's
+// datastore detection flags any package that imports the bare "database/sql"
+// package as a datastore, even when it only takes a *sql.DB parameter rather
+// than owning a store (e.g. cmd, or a query-helper package). Without a named
+// handle type, there's no principled "this type is the store" anchor for
+// lifecycle classification — running it against every exported type in such
+// a package (CLI command structs, unrelated DTOs, ...) produces noise, not
+// signal. Callers treat an empty result as "no read/write map for this
+// package" rather than guessing.
+func pickStoreTypes(types []pkgType) []pkgType {
+	var matched []pkgType
+	for _, t := range types {
+		if storeHandleNames[strings.ToLower(t.Name)] {
+			matched = append(matched, t)
+		}
+	}
+	return matched
+}
+
+// runDiagramDatastores builds the datastore access map: for each detected
+// SQL store, its schema (internal/context.DetectDBSchemas) plus a read-list
+// and write-list of packages/functions (internal/c4 datastore detection,
+// direction from internal/lifecycle role classification). Written via
+// emitDoc to docs/diagrams/datastore-map.md by default, same pattern as
+// `diagram arch`/`diagram lifecycle`.
+func runDiagramDatastores() error {
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+	s, dir, err := OpenStore(w, "diagram datastore-map")
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	db := s.DB()
+	modulePath := query.DetectModulePath(db)
+
+	facts, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		return fmt.Errorf("build c4 facts: %w", err)
+	}
+	datastores := datastoremap.GroupByPackage(datastoremap.FilterTestPackages(facts.Datastores))
+
+	schemas := context.DetectDBSchemas(dir)
+
+	stores, err := buildStores(db, schemas, datastores, modulePath)
+	if err != nil {
+		return err
+	}
+
+	summary := renderDatastoreSummary(stores)
+	d2src := renderDatastoreDiagram(stores).Render()
+
+	return emitDoc("datastore-map", summary, d2src)
+}
+
+// buildStores correlates each detected schema to its owning package (when
+// resolvable), classifies that package's persistence-handle type(s) via
+// internal/lifecycle, and buckets the results into read/write lists.
+// Datastore packages with no matching schema still get a Store entry (schema
+// unknown, access map populated) so a driver-detected store never vanishes
+// silently just because DetectDBSchemas couldn't find its DDL.
+func buildStores(db *sql.DB, schemas []context.DBSchema, datastores []c4.Datastore, modulePath string) ([]datastoremap.Store, error) {
+	matchedPkgs := make(map[string]bool, len(schemas))
+	stores := make([]datastoremap.Store, 0, len(schemas)+len(datastores))
+
+	for _, schema := range schemas {
+		st := datastoremap.Store{
+			Name:         schema.Name,
+			SchemaSource: schema.Source,
+			DDL:          schema.DDL,
+		}
+		if pkg, ok := datastoremap.MatchSchema(schema, datastores, modulePath); ok {
+			st.Package = pkg
+			matchedPkgs[pkg] = true
+			classifications, err := classifyPackage(db, pkg)
+			if err != nil {
+				return nil, err
+			}
+			st.Reads, st.Writes, st.Unclear = datastoremap.BucketRoles(classifications)
+		}
+		stores = append(stores, st)
+	}
+
+	// Datastore packages that no schema claimed still get an entry — a real
+	// touchpoint c4 found, just without known DDL. But c4's "SQL" fallback
+	// fires on any package that merely takes a *sql.DB parameter (e.g. a
+	// query-helper package), not just packages that own a store — if
+	// classifyPackage found no persistence-handle type at all (see
+	// pickStoreTypes), there's nothing to show, so skip rather than emit an
+	// empty, noisy entry.
+	for _, d := range datastores {
+		if matchedPkgs[d.Package] {
+			continue
+		}
+		classifications, err := classifyPackage(db, d.Package)
+		if err != nil {
+			return nil, err
+		}
+		reads, writes, unclear := datastoremap.BucketRoles(classifications)
+		if len(reads) == 0 && len(writes) == 0 && unclear == 0 {
+			continue
+		}
+		stores = append(stores, datastoremap.Store{
+			Name: d.Name, Package: d.Package,
+			Reads: reads, Writes: writes, Unclear: unclear,
+		})
+	}
+
+	return stores, nil
+}
+
+// classifyPackage finds pkg's persistence-handle type(s) and runs
+// internal/lifecycle classification against each, merging the results.
+func classifyPackage(db *sql.DB, pkg string) ([]lifecycle.Classification, error) {
+	types, err := findPackageTypes(db, pkg)
+	if err != nil {
+		return nil, err
+	}
+	if len(types) == 0 {
+		return nil, nil
+	}
+
+	var out []lifecycle.Classification
+	for _, t := range pickStoreTypes(types) {
+		refRows, err := query.FindRefs(db, t.ID, 10000, 0)
+		if err != nil {
+			return nil, fmt.Errorf("find refs for %s: %w", t.Name, err)
+		}
+		refs := lifecycle.FromRefRows(refRows)
+		out = append(out, lifecycle.Classify(t.Name, refs)...)
+	}
+	return out, nil
+}
+
+// findPackageTypes returns every exported struct/type declared directly in
+// pkg (excluding _test.go files) — candidates for pickStoreTypes.
+func findPackageTypes(db *sql.DB, pkg string) ([]pkgType, error) {
+	rows, err := db.Query(`
+		SELECT id, name
+		FROM symbols
+		WHERE pkg_path = ?
+		  AND kind IN (?, ?)
+		  AND length(name) > 0
+		  AND substr(name, 1, 1) = upper(substr(name, 1, 1))
+		  AND file_path_rel NOT LIKE '%_test.go'
+		ORDER BY line_start
+	`, pkg, cmdKindType, cmdKindStruct)
+	if err != nil {
+		return nil, fmt.Errorf("query package types: %w", err)
+	}
+	defer rows.Close()
+
+	var out []pkgType
+	for rows.Next() {
+		var t pkgType
+		if err := rows.Scan(&t.ID, &t.Name); err != nil {
+			return nil, fmt.Errorf("scan package type: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// renderDatastoreSummary renders the Claude-facing plain-text section:
+// schema DDL then read/write lists, per store.
+func renderDatastoreSummary(stores []datastoremap.Store) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "diagram datastore-map · %d store(s)\n", len(stores))
+
+	for _, st := range stores {
+		label := st.Name
+		if st.Package != "" {
+			label = fmt.Sprintf("%s (%s)", st.Name, st.Package)
+		}
+		fmt.Fprintf(&b, "\n## %s\n", label)
+
+		if st.SchemaSource != "" {
+			fmt.Fprintf(&b, "schema: %s\n", st.SchemaSource)
+			if st.DDL != "" {
+				b.WriteString(st.DDL)
+				if !strings.HasSuffix(st.DDL, "\n") {
+					b.WriteString("\n")
+				}
+			}
+		} else {
+			b.WriteString("schema: (not detected)\n")
+		}
+
+		if st.Package == "" {
+			b.WriteString("(no owning package resolved — read/write map unavailable)\n")
+			continue
+		}
+
+		fmt.Fprintf(&b, "\nreads (%d):\n", len(st.Reads))
+		writeEntryList(&b, st.Reads)
+		fmt.Fprintf(&b, "writes (%d):\n", len(st.Writes))
+		writeEntryList(&b, st.Writes)
+		if st.Unclear > 0 {
+			fmt.Fprintf(&b, "unclear: %d classification(s) neither read nor write\n", st.Unclear)
+		}
+	}
+
+	return b.String()
+}
+
+func writeEntryList(b *strings.Builder, entries []datastoremap.Entry) {
+	shown := entries
+	truncated := 0
+	if len(shown) > datastoreListCap {
+		truncated = len(shown) - datastoreListCap
+		shown = shown[:datastoreListCap]
+	}
+	for _, e := range shown {
+		name := e.Func
+		if name == "" {
+			name = "(file scope)"
+		}
+		fmt.Fprintf(b, "  %s  %s:%d  [%s]\n", name, e.File, e.Line, e.Role)
+	}
+	if truncated > 0 {
+		fmt.Fprintf(b, "  ... +%d more\n", truncated)
+	}
+}
+
+// datastorePerRoleCap bounds how many function nodes each read/write
+// container draws in the D2 diagram — the text summary above lists more
+// (datastoreListCap); the diagram stays legible at a smaller cap.
+const datastorePerRoleCap = 8
+
+// renderDatastoreDiagram builds a D2 diagram: one cylinder per store, with
+// "reads"/"writes" containers of function nodes, edges pointing store->read
+// and write->store (matching cmd/diagram.go's runDiagramLifecycle
+// convention: writes flow into the data, reads flow out of it).
+func renderDatastoreDiagram(stores []datastoremap.Store) *diagram.Builder {
+	var b diagram.Builder
+	b.Title = "snipe datastore access map"
+	b.Direction = "right"
+
+	for _, st := range stores {
+		storeID := diagram.SanitizeID(st.Name + "_" + st.Package)
+		storeNode := "store_" + storeID
+		b.AddNode(storeNode, st.Name, "cylinder", map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue})
+
+		if st.Package == "" {
+			continue
+		}
+
+		// Containers are siblings of storeNode, not its children: dagre
+		// (the D2 layout engine emitDoc shells out to) rejects an edge from a
+		// container to its own descendant, and storeNode -> read-fn / write-fn
+		// -> storeNode edges are exactly that shape if the containers nest
+		// under storeNode.
+		if len(st.Reads) > 0 {
+			container := "reads_" + storeID
+			b.AddContainer(container, st.Name+" reads", map[string]string{diagramFill: "#dbeafe"})
+			addRoleNodes(&b, container, st.Reads, func(fnNode string) {
+				b.AddEdge(storeNode, fnNode, "read", nil)
+			})
+		}
+		if len(st.Writes) > 0 {
+			container := "writes_" + storeID
+			b.AddContainer(container, st.Name+" writes", map[string]string{diagramFill: "#fef9c3"})
+			addRoleNodes(&b, container, st.Writes, func(fnNode string) {
+				b.AddEdge(fnNode, storeNode, "write", nil)
+			})
+		}
+	}
+
+	return &b
+}
+
+func addRoleNodes(b *diagram.Builder, container string, entries []datastoremap.Entry, edge func(fnNode string)) {
+	sorted := make([]datastoremap.Entry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].File != sorted[j].File {
+			return sorted[i].File < sorted[j].File
+		}
+		return sorted[i].Line < sorted[j].Line
+	})
+
+	shown := sorted
+	truncated := 0
+	if len(shown) > datastorePerRoleCap {
+		truncated = len(shown) - datastorePerRoleCap
+		shown = shown[:datastorePerRoleCap]
+	}
+	for _, e := range shown {
+		name := e.Func
+		if name == "" {
+			name = "(file scope)"
+		}
+		id := container + "." + diagram.SanitizeID(name+fmt.Sprintf("%d", e.Line))
+		label := fmt.Sprintf("%s · %s:%d", name, e.File, e.Line)
+		b.AddNode(id, label, "", nil)
+		edge(id)
+	}
+	if truncated > 0 {
+		id := container + "._more"
+		b.AddNode(id, fmt.Sprintf("+%d more", truncated), "", map[string]string{"font-color": "#6b7280"})
+	}
+}

--- a/cmd/datastoremap_test.go
+++ b/cmd/datastoremap_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/datastoremap"
+	"github.com/dkoosis/snipe/internal/lifecycle"
+)
+
+func TestPickStoreTypes_PrefersHandleName(t *testing.T) {
+	types := []pkgType{
+		{ID: "1", Name: "FileChurn"},
+		{ID: "2", Name: "Store"},
+		{ID: "3", Name: "MetricRow"},
+	}
+	got := pickStoreTypes(types)
+	if len(got) != 1 || got[0].Name != "Store" {
+		t.Fatalf("want only Store, got %+v", got)
+	}
+}
+
+func TestPickStoreTypes_NoHandleNameReturnsEmpty(t *testing.T) {
+	// c4 flags any package importing bare "database/sql" as a datastore, even
+	// one that only takes a *sql.DB parameter rather than owning a store.
+	// Without a named handle type, pickStoreTypes must return nothing rather
+	// than fall back to every exported type (that would run lifecycle
+	// classification against unrelated types and produce noise).
+	types := []pkgType{
+		{ID: "1", Name: "FileChurn"},
+		{ID: "2", Name: "MetricRow"},
+	}
+	got := pickStoreTypes(types)
+	if len(got) != 0 {
+		t.Fatalf("want empty result when no handle name matches, got %+v", got)
+	}
+}
+
+func TestPickStoreTypes_CaseInsensitiveMatch(t *testing.T) {
+	types := []pkgType{
+		{ID: "1", Name: "DB"},
+		{ID: "2", Name: "Other"},
+	}
+	got := pickStoreTypes(types)
+	if len(got) != 1 || got[0].Name != "DB" {
+		t.Fatalf("want only DB, got %+v", got)
+	}
+}
+
+func TestRenderDatastoreSummary_UnmatchedSchemaNotesMissingMap(t *testing.T) {
+	stores := []datastoremap.Store{
+		{Name: "schema", SchemaSource: "schema.sql", DDL: "CREATE TABLE t (id INTEGER)"},
+	}
+	got := renderDatastoreSummary(stores)
+	if !strings.Contains(got, "read/write map unavailable") {
+		t.Fatalf("want unresolved-package note, got:\n%s", got)
+	}
+	if !strings.Contains(got, "CREATE TABLE t") {
+		t.Fatalf("want DDL embedded, got:\n%s", got)
+	}
+}
+
+func TestRenderDatastoreSummary_MatchedStoreListsReadsAndWrites(t *testing.T) {
+	stores := []datastoremap.Store{
+		{
+			Name:         "SQLite",
+			Package:      "example.com/repo/internal/store",
+			SchemaSource: "internal/store/schema.go",
+			DDL:          "CREATE TABLE nugs (id TEXT)",
+			Reads:        []datastoremap.Entry{{Func: "LoadNug", File: "internal/store/read.go", Line: 10, Role: lifecycle.RoleRead}},
+			Writes:       []datastoremap.Entry{{Func: "SaveNug", File: "internal/store/write.go", Line: 20, Role: lifecycle.RoleCreate}},
+			Unclear:      2,
+		},
+	}
+	got := renderDatastoreSummary(stores)
+	for _, want := range []string{"reads (1)", "LoadNug", "writes (1)", "SaveNug", "unclear: 2"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderDatastoreSummary_ListCapTruncates(t *testing.T) {
+	var reads []datastoremap.Entry
+	for i := 0; i < datastoreListCap+5; i++ {
+		reads = append(reads, datastoremap.Entry{Func: "Fn", File: "f.go", Line: i + 1, Role: lifecycle.RoleRead})
+	}
+	stores := []datastoremap.Store{
+		{Name: "SQLite", Package: "example.com/repo/internal/store", Reads: reads},
+	}
+	got := renderDatastoreSummary(stores)
+	if !strings.Contains(got, "+5 more") {
+		t.Fatalf("want truncation marker, got:\n%s", got)
+	}
+}
+
+func TestRenderDatastoreDiagram_NoPackageStillDrawsStoreNode(t *testing.T) {
+	stores := []datastoremap.Store{
+		{Name: "schema", SchemaSource: "schema.sql"},
+	}
+	d2 := renderDatastoreDiagram(stores).Render()
+	if !strings.Contains(d2, "schema") {
+		t.Fatalf("want store node rendered even without a matched package, got:\n%s", d2)
+	}
+}
+
+func TestRenderDatastoreDiagram_DrawsReadWriteEdges(t *testing.T) {
+	stores := []datastoremap.Store{
+		{
+			Name:    "SQLite",
+			Package: "example.com/repo/internal/store",
+			Reads:   []datastoremap.Entry{{Func: "LoadNug", File: "read.go", Line: 10, Role: lifecycle.RoleRead}},
+			Writes:  []datastoremap.Entry{{Func: "SaveNug", File: "write.go", Line: 20, Role: lifecycle.RoleCreate}},
+		},
+	}
+	d2 := renderDatastoreDiagram(stores).Render()
+	if !strings.Contains(d2, "LoadNug") || !strings.Contains(d2, "SaveNug") {
+		t.Fatalf("want both read and write function nodes rendered, got:\n%s", d2)
+	}
+}

--- a/cmd/testdata/help/diagram-datastore-map.golden
+++ b/cmd/testdata/help/diagram-datastore-map.golden
@@ -1,6 +1,7 @@
-Usage: snipe diagram <command> [flags]
+Usage: snipe diagram datastore-map
 
-Render snipe graphs as D2 diagram source
+Datastore access map: schema + read/write packages per detected store. Writes
+docs/diagrams/datastore-map.md by default (--format d2/svg for stdout)
 
 Flags:
   -h, --help                Show context-sensitive help.
@@ -18,21 +19,3 @@ Flags:
       --timeout=DURATION    Timeout for command (e.g., 30s, 5m)
       --select="all"        Pick top candidates by score: all, best, top3,
                             top5 (applied before --limit)
-
-Graph & Structure:
-  diagram arch [flags]
-    Package import graph trimmed to the top-N by PageRank, grouped by layer.
-    Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)
-
-  diagram flow <entry> [flags]
-    Depth-limited call graph from an entry symbol
-
-  diagram lifecycle <type>
-    Render lifecycle CRUD groups for a type as D2
-
-  diagram seams [flags]
-    Rank pluggable interfaces by implementation count and fan-in. Writes
-    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)  diagram datastore-map
-    Datastore access map: schema + read/write packages per detected store.
-    Writes docs/diagrams/datastore-map.md by default (--format d2/svg for
-    stdout)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -154,8 +154,10 @@ Graph & Structure:
 
   diagram seams [flags]
     Rank pluggable interfaces by implementation count and fan-in. Writes
-    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)
-
+    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)  diagram datastore-map
+    Datastore access map: schema + read/write packages per detected store.
+    Writes docs/diagrams/datastore-map.md by default (--format d2/svg for
+    stdout)
   lifecycle [<type>] [flags]
     Trace every function creating, mutating, reading, or deleting a type
 

--- a/internal/datastoremap/datastoremap.go
+++ b/internal/datastoremap/datastoremap.go
@@ -1,0 +1,150 @@
+// Package datastoremap joins three signals snipe already collects into one
+// answer: for each detected datastore, which packages/functions read it and
+// which write it.
+//
+//  1. internal/c4 detects datastores by import (a package importing a driver
+//     from the fixed allowlist) — but that raw signal includes Go external
+//     test packages (declared `package foo_test`) as if they were real
+//     touchpoints, and can list the same package twice under a generic
+//     "SQL" name and a specific driver name.
+//  2. internal/context's DetectDBSchemas finds the DDL for a store — a
+//     separate detector (grep-shaped, not package-aware) that this package
+//     correlates back to a c4 Datastore by directory.
+//  3. internal/lifecycle classifies functions that reference a Go type as
+//     Create/Mutate/Read/Delete — the read/write direction c4 alone lacks.
+//
+// This package holds only the pure join/bucketing logic (filter, group,
+// match, bucket) so it's unit-testable without a database. DB access —
+// finding the candidate types in a package, fetching their refs — stays in
+// cmd/datastoremap.go, mirroring how internal/lifecycle stays pure while
+// cmd/diagram.go does the querying.
+package datastoremap
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dkoosis/snipe/internal/c4"
+	"github.com/dkoosis/snipe/internal/context"
+	"github.com/dkoosis/snipe/internal/lifecycle"
+)
+
+// Entry is one function's access to a store, projected from a lifecycle
+// Classification.
+type Entry struct {
+	Func string
+	File string
+	Line int
+	Role lifecycle.Role
+}
+
+// Store is the access-map render unit: one detected datastore, its schema
+// (when a DBSchema correlates to it), and its read/write function lists.
+type Store struct {
+	Name         string // display name, e.g. "SQLite"
+	Package      string // owning package import path, "" if no c4 match
+	SchemaSource string // DBSchema.Source, "" if no schema matched
+	DDL          string
+	Reads        []Entry
+	Writes       []Entry
+	Unclear      int // non-test classifications that were neither Read nor a write role
+}
+
+// FilterTestPackages drops c4 Datastore rows whose importing package is a Go
+// external test package (declared `package foo_test`, compiled only for
+// `go test`). The imports table records these importer packages exactly like
+// any real one, but they exist only to exercise the store — not a real
+// touchpoint of the running program.
+func FilterTestPackages(datastores []c4.Datastore) []c4.Datastore {
+	out := make([]c4.Datastore, 0, len(datastores))
+	for _, d := range datastores {
+		if strings.HasSuffix(d.Package, "_test") {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// GroupByPackage collapses multiple Datastore rows for the same importing
+// package into one row per package. A package that imports both a generic
+// driver ("database/sql") and a specific one (e.g. "modernc.org/sqlite")
+// produces two c4 rows for the same package; the specific name is always the
+// more useful label, so it wins over the generic "SQL" fallback.
+func GroupByPackage(datastores []c4.Datastore) []c4.Datastore {
+	best := make(map[string]c4.Datastore, len(datastores))
+	order := make([]string, 0, len(datastores))
+	for _, d := range datastores {
+		cur, ok := best[d.Package]
+		if !ok {
+			best[d.Package] = d
+			order = append(order, d.Package)
+			continue
+		}
+		if cur.Name == "SQL" && d.Name != "SQL" {
+			best[d.Package] = d
+		}
+	}
+	sort.Strings(order)
+	out := make([]c4.Datastore, 0, len(order))
+	for _, pkg := range order {
+		out = append(out, best[pkg])
+	}
+	return out
+}
+
+// MatchSchema finds the datastore whose package directory (relative to
+// modulePath) equals the DBSchema's source directory — the heuristic that
+// correlates a schema detected by DetectDBSchemas (embedded Go DDL, or a
+// migrations/ directory) with the c4-detected package that owns it. Returns
+// ("", false) when no datastore's package resolves to the schema's
+// directory — e.g. a repo-root schema.sql isn't owned by any one package.
+func MatchSchema(schema context.DBSchema, datastores []c4.Datastore, modulePath string) (string, bool) {
+	schemaDir := filepath.ToSlash(filepath.Dir(schema.Source))
+	for _, d := range datastores {
+		pkgDir := strings.TrimPrefix(d.Package, modulePath)
+		pkgDir = strings.TrimPrefix(pkgDir, "/")
+		if pkgDir != "" && pkgDir == schemaDir {
+			return d.Package, true
+		}
+	}
+	return "", false
+}
+
+// BucketRoles groups lifecycle classifications into read/write entries.
+// Test-file classifications are skipped entirely (they exercise the store,
+// they aren't its real read/write surface); Unknown/Type-use classifications
+// are counted in unclear rather than silently dropped, so a caller can see
+// the join left something unresolved instead of assuming full coverage.
+func BucketRoles(classifications []lifecycle.Classification) (reads, writes []Entry, unclear int) {
+	for _, c := range classifications {
+		if c.IsTestFile {
+			continue
+		}
+		e := Entry{Func: c.EnclosingName, File: c.FileRel, Line: c.Line, Role: c.Role}
+		switch c.Role {
+		case lifecycle.RoleRead:
+			reads = append(reads, e)
+		case lifecycle.RoleCreate, lifecycle.RoleMutate, lifecycle.RoleDelete:
+			writes = append(writes, e)
+		default:
+			unclear++
+		}
+	}
+	sortEntries(reads)
+	sortEntries(writes)
+	return reads, writes, unclear
+}
+
+func sortEntries(es []Entry) {
+	sort.Slice(es, func(i, j int) bool {
+		if es[i].File != es[j].File {
+			return es[i].File < es[j].File
+		}
+		if es[i].Line != es[j].Line {
+			return es[i].Line < es[j].Line
+		}
+		return es[i].Func < es[j].Func
+	})
+}

--- a/internal/datastoremap/datastoremap_test.go
+++ b/internal/datastoremap/datastoremap_test.go
@@ -1,0 +1,102 @@
+package datastoremap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dkoosis/snipe/internal/c4"
+	"github.com/dkoosis/snipe/internal/context"
+	"github.com/dkoosis/snipe/internal/lifecycle"
+)
+
+func TestFilterTestPackages(t *testing.T) {
+	in := []c4.Datastore{
+		{Name: "SQLite", Package: "example.com/repo/internal/store"},
+		{Name: "SQLite", Package: "example.com/repo/internal/query_test"},
+		{Name: "SQL", Package: "example.com/repo/internal/store"},
+	}
+	got := FilterTestPackages(in)
+	assert.Len(t, got, 2)
+	for _, d := range got {
+		assert.NotContains(t, d.Package, "_test")
+	}
+}
+
+func TestGroupByPackage_PrefersSpecificDriverOverGenericSQL(t *testing.T) {
+	in := []c4.Datastore{
+		{Name: "SQL", Package: "example.com/repo/internal/store", Driver: "database/sql"},
+		{Name: "SQLite", Package: "example.com/repo/internal/store", Driver: "modernc.org/sqlite"},
+	}
+	got := GroupByPackage(in)
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "SQLite", got[0].Name)
+	}
+}
+
+func TestGroupByPackage_DistinctPackagesKeepBothRows(t *testing.T) {
+	in := []c4.Datastore{
+		{Name: "SQLite", Package: "example.com/repo/internal/store"},
+		{Name: "Redis", Package: "example.com/repo/internal/cache"},
+	}
+	got := GroupByPackage(in)
+	assert.Len(t, got, 2)
+}
+
+func TestMatchSchema(t *testing.T) {
+	modulePath := "example.com/repo"
+	datastores := []c4.Datastore{
+		{Name: "SQLite", Package: "example.com/repo/internal/store"},
+	}
+
+	t.Run("directory match resolves the owning package", func(t *testing.T) {
+		schema := context.DBSchema{Source: "internal/store/schema.go", Name: "store"}
+		pkg, ok := MatchSchema(schema, datastores, modulePath)
+		assert.True(t, ok)
+		assert.Equal(t, "example.com/repo/internal/store", pkg)
+	})
+
+	t.Run("repo-root schema has no owning package", func(t *testing.T) {
+		schema := context.DBSchema{Source: "schema.sql", Name: "schema"}
+		_, ok := MatchSchema(schema, datastores, modulePath)
+		assert.False(t, ok)
+	})
+
+	t.Run("directory that matches no datastore package", func(t *testing.T) {
+		schema := context.DBSchema{Source: "migrations/0001_init.sql", Name: "migrations"}
+		_, ok := MatchSchema(schema, datastores, modulePath)
+		assert.False(t, ok)
+	})
+}
+
+func TestBucketRoles(t *testing.T) {
+	classifications := []lifecycle.Classification{
+		{EnclosingName: "LoadNug", FileRel: "store/read.go", Line: 10, Role: lifecycle.RoleRead},
+		{EnclosingName: "SaveNug", FileRel: "store/write.go", Line: 20, Role: lifecycle.RoleCreate},
+		{EnclosingName: "UpdateNug", FileRel: "store/write.go", Line: 30, Role: lifecycle.RoleMutate},
+		{EnclosingName: "DeleteNug", FileRel: "store/write.go", Line: 5, Role: lifecycle.RoleDelete},
+		{EnclosingName: "TestLoadNug", FileRel: "store/read_test.go", Line: 1, Role: lifecycle.RoleRead, IsTestFile: true},
+		{EnclosingName: "unrelated", FileRel: "store/misc.go", Line: 1, Role: lifecycle.RoleTypeUse},
+	}
+
+	reads, writes, unclear := BucketRoles(classifications)
+
+	assert.Len(t, reads, 1)
+	assert.Equal(t, "LoadNug", reads[0].Func)
+
+	if assert.Len(t, writes, 3) {
+		// sorted by file then line: write.go:5 (Delete), write.go:20 (Save), write.go:30 (Update)
+		assert.Equal(t, "DeleteNug", writes[0].Func)
+		assert.Equal(t, "SaveNug", writes[1].Func)
+		assert.Equal(t, "UpdateNug", writes[2].Func)
+	}
+
+	assert.Equal(t, 1, unclear)
+}
+
+func TestBucketRoles_Empty(t *testing.T) {
+	reads, writes, unclear := BucketRoles(nil)
+	assert.Empty(t, reads)
+	assert.Empty(t, writes)
+	assert.Equal(t, 0, unclear)
+}


### PR DESCRIPTION
## Summary

- Adds `snipe diagram datastore-map`: for each detected SQL datastore, renders its schema (from `internal/context.DetectDBSchemas`) plus a read-list and write-list of packages/functions, joining `internal/c4`'s datastore detection with `internal/lifecycle`'s CRUD role classification for direction. Writes `docs/diagrams/datastore-map.md` by default (`--format d2/svg` for stdout), following the `emitDoc` pattern from `diagram arch` (sn-l1kh.1).
- `internal/datastoremap` (new package) holds the pure join/bucketing logic — unit-tested without a database:
  - `FilterTestPackages` drops c4 rows from Go external test packages (`package foo_test`), which the raw c4 output otherwise reports as real touchpoints.
  - `GroupByPackage` collapses a package's generic `"SQL"` (`database/sql`) row into its specific driver row (`"SQLite"`, etc.) when both exist.
  - `MatchSchema` correlates a `DBSchema` to its owning c4 `Datastore` package by directory.
  - `BucketRoles` buckets `lifecycle.Classification` results into read/write lists, skipping test-file classifications.
- `cmd/datastoremap.go` does the DB-dependent half: for each datastore-owning package, finds its persistence-handle type by name (`Store`/`DB`/`Client`/`Repo`/...) and runs `lifecycle.Classify` against it. Deliberately does **not** fall back to classifying every exported type when no handle name matches — c4 flags any package importing bare `database/sql` as a datastore even when it only takes a `*sql.DB` parameter (e.g. a query-helper package), and classifying unrelated types there produced noise, not signal, found while smoke-testing against snipe's own repo.

## Test plan

- [x] `internal/datastoremap` unit tests (filter/group/match/bucket join logic)
- [x] `cmd` unit tests (`pickStoreTypes`, summary/diagram rendering)
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all green
- [x] `go test -race ./...` — all green
- [x] `go test -tags=blackbox ./test/blackbox/...` — all green
- [x] `govulncheck ./...` — 0 vulnerabilities in code paths
- [x] Manual smoke test: `snipe diagram datastore-map` against this repo's own index — correctly surfaces `internal/store` as the sole real datastore (schema + 90 reads / 2 writes), no test-package or false-positive-package noise
- [x] Help golden regenerated (`root.golden`, `diagram.golden`, new `diagram-datastore-map.golden`)

Closes: sn-l1kh.3