### PR TITLE
feat(context): parse DDL into table/column structure + detect dir-backed stores (sn-l1kh.4)

### DIFF
--- a/internal/context/datastore.go
+++ b/internal/context/datastore.go
@@ -1,0 +1,180 @@
+package context
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DataStore is a detected directory-of-files data store: Go code that writes
+// structured documents (markdown, JSON, ...) into a directory, one file per
+// logical record, as opposed to a SQL database (DBSchema) or a single
+// fixed-name state file. It's a sibling to DBSchema rather than a unified
+// type — the shapes (DDL text vs. a directory + naming convention) don't
+// unify cleanly.
+type DataStore struct {
+	// Source is the repo-relative .go file the pattern was detected in.
+	Source string `json:"source" yaml:"source"`
+	// Dir is the expression that builds the directory path (e.g.
+	// `filepath.Join(root, "docs", "diagrams")`), for a human/Claude reading
+	// the detection rather than the raw source.
+	Dir string `json:"dir" yaml:"dir"`
+	// Pattern is the expression that builds each file's name inside Dir
+	// (e.g. `name+".md"`). A computed (non-literal) pattern is exactly the
+	// signal that Dir holds many differently-named files, not one fixed one.
+	Pattern string `json:"pattern" yaml:"pattern"`
+}
+
+// mkdirAllVarRe captures the directory variable passed to os.MkdirAll.
+var mkdirAllVarRe = regexp.MustCompile(`os\.MkdirAll\(\s*([A-Za-z_]\w*)\s*,`)
+
+// dirJoinAssignRe captures how a MkdirAll'd variable's directory path was
+// built, when it's a simple `dir := filepath.Join(...)` assignment — used
+// only to render a readable Dir field, not for detection itself.
+var dirJoinAssignRe = regexp.MustCompile(`([A-Za-z_]\w*)\s*:?=\s*filepath\.Join\(([^)]*)\)`)
+
+// pathJoinAssignRe captures `pathVar := filepath.Join(dirVar, filenameExpr)`
+// — the per-file path built from a MkdirAll'd directory plus a filename
+// expression.
+var pathJoinAssignRe = regexp.MustCompile(`(\w+)\s*:?=\s*filepath\.Join\(\s*(\w+)\s*,\s*([^,)]+)\)`)
+
+// writeFileVarRe captures the (bare identifier) path argument passed to
+// os.WriteFile.
+var writeFileVarRe = regexp.MustCompile(`os\.WriteFile\(\s*(\w+)\s*,`)
+
+// writeFileInlineJoinRe captures the inline form
+// os.WriteFile(filepath.Join(dirVar, filenameExpr), ...) where the path is
+// built directly in the call rather than via an intermediate variable.
+var writeFileInlineJoinRe = regexp.MustCompile(`os\.WriteFile\(\s*filepath\.Join\(\s*(\w+)\s*,\s*([^,)]+)\)`)
+
+// DetectDataStores scans .go files under repoRoot for the MkdirAll +
+// WriteFile idiom that signals a directory-of-documents store: a directory
+// created with os.MkdirAll, then written into via os.WriteFile at a path
+// whose filename component is computed (a variable, concatenation, etc.)
+// rather than a fixed string literal. A fixed literal filename (e.g.
+// "session.json") means the directory holds one file, not a collection —
+// that's a state file, not a data store, and is intentionally excluded.
+//
+// This is a static-text heuristic, not a data-flow analysis: it looks for
+// the idiom's textual shape within a single file rather than tracing
+// variables through calls or across files. It's proportionate to what a
+// "surface this as a candidate store" detector needs, not a guarantee.
+func DetectDataStores(repoRoot string) []DataStore {
+	var out []DataStore
+	_ = filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel := relPath(repoRoot, path)
+		out = append(out, detectDataStoresInSource(rel, string(content))...)
+		return nil
+	})
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		return out[i].Dir < out[j].Dir
+	})
+	return out
+}
+
+// detectDataStoresInSource applies the MkdirAll+WriteFile idiom to one
+// file's source text.
+func detectDataStoresInSource(source, src string) []DataStore {
+	mkdirVars := map[string]bool{}
+	for _, m := range mkdirAllVarRe.FindAllStringSubmatch(src, -1) {
+		mkdirVars[m[1]] = true
+	}
+	if len(mkdirVars) == 0 {
+		return nil
+	}
+
+	writeFileVars := map[string]bool{}
+	for _, m := range writeFileVarRe.FindAllStringSubmatch(src, -1) {
+		writeFileVars[m[1]] = true
+	}
+
+	var out []DataStore
+	seen := map[string]bool{}
+
+	// Indirect form: pathVar := filepath.Join(dirVar, filenameExpr), later
+	// passed to os.WriteFile(pathVar, ...).
+	for _, m := range pathJoinAssignRe.FindAllStringSubmatch(src, -1) {
+		pathVar, dirVar, filenameExpr := m[1], m[2], strings.TrimSpace(m[3])
+		if !mkdirVars[dirVar] || !writeFileVars[pathVar] || isQuotedLiteral(filenameExpr) {
+			continue
+		}
+		key := dirVar + "|" + filenameExpr
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, DataStore{
+			Source:  source,
+			Dir:     dirExprFor(src, dirVar),
+			Pattern: filenameExpr,
+		})
+	}
+
+	// Inline form: os.WriteFile(filepath.Join(dirVar, filenameExpr), ...).
+	for _, m := range writeFileInlineJoinRe.FindAllStringSubmatch(src, -1) {
+		dirVar, filenameExpr := m[1], strings.TrimSpace(m[2])
+		if !mkdirVars[dirVar] || isQuotedLiteral(filenameExpr) {
+			continue
+		}
+		key := dirVar + "|" + filenameExpr
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, DataStore{
+			Source:  source,
+			Dir:     dirExprFor(src, dirVar),
+			Pattern: filenameExpr,
+		})
+	}
+
+	return out
+}
+
+// isQuotedLiteral reports whether expr is nothing but a quoted string
+// literal (e.g. `"metrics.jsonl"`) — a fixed filename, not a computed one.
+func isQuotedLiteral(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	return len(expr) >= 2 && expr[0] == '"' && expr[len(expr)-1] == '"' && !strings.ContainsAny(expr[1:len(expr)-1], `"+`)
+}
+
+// dirExprFor renders a readable directory expression for dirVar: the
+// filepath.Join(...) call it was assigned from, if found, else the bare
+// variable name.
+func dirExprFor(src, dirVar string) string {
+	re := regexp.MustCompile(regexp.QuoteMeta(dirVar) + `\s*:?=\s*filepath\.Join\(([^)]*)\)`)
+	if m := re.FindStringSubmatch(src); m != nil {
+		return "filepath.Join(" + strings.TrimSpace(m[1]) + ")"
+	}
+	// Fall back to the general assignment matcher (handles some formatting
+	// variance dirJoinAssignRe alone might catch that the exact-var regex
+	// above misses).
+	for _, m := range dirJoinAssignRe.FindAllStringSubmatch(src, -1) {
+		if m[1] == dirVar {
+			return "filepath.Join(" + strings.TrimSpace(m[2]) + ")"
+		}
+	}
+	return dirVar
+}

--- a/internal/context/datastore_test.go
+++ b/internal/context/datastore_test.go
@@ -1,0 +1,61 @@
+package context
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectDataStores_NotesStore(t *testing.T) {
+	got := DetectDataStores("testdata/datastore/notes-store")
+	if len(got) != 1 {
+		t.Fatalf("want 1 data store, got %d: %+v", len(got), got)
+	}
+	s := got[0]
+	if !strings.HasSuffix(s.Source, "store.go") {
+		t.Errorf("source: want ends with store.go, got %q", s.Source)
+	}
+	if !strings.Contains(s.Dir, `"notes"`) {
+		t.Errorf("dir: want mention of notes dir, got %q", s.Dir)
+	}
+	if !strings.Contains(s.Pattern, "id") || !strings.Contains(s.Pattern, ".md") {
+		t.Errorf("pattern: want computed filename mentioning id + .md, got %q", s.Pattern)
+	}
+}
+
+func TestDetectDataStores_FixedFileOnly(t *testing.T) {
+	// A directory holding one fixed-name file (e.g. session.json) is a state
+	// file, not a data store — MkdirAll+WriteFile alone isn't the signal;
+	// a computed per-record filename is.
+	got := DetectDataStores("testdata/datastore/fixed-file-only")
+	if len(got) != 0 {
+		t.Fatalf("want 0 data stores for a fixed-filename store, got %d: %+v", len(got), got)
+	}
+}
+
+func TestDetectDataStores_None(t *testing.T) {
+	got := DetectDataStores("testdata/datastore/none")
+	if len(got) != 0 {
+		t.Fatalf("want 0 data stores, got %d: %+v", len(got), got)
+	}
+}
+
+func TestDetectDataStores_SnipeItself(t *testing.T) {
+	// snipe's own repo has one real hit: cmd/diagram.go's writeDiagramDocTo,
+	// which MkdirAlls docs/diagrams/ then writes <name>.md per diagram type
+	// (sn-l1kh.1) — a directory of documents, the exact pattern this
+	// detector targets.
+	got := DetectDataStores("../..")
+	var found bool
+	for _, s := range got {
+		if strings.Contains(s.Source, "cmd/diagram.go") {
+			found = true
+			if !strings.Contains(s.Dir, "diagrams") {
+				t.Errorf("dir: want mention of diagrams, got %q", s.Dir)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected to find cmd/diagram.go's docs/diagrams store; got: %+v", got)
+	}
+}

--- a/internal/context/schema_parse.go
+++ b/internal/context/schema_parse.go
@@ -1,0 +1,229 @@
+package context
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Column is a parsed SQL column: name and declared type. Constraints
+// (PRIMARY KEY, NOT NULL, DEFAULT, ...) are intentionally dropped — a future
+// "table X: columns a, b, c" render needs name+type, not full fidelity.
+type Column struct {
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
+}
+
+// Table is a parsed CREATE TABLE statement: its name and column list.
+type Table struct {
+	Name    string   `json:"name" yaml:"name"`
+	Columns []Column `json:"columns" yaml:"columns"`
+}
+
+// createTableRe finds each CREATE TABLE statement's start; everything after
+// the match is the table name followed by its column-list parens.
+var createTableRe = regexp.MustCompile(`(?i)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`)
+
+// tableConstraintRe matches a column-list entry that is a table-level
+// constraint rather than a column definition: PRIMARY KEY(...), FOREIGN
+// KEY(...), UNIQUE(...), CHECK(...), or a named CONSTRAINT.
+var tableConstraintRe = regexp.MustCompile(`(?i)^(PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE\s*\(|CHECK\s*\(|CONSTRAINT\b)`)
+
+// ParseSchema parses one or more CREATE TABLE statements out of ddl (as
+// produced by DetectDBSchemas) into a table -> columns structure. It is a
+// lightweight tokenizer over the common SQL subset (SQLite/Postgres/MySQL
+// CREATE TABLE), not a full SQL-dialect parser: CREATE INDEX/VIEW/TRIGGER
+// statements are ignored, and column types are captured verbatim up to the
+// first constraint keyword (name + type is enough for the intended render).
+func ParseSchema(ddl string) []Table {
+	var tables []Table
+	locs := createTableRe.FindAllStringIndex(ddl, -1)
+	for _, loc := range locs {
+		rest := ddl[loc[1]:]
+		name, afterName := readIdent(rest)
+		if name == "" {
+			continue
+		}
+		openIdx := strings.IndexByte(afterName, '(')
+		if openIdx < 0 {
+			continue
+		}
+		body, ok := matchParens(afterName[openIdx:])
+		if !ok {
+			continue
+		}
+		tables = append(tables, Table{
+			Name:    name,
+			Columns: parseColumns(body),
+		})
+	}
+	return tables
+}
+
+// parseColumns splits a CREATE TABLE column-list body on top-level commas
+// and extracts a name+type pair from each entry that is a column definition
+// (as opposed to a table-level constraint).
+func parseColumns(body string) []Column {
+	var cols []Column
+	for _, part := range splitTopLevel(body, ',') {
+		part = strings.TrimSpace(part)
+		if part == "" || tableConstraintRe.MatchString(part) {
+			continue
+		}
+		name, rest := readIdent(part)
+		if name == "" {
+			continue
+		}
+		typ := readType(rest)
+		if typ == "" {
+			continue
+		}
+		cols = append(cols, Column{Name: name, Type: typ})
+	}
+	return cols
+}
+
+// readIdent reads one identifier from the front of s, skipping leading
+// whitespace. Handles quoted identifiers (backtick, double-quote, bracket)
+// as well as bare word characters. Returns the identifier (unquoted) and
+// whatever remains of s after it.
+func readIdent(s string) (ident string, rest string) {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i++
+	}
+	if i >= len(s) {
+		return "", s
+	}
+	switch s[i] {
+	case '`':
+		if end := strings.IndexByte(s[i+1:], '`'); end >= 0 {
+			return s[i+1 : i+1+end], s[i+1+end+1:]
+		}
+		return "", s
+	case '"':
+		if end := strings.IndexByte(s[i+1:], '"'); end >= 0 {
+			return s[i+1 : i+1+end], s[i+1+end+1:]
+		}
+		return "", s
+	case '[':
+		if end := strings.IndexByte(s[i+1:], ']'); end >= 0 {
+			return s[i+1 : i+1+end], s[i+1+end+1:]
+		}
+		return "", s
+	}
+	j := i
+	for j < len(s) && isSchemaIdentByte(s[j]) {
+		j++
+	}
+	if j == i {
+		return "", s
+	}
+	return s[i:j], s[j:]
+}
+
+// isSchemaIdentByte reports whether c can appear in a bare SQL identifier as
+// read by readIdent. Includes '.' for schema-qualified table names
+// (schema.table), which the repo's general-purpose isIdentByte (roles.go)
+// doesn't need.
+func isSchemaIdentByte(c byte) bool {
+	return c == '_' || c == '.' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// readType reads a column's declared type from the front of s: the next
+// word, plus a following parenthesized precision/scale if present (e.g.
+// "VARCHAR(255)", "DECIMAL(10,2)"). Anything after that — NOT NULL, DEFAULT,
+// PRIMARY KEY, REFERENCES, etc. — is a constraint, not part of the type, and
+// is dropped.
+func readType(s string) string {
+	name, rest := readIdent(s)
+	if name == "" {
+		return ""
+	}
+	rest = strings.TrimLeft(rest, " \t\n\r")
+	if strings.HasPrefix(rest, "(") {
+		if inner, ok := matchParens(rest); ok {
+			return name + "(" + strings.TrimSpace(inner) + ")"
+		}
+	}
+	return name
+}
+
+// matchParens expects s to start with '(' and returns the content between it
+// and its matching close paren, honoring nested parens and single-quoted
+// string literals. Callers only need the inner content — none track where
+// the match ends — so unlike the exported matchers elsewhere in this
+// package, it has no "rest" return.
+func matchParens(s string) (inner string, ok bool) {
+	if len(s) == 0 || s[0] != '(' {
+		return "", false
+	}
+	depth := 0
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '\'':
+			j := i + 1
+			for j < len(s) {
+				if s[j] == '\'' {
+					if j+1 < len(s) && s[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			i = j
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[1:i], true
+			}
+		}
+		i++
+	}
+	return "", false
+}
+
+// splitTopLevel splits s on sep, ignoring occurrences inside nested parens or
+// single-quoted string literals.
+func splitTopLevel(s string, sep byte) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '\'':
+			j := i + 1
+			for j < len(s) {
+				if s[j] == '\'' {
+					if j+1 < len(s) && s[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			i = j
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if s[i] == sep && depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+		i++
+	}
+	parts = append(parts, s[start:])
+	return parts
+}

--- a/internal/context/schema_parse_test.go
+++ b/internal/context/schema_parse_test.go
@@ -1,0 +1,203 @@
+package context
+
+import "testing"
+
+func findTable(tables []Table, name string) (Table, bool) {
+	for _, t := range tables {
+		if t.Name == name {
+			return t, true
+		}
+	}
+	return Table{}, false
+}
+
+func findColumn(cols []Column, name string) (Column, bool) {
+	for _, c := range cols {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return Column{}, false
+}
+
+func TestParseSchema_Basic(t *testing.T) {
+	ddl := `
+CREATE TABLE IF NOT EXISTS users (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	email VARCHAR(255) NOT NULL,
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE posts (
+	id TEXT PRIMARY KEY,
+	user_id INTEGER NOT NULL,
+	body TEXT,
+	FOREIGN KEY (user_id) REFERENCES users(id)
+);
+`
+	tables := ParseSchema(ddl)
+	if len(tables) != 2 {
+		t.Fatalf("want 2 tables, got %d: %+v", len(tables), tables)
+	}
+
+	users, ok := findTable(tables, "users")
+	if !ok {
+		t.Fatalf("missing users table: %+v", tables)
+	}
+	if len(users.Columns) != 3 {
+		t.Fatalf("users: want 3 columns, got %d: %+v", len(users.Columns), users.Columns)
+	}
+	id, ok := findColumn(users.Columns, "id")
+	if !ok || id.Type != "INTEGER" {
+		t.Errorf("users.id: want type INTEGER, got %+v (found=%v)", id, ok)
+	}
+	email, ok := findColumn(users.Columns, "email")
+	if !ok || email.Type != "VARCHAR(255)" {
+		t.Errorf("users.email: want type VARCHAR(255), got %+v (found=%v)", email, ok)
+	}
+
+	posts, ok := findTable(tables, "posts")
+	if !ok {
+		t.Fatalf("missing posts table: %+v", tables)
+	}
+	// FOREIGN KEY line is a table-level constraint, not a column.
+	if len(posts.Columns) != 3 {
+		t.Errorf("posts: want 3 columns (FOREIGN KEY excluded), got %d: %+v", len(posts.Columns), posts.Columns)
+	}
+	if _, ok := findColumn(posts.Columns, "user_id"); !ok {
+		t.Errorf("posts: missing user_id column: %+v", posts.Columns)
+	}
+}
+
+func TestParseSchema_CompositePrimaryKeyExcluded(t *testing.T) {
+	ddl := `
+CREATE TABLE call_graph (
+	caller_id TEXT NOT NULL,
+	callee_id TEXT NOT NULL,
+	line INT NOT NULL,
+	col INT NOT NULL,
+	PRIMARY KEY (caller_id, callee_id, line, col),
+	FOREIGN KEY (caller_id) REFERENCES symbols(id),
+	FOREIGN KEY (callee_id) REFERENCES symbols(id)
+);
+`
+	tables := ParseSchema(ddl)
+	if len(tables) != 1 {
+		t.Fatalf("want 1 table, got %d: %+v", len(tables), tables)
+	}
+	cg := tables[0]
+	if len(cg.Columns) != 4 {
+		t.Fatalf("want 4 real columns (constraints excluded), got %d: %+v", len(cg.Columns), cg.Columns)
+	}
+	for _, want := range []string{"caller_id", "callee_id", "line", "col"} {
+		if _, ok := findColumn(cg.Columns, want); !ok {
+			t.Errorf("missing column %q: %+v", want, cg.Columns)
+		}
+	}
+}
+
+func TestParseSchema_IgnoresCreateIndex(t *testing.T) {
+	ddl := `
+CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT);
+CREATE INDEX idx_widgets_name ON widgets(name);
+CREATE UNIQUE INDEX idx_widgets_id ON widgets(id);
+`
+	tables := ParseSchema(ddl)
+	if len(tables) != 1 {
+		t.Fatalf("want 1 table (indexes ignored), got %d: %+v", len(tables), tables)
+	}
+	if tables[0].Name != "widgets" {
+		t.Errorf("want widgets, got %q", tables[0].Name)
+	}
+}
+
+func TestParseSchema_QuotedIdentifiers(t *testing.T) {
+	ddl := "CREATE TABLE `orders` (`id` TEXT PRIMARY KEY, `total` DECIMAL(10,2));"
+	tables := ParseSchema(ddl)
+	if len(tables) != 1 {
+		t.Fatalf("want 1 table, got %d: %+v", len(tables), tables)
+	}
+	if tables[0].Name != "orders" {
+		t.Errorf("want unquoted name 'orders', got %q", tables[0].Name)
+	}
+	total, ok := findColumn(tables[0].Columns, "total")
+	if !ok || total.Type != "DECIMAL(10,2)" {
+		t.Errorf("want total DECIMAL(10,2), got %+v (found=%v)", total, ok)
+	}
+}
+
+func TestParseSchema_Empty(t *testing.T) {
+	if got := ParseSchema(""); len(got) != 0 {
+		t.Errorf("want 0 tables for empty ddl, got %d", len(got))
+	}
+	if got := ParseSchema("-- just a comment, no DDL"); len(got) != 0 {
+		t.Errorf("want 0 tables for DDL-free input, got %d", len(got))
+	}
+}
+
+// TestParseSchema_RealSchema exercises ParseSchema end-to-end against
+// DetectDBSchemas' output for a real fixture (rather than a hand-written
+// DDL string), confirming the two functions compose the way a future
+// "table X: columns a, b, c" renderer would use them.
+func TestParseSchema_RealSchema(t *testing.T) {
+	schemas := DetectDBSchemas("testdata/dbschema/embedded-go")
+	if len(schemas) != 1 {
+		t.Fatalf("want 1 detected schema, got %d", len(schemas))
+	}
+	tables := ParseSchema(schemas[0].DDL)
+	symbols, ok := findTable(tables, "symbols")
+	if !ok {
+		t.Fatalf("missing symbols table from parsed DDL: %+v", tables)
+	}
+	if len(symbols.Columns) != 3 {
+		t.Fatalf("symbols: want 3 columns, got %d: %+v", len(symbols.Columns), symbols.Columns)
+	}
+	id, ok := findColumn(symbols.Columns, "id")
+	if !ok || id.Type != "TEXT" {
+		t.Errorf("symbols.id: want TEXT, got %+v (found=%v)", id, ok)
+	}
+}
+
+// TestParseSchema_SnipeItself parses snipe's own store schema (via
+// DetectDBSchemas on the real repo) and checks the symbols table's columns
+// come out structured, with FOREIGN KEY / composite PRIMARY KEY lines
+// correctly excluded from the column list.
+func TestParseSchema_SnipeItself(t *testing.T) {
+	schemas := DetectDBSchemas("../..")
+	var storeSchema *DBSchema
+	for i := range schemas {
+		if schemas[i].Name == "store" {
+			storeSchema = &schemas[i]
+			break
+		}
+	}
+	if storeSchema == nil {
+		t.Fatalf("expected a 'store' schema from snipe's own repo; got: %v", sources(schemas))
+	}
+
+	tables := ParseSchema(storeSchema.DDL)
+	symbols, ok := findTable(tables, "symbols")
+	if !ok {
+		t.Fatalf("missing symbols table: %+v", tables)
+	}
+	for _, want := range []string{"id", "name", "kind", "file_path"} {
+		if _, ok := findColumn(symbols.Columns, want); !ok {
+			t.Errorf("symbols: missing column %q: %+v", want, symbols.Columns)
+		}
+	}
+
+	callGraph, ok := findTable(tables, "call_graph")
+	if !ok {
+		t.Fatalf("missing call_graph table: %+v", tables)
+	}
+	for _, want := range []string{"caller_id", "callee_id", "file_path", "line", "col"} {
+		if _, ok := findColumn(callGraph.Columns, want); !ok {
+			t.Errorf("call_graph: missing column %q: %+v", want, callGraph.Columns)
+		}
+	}
+	// The composite PRIMARY KEY and two FOREIGN KEY lines are table-level
+	// constraints, not columns — exactly 5 real columns.
+	if len(callGraph.Columns) != 5 {
+		t.Errorf("call_graph: want 5 columns (constraints excluded), got %d: %+v", len(callGraph.Columns), callGraph.Columns)
+	}
+}

--- a/internal/context/testdata/datastore/fixed-file-only/session.go
+++ b/internal/context/testdata/datastore/fixed-file-only/session.go
@@ -1,0 +1,18 @@
+// Package sessionish is a fixture: a directory holding a single fixed-name
+// file — a state file, not a data store, and should NOT be detected.
+package sessionish
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Save writes one fixed-name file into a ".data" directory.
+func Save(root string, data []byte) error {
+	dir := filepath.Join(root, ".data")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "session.json")
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/context/testdata/datastore/none/main.go
+++ b/internal/context/testdata/datastore/none/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/internal/context/testdata/datastore/notes-store/store.go
+++ b/internal/context/testdata/datastore/notes-store/store.go
@@ -1,0 +1,18 @@
+// Package notes is a fixture: a directory-of-markdown-files store.
+package notes
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// SaveNote writes one note per id into a "notes" directory — a
+// directory-of-documents store, the pattern DetectDataStores looks for.
+func SaveNote(root, id string, body []byte) error {
+	dir := filepath.Join(root, "notes")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, id+".md")
+	return os.WriteFile(path, body, 0o644)
+}


### PR DESCRIPTION
## What

Extends the datastore map (sn-l1kh.4) with two additions on top of the existing `DetectDBSchemas` SQL detection. The SQL half was already done; this is the column-parse + non-SQL generalization the bead scoped.

### 1. `ParseSchema(ddl string) []Table` — structured DDL

Turns `DBSchema.DDL` (raw compacted CREATE TABLE text) into a `table -> [column]{name, type}` structure a future "table X: columns a, b, c" renderer can consume instead of dumping raw SQL.

- Lightweight tokenizer over CREATE TABLE statements — no new SQL-parser dependency (stdlib + regex only).
- Handles quoted identifiers (`` `orders` ``, `"col"`, `[col]`), parenthesized types (`VARCHAR(255)`, `DECIMAL(10,2)`), schema-qualified names.
- Excludes table-level constraints (PRIMARY KEY / FOREIGN KEY / UNIQUE / CHECK / CONSTRAINT) from the column list; ignores CREATE INDEX/VIEW/TRIGGER.
- Scope: name + type, not full-dialect fidelity — proportionate to the intended render.

### 2. `DetectDataStores(repoRoot) []DataStore` — dir/file-backed stores

A sibling detector to `DetectDBSchemas` for directory-of-documents stores: Go code that `os.MkdirAll`s a directory then `os.WriteFile`s into it at a **computed** (per-record) filename — markdown notes, JSON docs, etc.

- A fixed-name file (`session.json`) is a state file, not a store, and is excluded — the computed filename is the signal.
- `DataStore` is a sibling type, not a forced unification with `DBSchema` — DDL text and dir+naming-convention shapes don't unify cleanly.
- Static-text heuristic within a single file, not data-flow analysis — proportionate to "surface this as a candidate store".

## Tests

Unit tests for both, including real-repo assertions:
- `ParseSchema` against snipe's own `internal/store/schema.go` (symbols + call_graph columns, constraints excluded).
- `DetectDataStores` surfacing `cmd/diagram.go`'s `docs/diagrams/<name>.md` store (landed in sn-l1kh.1), plus fixture cases for the notes-store hit, the fixed-file-only miss, and the empty case.

`make audit` green (vet, lint 0 issues, test, race, blackbox, eval, vuln).

Closes: sn-l1kh.4
