### PR TITLE
feat(diagram): system map — comprehension view of subsystems (sn-l1kh.2)

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -400,6 +400,7 @@ type DiagramCmd struct {
 	Lifecycle  DiagramLifecycleCmd  `cmd:"" help:"Render lifecycle CRUD groups for a type as D2"`
 	Seams      DiagramSeamsCmd      `cmd:"" help:"Rank pluggable interfaces by implementation count and fan-in. Writes docs/diagrams/seam-map.md by default (--format d2/svg for stdout)"`
 	Datastores DiagramDatastoresCmd `cmd:"" name:"datastore-map" help:"Datastore access map: schema + read/write packages per detected store. Writes docs/diagrams/datastore-map.md by default (--format d2/svg for stdout)"`
+	System     DiagramSystemCmd     `cmd:"" name:"system-map" help:"Comprehension view: packages collapsed into a handful of subsystems, only cross-subsystem edges shown. Writes docs/diagrams/system-map.md by default (--format d2/svg for stdout)"`
 }
 
 // AfterApply maps the global --format into the diagram package var. Unset
@@ -461,6 +462,15 @@ type DiagramDatastoresCmd struct{}
 
 func (c *DiagramDatastoresCmd) Run() error {
 	return runDiagramDatastores()
+}
+
+type DiagramSystemCmd struct {
+	Top int `default:"0" help:"Trim to top-N packages by PageRank before grouping (0 = no trim)"`
+}
+
+func (c *DiagramSystemCmd) Run() error {
+	systemMapTopN = c.Top
+	return runDiagramSystem()
 }
 
 type LifecycleCmd struct {

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -78,6 +78,7 @@ const (
 	diagramFill      = "fill"
 	diagramColorWarn = "#fde68a"
 	diagramTrue      = "true"
+	diagramBold      = "bold"
 )
 
 // Common error message strings.

--- a/cmd/datastoremap.go
+++ b/cmd/datastoremap.go
@@ -290,7 +290,7 @@ func renderDatastoreDiagram(stores []datastoremap.Store) *diagram.Builder {
 	for _, st := range stores {
 		storeID := diagram.SanitizeID(st.Name + "_" + st.Package)
 		storeNode := "store_" + storeID
-		b.AddNode(storeNode, st.Name, "cylinder", map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue})
+		b.AddNode(storeNode, st.Name, "cylinder", map[string]string{diagramFill: diagramColorWarn, diagramBold: diagramTrue})
 
 		if st.Package == "" {
 			continue

--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -263,7 +263,7 @@ func nodeStyleForRank(rank int) map[string]string {
 	case rank == 0:
 		return nil
 	case rank <= 3:
-		return map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue}
+		return map[string]string{diagramFill: diagramColorWarn, diagramBold: diagramTrue}
 	case rank <= 10:
 		return map[string]string{diagramFill: "#fef3c7"}
 	default:
@@ -419,7 +419,7 @@ func runDiagramFlow(args []string) error {
 		style := map[string]string{}
 		if id == root.ID {
 			style[diagramFill] = diagramColorWarn
-			style["bold"] = diagramTrue
+			style[diagramBold] = diagramTrue
 		}
 		if len(style) == 0 {
 			style = nil
@@ -689,7 +689,7 @@ func runDiagramLifecycle(args []string) error {
 
 	// Center node: the type.
 	typeNodeID := "type_" + diagram.SanitizeID(sym.Name)
-	b.AddNode(typeNodeID, sym.Name, "cylinder", map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue})
+	b.AddNode(typeNodeID, sym.Name, "cylinder", map[string]string{diagramFill: diagramColorWarn, diagramBold: diagramTrue})
 
 	// One container per role with role-specific tint.
 	roleColors := map[lifecycle.Role]string{

--- a/cmd/seammap.go
+++ b/cmd/seammap.go
@@ -196,7 +196,7 @@ func buildSeams(db *sql.DB) ([]Seam, error) {
 func seamNodeStyle(pos int) map[string]string {
 	switch {
 	case pos <= 3:
-		return map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue}
+		return map[string]string{diagramFill: diagramColorWarn, diagramBold: diagramTrue}
 	case pos <= 10:
 		return map[string]string{diagramFill: "#fef3c7"}
 	default:

--- a/cmd/systemmap.go
+++ b/cmd/systemmap.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dkoosis/snipe/internal/diagram"
+	"github.com/dkoosis/snipe/internal/graphmetrics"
+	"github.com/dkoosis/snipe/internal/output"
+)
+
+// systemMapTopN mirrors diagramArchTopN's role for `diagram system`: 0 means
+// no PageRank trim (the default — a comprehension view wants every package
+// accounted for somewhere, even if collapsed into a small subsystem).
+var systemMapTopN int
+
+// Subsystem names — the handful of "main parts of the system" that
+// subsystemOf buckets packages into. Named constants (not inline literals)
+// because each appears in both subsystemOf and its test table (goconst).
+const (
+	subsystemCLI          = "CLI"
+	subsystemRoot         = "Root"
+	subsystemIndexing     = "Indexing & Analysis"
+	subsystemPersistence  = "Persistence"
+	subsystemQuery        = "Query"
+	subsystemPresentation = "Presentation"
+	subsystemSupport      = "Support"
+)
+
+// ---------- system map ------------------------------------------------------
+//
+// sn-l1kh.2: a comprehension view answering "what are the main parts of this
+// system and how do they relate", distinct from `diagram arch` (a diagnostic
+// view of all packages flat, grouped only visually by layer container).
+// System map collapses each subsystem to a single node and collapses
+// intra-subsystem edges entirely — only cross-subsystem relationships are
+// drawn. Reuses arch's graph-loading path (LoadImportsGraph, TopNByPageRank,
+// filterGraph) rather than re-deriving package/edge data.
+
+func runDiagramSystem() error {
+	w := output.NewWriter(os.Stdout, GetOutputFormat())
+	s, _, err := OpenStore(w, "diagram system-map")
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	g, err := graphmetrics.LoadImportsGraph(s)
+	if err != nil {
+		return fmt.Errorf("load imports graph: %w", err)
+	}
+
+	keep, ranking, err := graphmetrics.TopNByPageRank(s, "imports", systemMapTopN)
+	if err != nil {
+		return err
+	}
+
+	pkgs, edges := filterGraph(g, keep)
+	module := stripLastSeg(pkgsCommonPrefix(pkgs))
+
+	groups, groupEdges := groupSystemMap(pkgs, edges, module)
+
+	var b diagram.Builder
+	b.Title = "snipe system map · subsystems"
+	b.Direction = "down"
+
+	for _, gr := range groups {
+		style := map[string]string{diagramFill: "#f5f5f5"}
+		if hasHighRank(gr.pkgs, ranking) {
+			style = map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue}
+		}
+		label := fmt.Sprintf("%s (%d)", gr.name, len(gr.pkgs))
+		b.AddNode(systemNodeID(gr.name), label, "", style)
+	}
+	for _, e := range groupEdges {
+		label := ""
+		if e.count > 1 {
+			label = fmt.Sprintf("%d", e.count)
+		}
+		b.AddEdge(systemNodeID(e.from), systemNodeID(e.to), label, nil)
+	}
+
+	sb := renderSystemMapSummary(groups, groupEdges, pkgs, edges, systemMapTopN, ranking, module)
+
+	return emitDoc("system-map", sb, b.Render())
+}
+
+// systemGroup is one collapsed subsystem: its display name and member
+// packages (full import paths, sorted).
+type systemGroup struct {
+	name string
+	pkgs []string
+}
+
+// groupEdge is a collapsed, deduplicated cross-subsystem relationship. count
+// is the number of underlying package-level edges it represents.
+type groupEdge struct {
+	from, to string
+	count    int
+}
+
+// groupSystemMap buckets pkgs into subsystems via subsystemOf, then collapses
+// edges: intra-subsystem edges are dropped entirely, cross-subsystem edges
+// are deduplicated into one groupEdge per (from,to) pair with a count of how
+// many package-level edges it summarizes. Groups and edges are returned in a
+// deterministic (sorted) order.
+func groupSystemMap(pkgs []string, edges [][2]string, module string) ([]systemGroup, []groupEdge) {
+	members := map[string][]string{}
+	pkgGroup := map[string]string{}
+	for _, p := range pkgs {
+		layer := layerOf(p, module)
+		name := subsystemOf(layer)
+		members[name] = append(members[name], p)
+		pkgGroup[p] = name
+	}
+
+	var groups []systemGroup
+	for name, ps := range members {
+		sort.Strings(ps)
+		groups = append(groups, systemGroup{name: name, pkgs: ps})
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].name < groups[j].name })
+
+	counts := map[[2]string]int{}
+	for _, e := range edges {
+		from, to := pkgGroup[e[0]], pkgGroup[e[1]]
+		if from == "" || to == "" || from == to {
+			continue
+		}
+		counts[[2]string{from, to}]++
+	}
+	var groupEdges []groupEdge
+	for k, c := range counts {
+		groupEdges = append(groupEdges, groupEdge{from: k[0], to: k[1], count: c})
+	}
+	sort.Slice(groupEdges, func(i, j int) bool {
+		if groupEdges[i].from != groupEdges[j].from {
+			return groupEdges[i].from < groupEdges[j].from
+		}
+		return groupEdges[i].to < groupEdges[j].to
+	})
+	return groups, groupEdges
+}
+
+// subsystemOf maps a package's arch layer (as computed by layerOf: "cmd",
+// "root", or "internal/<name>") to one of a handful of comprehension-level
+// "main parts of the system", grouped by naming convention. New internal
+// packages that don't match a known theme fall into "Support" rather than
+// growing the subsystem count — the map favors a stable, readable handful of
+// parts over exhaustively categorizing every package.
+func subsystemOf(layer string) string {
+	switch layer {
+	case "cmd":
+		return subsystemCLI
+	case "root":
+		return subsystemRoot
+	}
+	name := strings.TrimPrefix(layer, "internal/")
+	switch name {
+	case "index", "analyze", "gitchurn", "graphmetrics", "lifecycle":
+		return subsystemIndexing
+	case "store", "vector", "kg":
+		return subsystemPersistence
+	case "query", "search":
+		return subsystemQuery
+	case "diagram", "output", "c4":
+		return subsystemPresentation
+	default:
+		return subsystemSupport
+	}
+}
+
+// hasHighRank reports whether any package in a subsystem ranks in the top 3
+// by PageRank (rank == 0 means "no ranking data" — never highlight on that).
+func hasHighRank(pkgs []string, ranking map[string]int) bool {
+	for _, p := range pkgs {
+		if r, ok := ranking[p]; ok && r >= 1 && r <= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+func renderSystemMapSummary(groups []systemGroup, groupEdges []groupEdge, pkgs []string, edges [][2]string, topN int, ranking map[string]int, module string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "diagram system-map · %d packages collapsed into %d subsystems · %d cross-subsystem relationships (was %d package edges)",
+		len(pkgs), len(groups), len(groupEdges), len(edges))
+	if topN > 0 && len(ranking) > 0 {
+		fmt.Fprintf(&sb, " · trimmed to top-%d packages by PageRank", topN)
+	}
+	if module != "" {
+		fmt.Fprintf(&sb, " · module=%s", module)
+	}
+	sb.WriteString("\n\n")
+
+	for _, gr := range groups {
+		fmt.Fprintf(&sb, "%s (%d package%s)\n", gr.name, len(gr.pkgs), plural(len(gr.pkgs)))
+		for _, p := range gr.pkgs {
+			fmt.Fprintf(&sb, "  %s\n", shortPkg(p, module))
+		}
+	}
+
+	if len(groupEdges) > 0 {
+		sb.WriteString("\nrelationships:\n")
+		for _, e := range groupEdges {
+			fmt.Fprintf(&sb, "  %s -> %s (%d)\n", e.from, e.to, e.count)
+		}
+	}
+
+	return sb.String()
+}
+
+// systemNodeID derives a D2-safe node ID from a subsystem display name.
+// diagram.SanitizeID strips spaces/dots/quotes but not "&", which is a D2
+// operator character — left in place it produces an invalid unquoted
+// identifier (e.g. "Indexing_&_Analysis"). Subsystem names are short,
+// human-authored labels (not file paths), so replacing "&" with "and" before
+// sanitizing keeps IDs valid without touching the shared sanitizer.
+func systemNodeID(name string) string {
+	return diagram.SanitizeID(strings.ReplaceAll(name, "&", "and"))
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/cmd/systemmap.go
+++ b/cmd/systemmap.go
@@ -69,7 +69,7 @@ func runDiagramSystem() error {
 	for _, gr := range groups {
 		style := map[string]string{diagramFill: "#f5f5f5"}
 		if hasHighRank(gr.pkgs, ranking) {
-			style = map[string]string{diagramFill: diagramColorWarn, "bold": diagramTrue}
+			style = map[string]string{diagramFill: diagramColorWarn, diagramBold: diagramTrue}
 		}
 		label := fmt.Sprintf("%s (%d)", gr.name, len(gr.pkgs))
 		b.AddNode(systemNodeID(gr.name), label, "", style)

--- a/cmd/systemmap_test.go
+++ b/cmd/systemmap_test.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// sn-l1kh.2: subsystemOf must fold every current internal package into one
+// of a small, stable set of comprehension-level "parts of the system" — the
+// whole point of the system map is fewer groups than `diagram arch` shows
+// packages.
+func TestSubsystemOf(t *testing.T) {
+	tests := []struct {
+		layer string
+		want  string
+	}{
+		{"cmd", subsystemCLI},
+		{"root", subsystemRoot},
+		{"internal/index", subsystemIndexing},
+		{"internal/analyze", subsystemIndexing},
+		{"internal/gitchurn", subsystemIndexing},
+		{"internal/graphmetrics", subsystemIndexing},
+		{"internal/lifecycle", subsystemIndexing},
+		{"internal/store", subsystemPersistence},
+		{"internal/vector", subsystemPersistence},
+		{"internal/kg", subsystemPersistence},
+		{"internal/query", subsystemQuery},
+		{"internal/search", subsystemQuery},
+		{"internal/diagram", subsystemPresentation},
+		{"internal/output", subsystemPresentation},
+		{"internal/c4", subsystemPresentation},
+		{"internal/config", subsystemSupport},
+		{"internal/util", subsystemSupport},
+		{"internal/telemetry", subsystemSupport},
+		// Unknown/future package names must not grow the subsystem count —
+		// they fall into Support rather than becoming their own group.
+		{"internal/somethingnew", subsystemSupport},
+	}
+	for _, tt := range tests {
+		t.Run(tt.layer, func(t *testing.T) {
+			if got := subsystemOf(tt.layer); got != tt.want {
+				t.Errorf("subsystemOf(%q) = %q, want %q", tt.layer, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGroupSystemMap_CollapsesIntraGroupEdges is the acceptance case: two
+// packages in the same subsystem must produce zero group edges between them,
+// while an edge crossing subsystems must survive, deduplicated with a count.
+func TestGroupSystemMap_CollapsesIntraGroupEdges(t *testing.T) {
+	module := "example.com/mod"
+	pkgs := []string{
+		module + "/internal/store",
+		module + "/internal/vector",  // same subsystem as store (Persistence)
+		module + "/internal/query",   // different subsystem (Query)
+		module + "/internal/query/x", // layerOf collapses to internal/query too
+	}
+	edges := [][2]string{
+		{module + "/internal/store", module + "/internal/vector"},  // intra-group: dropped
+		{module + "/internal/query", module + "/internal/store"},   // cross-group: kept
+		{module + "/internal/query/x", module + "/internal/store"}, // cross-group: same pair, count=2
+	}
+
+	groups, groupEdges := groupSystemMap(pkgs, edges, module)
+
+	groupNames := map[string]int{}
+	for _, g := range groups {
+		groupNames[g.name] = len(g.pkgs)
+	}
+	if groupNames["Persistence"] != 2 {
+		t.Errorf("Persistence group = %d pkgs, want 2", groupNames["Persistence"])
+	}
+	if groupNames["Query"] != 2 {
+		t.Errorf("Query group = %d pkgs, want 2 (internal/query and internal/query/x collapse to one layer)", groupNames["Query"])
+	}
+
+	if len(groupEdges) != 1 {
+		t.Fatalf("got %d group edges, want 1 (intra-Persistence edge dropped, both Query->Persistence edges merged): %+v", len(groupEdges), groupEdges)
+	}
+	e := groupEdges[0]
+	if e.from != "Query" || e.to != "Persistence" {
+		t.Errorf("edge = %s -> %s, want Query -> Persistence", e.from, e.to)
+	}
+	if e.count != 2 {
+		t.Errorf("edge count = %d, want 2 (two underlying package edges collapsed)", e.count)
+	}
+}
+
+func TestGroupSystemMap_NoCrossGroupEdges(t *testing.T) {
+	module := "example.com/mod"
+	pkgs := []string{module + "/internal/store", module + "/internal/vector"}
+	edges := [][2]string{{module + "/internal/store", module + "/internal/vector"}}
+
+	groups, groupEdges := groupSystemMap(pkgs, edges, module)
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+	if len(groupEdges) != 0 {
+		t.Errorf("got %d group edges, want 0 (single subsystem, all edges intra-group): %+v", len(groupEdges), groupEdges)
+	}
+}
+
+// TestSystemNodeID_StripsAmpersand is a regression test: diagram.SanitizeID
+// doesn't strip "&" (only dots/slashes/spaces/quotes/parens), so a raw
+// subsystem name like "Indexing & Analysis" sanitized directly produces
+// "Indexing_&_Analysis" — an invalid unquoted D2 identifier that fails to
+// compile (`unexpected text after map key`). Caught via a manual smoke test
+// of `snipe diagram system-map` against snipe's own index.
+func TestSystemNodeID_StripsAmpersand(t *testing.T) {
+	got := systemNodeID(subsystemIndexing) // "Indexing & Analysis"
+	if strings.Contains(got, "&") {
+		t.Errorf("systemNodeID(%q) = %q, contains \"&\" (invalid D2 identifier)", subsystemIndexing, got)
+	}
+	want := "Indexing_and_Analysis"
+	if got != want {
+		t.Errorf("systemNodeID(%q) = %q, want %q", subsystemIndexing, got, want)
+	}
+}
+
+func TestHasHighRank(t *testing.T) {
+	ranking := map[string]int{"a": 1, "b": 5, "c": 3}
+	if !hasHighRank([]string{"x", "a"}, ranking) {
+		t.Error("want true: a ranks 1 (top-3)")
+	}
+	if hasHighRank([]string{"b"}, ranking) {
+		t.Error("want false: b ranks 5 (not top-3)")
+	}
+	if hasHighRank([]string{"unranked"}, ranking) {
+		t.Error("want false: unranked package (rank 0/absent) must never highlight")
+	}
+	if hasHighRank(nil, ranking) {
+		t.Error("want false: empty pkg list")
+	}
+}

--- a/cmd/testdata/help/diagram-system-map.golden
+++ b/cmd/testdata/help/diagram-system-map.golden
@@ -1,0 +1,25 @@
+Usage: snipe diagram system-map [flags]
+
+Comprehension view: packages collapsed into a handful of subsystems,
+only cross-subsystem edges shown. Writes docs/diagrams/system-map.md by default
+(--format d2/svg for stdout)
+
+Flags:
+  -h, --help                Show context-sensitive help.
+      --limit=10            Cap results returned (applied after --select)
+      --offset=0            Pagination offset
+      --context=2           Context lines around match
+      --no-body             Exclude function body
+      --no-siblings         Exclude sibling declarations
+      --signature-only      Return only signature (no body, no context)
+      --max-tokens=0        Token budget (0 = unlimited)
+      --format="concise"    concise (LLM default) | detailed | summary | json
+                            (stable, for tooling) | human (TTY)
+      --kg-hints            Include Orca KG hints
+      --no-suggestions      Suppress next-step suggestions in Claude output
+      --timeout=DURATION    Timeout for command (e.g., 30s, 5m)
+      --select="all"        Pick top candidates by score: all, best, top3,
+                            top5 (applied before --limit)
+
+      --top=0               Trim to top-N packages by PageRank before grouping
+                            (0 = no trim)

--- a/cmd/testdata/help/diagram.golden
+++ b/cmd/testdata/help/diagram.golden
@@ -32,7 +32,14 @@ Graph & Structure:
 
   diagram seams [flags]
     Rank pluggable interfaces by implementation count and fan-in. Writes
-    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)  diagram datastore-map
+    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)
+
+  diagram datastore-map
     Datastore access map: schema + read/write packages per detected store.
     Writes docs/diagrams/datastore-map.md by default (--format d2/svg for
     stdout)
+
+  diagram system-map [flags]
+    Comprehension view: packages collapsed into a handful of subsystems, only
+    cross-subsystem edges shown. Writes docs/diagrams/system-map.md by default
+    (--format d2/svg for stdout)

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -154,10 +154,18 @@ Graph & Structure:
 
   diagram seams [flags]
     Rank pluggable interfaces by implementation count and fan-in. Writes
-    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)  diagram datastore-map
+    docs/diagrams/seam-map.md by default (--format d2/svg for stdout)
+
+  diagram datastore-map
     Datastore access map: schema + read/write packages per detected store.
     Writes docs/diagrams/datastore-map.md by default (--format d2/svg for
     stdout)
+
+  diagram system-map [flags]
+    Comprehension view: packages collapsed into a handful of subsystems, only
+    cross-subsystem edges shown. Writes docs/diagrams/system-map.md by default
+    (--format d2/svg for stdout)
+
   lifecycle [<type>] [flags]
     Trace every function creating, mutating, reading, or deleting a type
 


### PR DESCRIPTION
## What

Adds `snipe diagram system-map`: a comprehension view answering "what are the main parts of this system and how do they relate", distinct from `diagram arch` (a diagnostic view of all packages flat).

It collapses packages into a handful of named subsystems — CLI, Indexing & Analysis, Persistence, Query, Presentation, Support — by naming convention over the existing arch layer grouping, drops intra-subsystem edges entirely, and draws only cross-subsystem relationships (deduplicated, with an edge count label). On snipe's own index: 34 packages → 7 subsystems, 76 package edges → 22 cross-subsystem relationships.

## How

- New logic lives in `cmd/systemmap.go` (kept out of `diagram.go` to minimize collision with sibling beads on the same base branch).
- Reuses arch's graph-loading path (`graphmetrics.LoadImportsGraph`, `TopNByPageRank`, `filterGraph`) rather than re-deriving package/edge data.
- Emits via the `emitDoc` pattern from sn-l1kh.1 — writes `docs/diagrams/system-map.md` (embedded SVG when `d2` is on PATH, D2 source underneath) by default; `--format d2/svg` dump to stdout.
- Only `cmd/commands.go` touched for the Kong wiring (new `system-map` subcommand + golden help regen).

## Bug found & fixed

`diagram.SanitizeID` strips spaces/dots/quotes but not `&`, so "Indexing & Analysis" sanitized directly produced the invalid unquoted D2 identifier `Indexing_&_Analysis` (fails to compile: `unexpected text after map key`). Added `systemNodeID`, which replaces `&`→`and` before sanitizing, plus a regression test. Caught via a manual smoke test of the command against snipe's own index.

## Tests

- Unit tests for the grouping logic: `subsystemOf` (all current packages bucket into the stable set; unknowns fall to Support), `groupSystemMap` (intra-group edges dropped, cross-group deduplicated with count), `hasHighRank`, and the `&`-sanitization regression.
- `make audit` gates green (vet, lint, unit, race, blackbox, govulncheck).

## Rebase note

Rebased onto current `origin/main` (past sibling PRs #219 seam-map and #222 datastore-map). The rebase surfaced a latent goconst issue — three PRs independently added a `"bold"` style literal, tipping the package over golangci-lint's `min-occurrences: 5` threshold that no single PR tripped in isolation. Fixed by extracting `diagramBold` into `cmd/constants.go` and pointing all six call sites at it (second commit).

Closes: sn-l1kh.2