### PR TITLE
fix(c4): group datastore facts by driver technology, not per-importer

### DIFF
--- a/cmd/c4.go
+++ b/cmd/c4.go
@@ -97,7 +97,7 @@ func buildC4Response(s *store.Store, dir, level string, start time.Time) (output
 	}
 	for _, d := range facts.Datastores {
 		result.Datastores = append(result.Datastores, output.C4Datastore{
-			Name: d.Name, Driver: d.Driver, Package: d.Package, File: d.File, Line: d.Line,
+			Name: d.Name, Driver: d.Driver, Evidence: d.Evidence, File: d.File, Line: d.Line,
 		})
 	}
 	for _, e := range facts.External {
@@ -166,7 +166,8 @@ func writeC4Text(results []output.C4Result) error {
 		b.WriteString("\n## datastores\n")
 		writeC4Capped(&b, len(r.Datastores), func(i int) string {
 			d := r.Datastores[i]
-			return fmt.Sprintf("  %s | %s | %s | %s:%d\n", d.Name, d.Driver, d.Package, d.File, d.Line)
+			return fmt.Sprintf("  %s | %s | evidence: %s | %s:%d\n",
+				d.Name, d.Driver, strings.Join(d.Evidence, ", "), d.File, d.Line)
 		})
 	}
 

--- a/internal/c4/facts.go
+++ b/internal/c4/facts.go
@@ -56,13 +56,19 @@ type Container struct {
 	Line int
 }
 
-// Datastore is a package that imports a driver from the fixed allowlist.
+// Datastore is a driver technology detected via the fixed import allowlist,
+// grouped across every importing package — one row per distinct technology
+// (e.g. one "SQLite" row covering both modernc.org/sqlite and
+// mattn/go-sqlite3 importers), not one row per importer. Evidence lists the
+// distinct importing packages; File/Line is the deterministic earliest
+// evidence across the whole group (isEarlierEvidence), the same pick rule
+// mergeExternalSystems already uses for ExternalSystem.
 type Datastore struct {
-	Name    string // display name, e.g. "SQLite"
-	Driver  string // the matched import pkg_path
-	Package string // the importing package
-	File    string
-	Line    int
+	Name     string   // display name, e.g. "SQLite"
+	Driver   string   // representative matched import pkg_path
+	Evidence []string // importing package paths, sorted
+	File     string
+	Line     int
 }
 
 // ExternalSystem is a third-party service, detected via env-var literals
@@ -92,9 +98,10 @@ type Component struct {
 	Purpose string
 }
 
-// driverAllowlist maps a substring match against imports.pkg_path to a
-// display datastore name (design field's fixed allowlist). Order does not
-// matter: matches are independent, evaluated against every import row.
+// driverAllowlist maps a path-segment-anchored match (see
+// matchesDriverPath) against imports.pkg_path to a display datastore name
+// (design field's fixed allowlist). Order does not matter: matches are
+// independent, evaluated against every import row.
 var driverAllowlist = []struct{ match, name string }{
 	{"modernc.org/sqlite", "SQLite"},
 	{"mattn/go-sqlite3", "SQLite"},
@@ -104,6 +111,30 @@ var driverAllowlist = []struct{ match, name string }{
 	{"bbolt", "BoltDB"},
 	{"badger", "Badger"},
 	{"database/sql", "SQL"},
+}
+
+// matchesDriverPath reports whether pkgPath matches an allowlist entry,
+// anchored to a full path segment (or exact prefix) rather than raw
+// substring containment (CodeRabbit finding on PR #214, folded into
+// sn-igsn's grouping-key redesign): a bare strings.Contains would
+// misclassify a module merely containing an allowlisted word as one of its
+// path components — e.g. "github.com/acme/badgerlint" contains "badger" but
+// is not the Badger driver. match may be a single segment ("badger") or a
+// multi-segment suffix ("mattn/go-sqlite3"); pkgPath matches when match is
+// pkgPath itself, a leading path-segment prefix of it, a trailing
+// path-segment suffix of it, or a path-segment-bounded substring of it
+// (covers versioned subpackages like "github.com/jackc/pgx/v5").
+func matchesDriverPath(pkgPath, match string) bool {
+	if pkgPath == match {
+		return true
+	}
+	if strings.HasPrefix(pkgPath, match+"/") {
+		return true
+	}
+	if strings.HasSuffix(pkgPath, "/"+match) {
+		return true
+	}
+	return strings.Contains(pkgPath, "/"+match+"/")
 }
 
 // envSuffixRe matches the design field's external-system env-var predicate:
@@ -279,7 +310,11 @@ func moduleDisplayName(modulePath string) string {
 }
 
 // findDatastores scans the imports table for rows matching the fixed driver
-// allowlist, deduped by (display name, importing package).
+// allowlist, grouped by display name (technology) — one Datastore per
+// distinct technology, with every importing package folded into its Evidence
+// list rather than emitted as a repeat row (sn-igsn: per-importer output was
+// noisy relative to D4 and the C4-model's own semantics — a datastore is a
+// container-level element, not a per-caller fact).
 func findDatastores(db *sql.DB) ([]Datastore, error) {
 	rows, err := db.Query(`
 		SELECT file_path, pkg_path, COALESCE(importer_pkg,''), line
@@ -291,9 +326,14 @@ func findDatastores(db *sql.DB) ([]Datastore, error) {
 	}
 	defer rows.Close()
 
-	type key struct{ name, pkg string }
-	seen := make(map[key]bool)
-	var out []Datastore
+	type group struct {
+		driver    string // representative matched pkg_path (first encountered)
+		importers map[string]bool
+		file      string
+		line      int
+	}
+	groups := make(map[string]*group)
+	var order []string
 	for rows.Next() {
 		var file, pkgPath, importerPkg string
 		var line int
@@ -301,33 +341,45 @@ func findDatastores(db *sql.DB) ([]Datastore, error) {
 			return nil, fmt.Errorf("scan import: %w", err)
 		}
 		for _, d := range driverAllowlist {
-			if !strings.Contains(pkgPath, d.match) {
+			if !matchesDriverPath(pkgPath, d.match) {
 				continue
 			}
-			k := key{d.name, importerPkg}
-			if seen[k] {
-				break
+			g, ok := groups[d.name]
+			if !ok {
+				g = &group{driver: pkgPath, importers: make(map[string]bool)}
+				groups[d.name] = g
+				order = append(order, d.name)
 			}
-			seen[k] = true
-			out = append(out, Datastore{
-				Name:    d.name,
-				Driver:  pkgPath,
-				Package: importerPkg,
-				File:    file,
-				Line:    line,
-			})
+			if importerPkg != "" {
+				g.importers[importerPkg] = true
+			}
+			if isEarlierEvidence(file, line, g.file, g.line) {
+				g.file, g.line = file, line
+			}
 			break
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Name != out[j].Name {
-			return out[i].Name < out[j].Name
+
+	sort.Strings(order)
+	out := make([]Datastore, 0, len(order))
+	for _, name := range order {
+		g := groups[name]
+		evidence := make([]string, 0, len(g.importers))
+		for pkg := range g.importers {
+			evidence = append(evidence, pkg)
 		}
-		return out[i].Package < out[j].Package
-	})
+		sort.Strings(evidence)
+		out = append(out, Datastore{
+			Name:     name,
+			Driver:   g.driver,
+			Evidence: evidence,
+			File:     g.file,
+			Line:     g.line,
+		})
+	}
 	return out, nil
 }
 
@@ -503,7 +555,7 @@ func allTestFiles(files []string) bool {
 // allowlist — such imports are reported as datastores, not external systems.
 func isDriverMatch(pkgPath string) bool {
 	for _, d := range driverAllowlist {
-		if strings.Contains(pkgPath, d.match) {
+		if matchesDriverPath(pkgPath, d.match) {
 			return true
 		}
 	}
@@ -633,10 +685,12 @@ func isEarlierEvidence(file string, line int, bestFile string, bestLine int) boo
 func findFlows(db *sql.DB, datastores []Datastore, external []ExternalSystem) ([]Flow, error) {
 	var out []Flow
 	for _, d := range datastores {
-		if d.Package == "" {
-			continue
+		for _, pkg := range d.Evidence {
+			if pkg == "" {
+				continue
+			}
+			out = append(out, Flow{From: pkg, To: d.Name, Kind: "datastore", File: d.File, Line: d.Line})
 		}
-		out = append(out, Flow{From: d.Package, To: d.Name, Kind: "datastore", File: d.File, Line: d.Line})
 	}
 
 	importerByRoot, err := loadImporterPkgsByRoot(db)

--- a/internal/c4/facts_test.go
+++ b/internal/c4/facts_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/dkoosis/snipe/internal/c4"
@@ -99,8 +100,86 @@ func TestBuildFacts_Datastore(t *testing.T) {
 	if f.Datastores[0].Name != "SQLite" {
 		t.Errorf("want SQLite, got %q", f.Datastores[0].Name)
 	}
-	if f.Datastores[0].Package != testModule+"/internal/store" {
-		t.Errorf("want package %q, got %q", testModule+"/internal/store", f.Datastores[0].Package)
+	if len(f.Datastores[0].Evidence) != 1 || f.Datastores[0].Evidence[0] != testModule+"/internal/store" {
+		t.Errorf("want evidence [%q], got %v", testModule+"/internal/store", f.Datastores[0].Evidence)
+	}
+}
+
+// TestBuildFacts_Datastore_GroupsByTechnology is the sn-igsn regression: a
+// technology imported from multiple packages (or via multiple driver
+// packages that map to the same display name) must collapse into ONE
+// Datastore row with every importer folded into Evidence, not one row per
+// importer.
+func TestBuildFacts_Datastore_GroupsByTechnology(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/store/db.go"), "modernc.org/sqlite", testModule+"/internal/store", 3)
+	addImport(t, s.DB(), filepath.Join(dir, "cmd/root.go"), "modernc.org/sqlite", testModule+"/cmd", 7)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/query/q.go"), "database/sql", testModule+"/internal/query", 1)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/query/q_test.go"), "database/sql", testModule+"/internal/query_test", 2)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Datastores) != 2 {
+		t.Fatalf("want 2 datastore technologies (SQLite, SQL), got %d: %+v", len(f.Datastores), f.Datastores)
+	}
+
+	byName := make(map[string]c4.Datastore, len(f.Datastores))
+	for _, d := range f.Datastores {
+		byName[d.Name] = d
+	}
+
+	sqlite, ok := byName["SQLite"]
+	if !ok {
+		t.Fatalf("want a SQLite datastore, got %+v", f.Datastores)
+	}
+	wantSQLite := []string{testModule + "/cmd", testModule + "/internal/store"}
+	if !reflect.DeepEqual(sqlite.Evidence, wantSQLite) {
+		t.Errorf("want SQLite evidence %v (both importers, sorted), got %v", wantSQLite, sqlite.Evidence)
+	}
+
+	sqlRow, ok := byName["SQL"]
+	if !ok {
+		t.Fatalf("want a SQL datastore, got %+v", f.Datastores)
+	}
+	wantSQL := []string{testModule + "/internal/query", testModule + "/internal/query_test"}
+	if !reflect.DeepEqual(sqlRow.Evidence, wantSQL) {
+		t.Errorf("want SQL evidence %v (both importers, sorted), got %v", wantSQL, sqlRow.Evidence)
+	}
+}
+
+// TestBuildFacts_Datastore_AnchoredMatchExcludesLookalike is a regression
+// for the driverAllowlist's substring-match bug flagged on PR #214: a
+// strings.Contains match on "badger" would misclassify any module merely
+// containing that word as a path component (e.g. "badgerlint") as the
+// Badger driver. matchesDriverPath anchors to full path segments instead.
+func TestBuildFacts_Datastore_AnchoredMatchExcludesLookalike(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/lint/l.go"), "github.com/acme/badgerlint", testModule+"/internal/lint", 1)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Datastores) != 0 {
+		t.Errorf("want 0 datastores (badgerlint is not the Badger driver), got %+v", f.Datastores)
+	}
+}
+
+// TestBuildFacts_Datastore_AnchoredMatchIncludesVersionedSubpackage checks
+// the anchoring doesn't over-correct into false negatives: a real driver's
+// versioned subpackage (e.g. pgx/v5) must still match.
+func TestBuildFacts_Datastore_AnchoredMatchIncludesVersionedSubpackage(t *testing.T) {
+	s, dir := newC4TestRepo(t)
+	addImport(t, s.DB(), filepath.Join(dir, "internal/store/pg.go"), "github.com/jackc/pgx/v5", testModule+"/internal/store", 1)
+
+	f, err := c4.BuildFacts(s, dir, c4.LevelContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Datastores) != 1 || f.Datastores[0].Name != "PostgreSQL" {
+		t.Errorf("want 1 PostgreSQL datastore (pgx/v5 versioned subpackage), got %+v", f.Datastores)
 	}
 }
 

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -994,13 +994,15 @@ type C4Container struct {
 	Line int    `json:"line"`
 }
 
-// C4Datastore is a package that imports a driver from the fixed allowlist.
+// C4Datastore is a driver technology detected via the fixed import
+// allowlist, grouped across every importing package (one row per
+// technology, e.g. "SQLite" — not one row per importer).
 type C4Datastore struct {
-	Name    string `json:"name"`
-	Driver  string `json:"driver"`
-	Package string `json:"package"`
-	File    string `json:"file"`
-	Line    int    `json:"line"`
+	Name     string   `json:"name"`
+	Driver   string   `json:"driver"`
+	Evidence []string `json:"evidence"`
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
 }
 
 // C4ExternalSystem is a third-party service detected via env-var literals

--- a/test/blackbox/c4_test.go
+++ b/test/blackbox/c4_test.go
@@ -9,9 +9,10 @@ import (
 )
 
 // writeC4Fixture writes a repo shaped for the c4 command's three signal
-// kinds: a Go main entry point (container), a package importing a SQLite
-// driver (datastore), a package with a fake external SDK import plus an
-// os.Getenv env-var call (external system, per the design field's own
+// kinds: a Go main entry point (container), two packages importing the same
+// SQLite driver (datastore — sn-igsn: must group into ONE row, not one per
+// importer), a package with a fake external SDK import plus an os.Getenv
+// env-var call (external system, per the design field's own
 // stripe-go/STRIPE_API_KEY example), a package importing testify only
 // from a _test.go file (must NOT surface as external), and a package
 // importing an ordinary compile-time-only library with no env correlation
@@ -32,6 +33,16 @@ func main() {}
 import _ "modernc.org/sqlite"
 
 func Open() {}
+`)
+
+	// A second, distinct importer of the same driver technology: the c4
+	// command must fold this into the SAME "SQLite" datastore row rather than
+	// emit a second per-importer row.
+	writeFile(t, filepath.Join(repoDir, "internal/index/idx.go"), `package index
+
+import _ "modernc.org/sqlite"
+
+func Load() {}
 `)
 
 	writeFile(t, filepath.Join(repoDir, "billing/pay.go"), `package billing
@@ -105,14 +116,19 @@ func TestC4_ContainerLevel_JSON(t *testing.T) {
 		t.Errorf("want container name c4fixture, got %q", name)
 	}
 
-	// Datastore: SQLite via modernc.org/sqlite.
+	// Datastore: SQLite via modernc.org/sqlite, grouped into ONE row even
+	// though two distinct packages import it (sn-igsn).
 	datastores := requireSlice(t, r["datastores"], "datastores")
 	if len(datastores) != 1 {
-		t.Fatalf("want 1 datastore, got %d: %v", len(datastores), datastores)
+		t.Fatalf("want 1 datastore (grouped by technology), got %d: %v", len(datastores), datastores)
 	}
 	d := requireMap(t, datastores[0], "datastores[0]")
 	if name := getString(t, d["name"], "datastores[0].name"); name != "SQLite" {
 		t.Errorf("want datastore SQLite, got %q", name)
+	}
+	dsEvidence := requireSlice(t, d["evidence"], "datastores[0].evidence")
+	if len(dsEvidence) != 2 {
+		t.Errorf("want 2 evidence entries (both importing packages), got %d: %v", len(dsEvidence), dsEvidence)
 	}
 
 	// External: stripe-go import + STRIPE_API_KEY env merge into ONE system


### PR DESCRIPTION
## Summary
- \`snipe c4\`'s \`findDatastores\` grouped output per importer (e.g. 14 rows on snipe's own self-check), noisy relative to D4 and the C4-model's own semantics — a datastore is a container-level element, not a per-caller fact.
- \`Datastore\`/\`output.C4Datastore\` now group by display name (technology): one row per distinct driver (e.g. one "SQLite" row), with a sorted \`Evidence []string\` list of importing packages replacing the single \`Package\` field — same pattern \`mergeExternalSystems\` already uses for \`ExternalSystem\`.
- Also anchors \`driverAllowlist\` matching to a full path segment or exact prefix (new \`matchesDriverPath\` helper) instead of raw \`strings.Contains\`, per CodeRabbit's PR #214 finding — a bare substring match risks false positives (e.g. \`github.com/acme/badgerlint\` matching "badger"), which would have compounded once matches feed a grouping key instead of a per-row match.

## Test plan
- [x] \`internal/c4/facts_test.go\`: updated \`TestBuildFacts_Datastore\` for the \`Evidence\` shape; added \`TestBuildFacts_Datastore_GroupsByTechnology\` (multiple importers across two driver technologies collapse into two grouped rows), \`TestBuildFacts_Datastore_AnchoredMatchExcludesLookalike\`, \`TestBuildFacts_Datastore_AnchoredMatchIncludesVersionedSubpackage\`
- [x] \`test/blackbox/c4_test.go\`: fixture now has two SQLite importers; asserts one grouped row with 2 evidence entries
- [x] \`make audit\` green (vet, lint, test, race, blackbox, eval, vuln)

Closes: sn-igsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Datastore results are now grouped by technology, combining evidence from all importing packages.
  * Evidence entries are sorted for consistent output.
  * Driver detection now avoids lookalike matches while recognizing versioned driver paths.
  * Datastore flows are generated for each importing package.
* **Output Changes**
  * Datastore output now shows an evidence list instead of a single package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->