### PR TITLE
fix(cli): un-garble --help epilogue + drop duplicate overview list

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,16 +68,13 @@ const rootHelp = `snipe: Go code navigation for Claude.
   snipe context            Claude-optimized orientation
   snipe context --full     Full architecture dump
 
-Pick the right overview command:
-  context   start here — project orientation (read first)
-  pack      deep dive on one symbol or package
-  sym       symbol-only (def+refs+callers+callees), no package context
-  explain   structured function walkthrough (LLM consumption)
-
-Typical flow:  context → pack <symbol> → callers/callees → tests <symbol>
-IDs chain:     every result's 'id' field is valid input to the next command
-Index:         all commands except 'search' need a built index — run 'snipe index' first
-Writes:        only 'edit' modifies files; all other commands are read-only`
+Notes:
+  Typical flow:  context → pack <symbol> → callers/callees → tests <symbol>
+  IDs chain:     every result's 'id' field is valid input to the next command
+  Index:         all commands except 'search' need a built index —
+                 run 'snipe index' first
+  Writes:        only 'edit' modifies files; all other commands are
+                 read-only`
 
 // Globals holds the persistent flags shared by every command. It is embedded
 // into the root CLI struct so the flags parse in any position, and its

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -13,17 +13,14 @@ snipe: Go code navigation for Claude.
     snipe context            Claude-optimized orientation
     snipe context --full     Full architecture dump
 
-Pick the right overview command:
+Notes:
 
-    context   start here — project orientation (read first)
-    pack      deep dive on one symbol or package
-    sym       symbol-only (def+refs+callers+callees), no package context
-    explain   structured function walkthrough (LLM consumption)
-
-Typical flow: context → pack <symbol> → callers/callees → tests <symbol> IDs
-chain: every result's 'id' field is valid input to the next command Index: all
-commands except 'search' need a built index — run 'snipe index' first Writes:
-only 'edit' modifies files; all other commands are read-only
+    Typical flow:  context → pack <symbol> → callers/callees → tests <symbol>
+    IDs chain:     every result's 'id' field is valid input to the next command
+    Index:         all commands except 'search' need a built index —
+                   run 'snipe index' first
+    Writes:        only 'edit' modifies files; all other commands are
+                   read-only
 
 Flags:
   -h, --help                Show context-sensitive help.


### PR DESCRIPTION
Fixes the run-on epilogue paragraph and removes the redundant overview list from `snipe --help`. Text-only (rootHelp const + its golden). make green.

Closes: sn-66mf