### PR TITLE
feat(cli): diagram flow/lifecycle default to docs/diagrams/*.md

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -396,8 +396,8 @@ type DiagramCmd struct {
 	// diagram reuses the global --format flag (d2 default, or svg). It cannot
 	// redeclare --format because the global flag is embedded on every command.
 	Arch       DiagramArchCmd       `cmd:"" help:"Package import graph trimmed to the top-N by PageRank, grouped by layer. Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)"`
-	Flow       DiagramFlowCmd       `cmd:"" help:"Depth-limited call graph from an entry symbol"`
-	Lifecycle  DiagramLifecycleCmd  `cmd:"" help:"Render lifecycle CRUD groups for a type as D2"`
+	Flow       DiagramFlowCmd       `cmd:"" help:"Depth-limited call graph from an entry symbol. Writes docs/diagrams/flow-<name>.md by default (--format d2/svg for stdout)"`
+	Lifecycle  DiagramLifecycleCmd  `cmd:"" help:"Render lifecycle CRUD groups for a type as D2. Writes docs/diagrams/lifecycle-<name>.md by default (--format d2/svg for stdout)"`
 	Seams      DiagramSeamsCmd      `cmd:"" help:"Rank pluggable interfaces by implementation count and fan-in. Writes docs/diagrams/seam-map.md by default (--format d2/svg for stdout)"`
 	Datastores DiagramDatastoresCmd `cmd:"" name:"datastore-map" help:"Datastore access map: schema + read/write packages per detected store. Writes docs/diagrams/datastore-map.md by default (--format d2/svg for stdout)"`
 	System     DiagramSystemCmd     `cmd:"" name:"system-map" help:"Comprehension view: packages collapsed into a handful of subsystems, only cross-subsystem edges shown. Writes docs/diagrams/system-map.md by default (--format d2/svg for stdout)"`

--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -440,7 +440,12 @@ func runDiagramFlow(args []string) error {
 	written := map[string]bool{}
 	walk(roots, edges, 0, diagramFlowDepth, syMap, &sb, written)
 
-	return emitDoc(fmt.Sprintf("flow-%s", diagram.SanitizeID(root.Name)), sb.String(), b.Render())
+	// Filename derives from the receiver-qualified label, not the bare name, so
+	// two same-named methods on different receivers ((*Foo).Process vs
+	// (*Bar).Process) produce distinct docs instead of silently clobbering each
+	// other (writeDiagramDocTo does an unconditional WriteFile). displayLabel is
+	// the same disambiguator used for node labels above.
+	return emitDoc(fmt.Sprintf("flow-%s", diagram.SanitizeID(displayLabel(&root))), sb.String(), b.Render())
 }
 
 // pickFlowEntry resolves a bare entry name to a single symbol suitable as a

--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -440,7 +440,7 @@ func runDiagramFlow(args []string) error {
 	written := map[string]bool{}
 	walk(roots, edges, 0, diagramFlowDepth, syMap, &sb, written)
 
-	return emit(sb.String(), b.Render())
+	return emitDoc(fmt.Sprintf("flow-%s", diagram.SanitizeID(root.Name)), sb.String(), b.Render())
 }
 
 // pickFlowEntry resolves a bare entry name to a single symbol suitable as a
@@ -757,7 +757,7 @@ func runDiagramLifecycle(args []string) error {
 		fmt.Fprintf(&sb, "  %s (%d)\n", role, len(fns))
 	}
 
-	return emit(sb.String(), b.Render())
+	return emitDoc(fmt.Sprintf("lifecycle-%s", diagram.SanitizeID(sym.Name)), sb.String(), b.Render())
 }
 
 // edgeFromType picks edge direction depending on role: Create/Mutate/Delete

--- a/cmd/diagram_test.go
+++ b/cmd/diagram_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dkoosis/snipe/internal/diagram"
 	"github.com/dkoosis/snipe/internal/query"
 )
 
@@ -209,5 +210,41 @@ func TestWriteDiagramDocTo_D2Available(t *testing.T) {
 	}
 	if strings.Contains(doc, "not rendered") {
 		t.Errorf("doc reports degrade despite fake d2 succeeding:\n%s", doc)
+	}
+}
+
+// sn-l1kh.8: runDiagramFlow/runDiagramLifecycle now route through emitDoc
+// (the same default-doc path arch/seams/datastore-map/system-map already
+// use), naming the doc "flow-<name>" / "lifecycle-<name>" with <name> run
+// through diagram.SanitizeID first. A qualified/dotted symbol name (as can
+// arrive from a CLI arg like "pkg/path.Symbol") must never survive
+// un-sanitized into that name — SanitizeID replaces both "." and "/" so the
+// result stays a single flat file under docs/diagrams/, never a
+// subdirectory.
+func TestWriteDiagramDocTo_QualifiedNameStaysFlat(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH", t.TempDir()) // d2 missing: irrelevant to this check
+
+	raw := "pkg/path.Symbol"
+	name := "lifecycle-" + diagram.SanitizeID(raw)
+
+	if err := writeDiagramDocTo(root, name, "diagram lifecycle · type=Symbol", "a -> b\n"); err != nil {
+		t.Fatalf("writeDiagramDocTo: %v", err)
+	}
+
+	diagramsDir := filepath.Join(root, "docs", "diagrams")
+	entries, err := os.ReadDir(diagramsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", diagramsDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("unexpected subdirectory %q under docs/diagrams/ from qualified name %q", e.Name(), raw)
+		}
+	}
+
+	wantPath := filepath.Join(diagramsDir, "lifecycle-pkg_path_Symbol.md")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("expected flat file %s: %v", wantPath, err)
 	}
 }

--- a/cmd/diagram_test.go
+++ b/cmd/diagram_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"sort"
@@ -246,5 +247,41 @@ func TestWriteDiagramDocTo_QualifiedNameStaysFlat(t *testing.T) {
 	wantPath := filepath.Join(diagramsDir, "lifecycle-pkg_path_Symbol.md")
 	if _, err := os.Stat(wantPath); err != nil {
 		t.Errorf("expected flat file %s: %v", wantPath, err)
+	}
+}
+
+// sn-l1kh.8: runDiagramFlow derives the doc filename from displayLabel (the
+// receiver-qualified name), not the bare symbol name. Two methods sharing a
+// name on different receivers ((*Foo).Process vs (*Bar).Process) must yield
+// distinct, non-colliding filenames — otherwise the second `snipe diagram flow
+// Process` run silently clobbers the first (writeDiagramDocTo does an
+// unconditional WriteFile). pickFlowEntry's tiered fallback still returns just
+// one root per run; this guards the filename derivation, not the selection.
+func TestDiagramFlow_FilenameDisambiguatesByReceiver(t *testing.T) {
+	mkRoot := func(recv string) query.SymbolRow {
+		return query.SymbolRow{
+			Name:     "Process",
+			Receiver: sql.NullString{String: recv, Valid: true},
+		}
+	}
+	foo := mkRoot("(*Foo)")
+	bar := mkRoot("(*Bar)")
+
+	nameFor := func(r query.SymbolRow) string {
+		return "flow-" + diagram.SanitizeID(displayLabel(&r))
+	}
+	fooName := nameFor(foo)
+	barName := nameFor(bar)
+
+	if fooName == barName {
+		t.Fatalf("filenames collide for distinct receivers: both %q", fooName)
+	}
+	// Bare name would have collided — confirm the qualifier actually landed.
+	bare := "flow-" + diagram.SanitizeID("Process")
+	if fooName == bare || barName == bare {
+		t.Errorf("filename fell back to bare name %q (foo=%q bar=%q)", bare, fooName, barName)
+	}
+	if strings.ContainsAny(fooName, "./") || strings.ContainsAny(barName, "./") {
+		t.Errorf("sanitized filename still contains path separators: foo=%q bar=%q", fooName, barName)
 	}
 }

--- a/cmd/testdata/help/diagram-flow.golden
+++ b/cmd/testdata/help/diagram-flow.golden
@@ -1,6 +1,7 @@
 Usage: snipe diagram flow <entry> [flags]
 
-Depth-limited call graph from an entry symbol
+Depth-limited call graph from an entry symbol. Writes
+docs/diagrams/flow-<name>.md by default (--format d2/svg for stdout)
 
 Arguments:
   <entry>    Entry symbol

--- a/cmd/testdata/help/diagram-lifecycle.golden
+++ b/cmd/testdata/help/diagram-lifecycle.golden
@@ -1,6 +1,7 @@
 Usage: snipe diagram lifecycle <type>
 
-Render lifecycle CRUD groups for a type as D2
+Render lifecycle CRUD groups for a type as D2. Writes
+docs/diagrams/lifecycle-<name>.md by default (--format d2/svg for stdout)
 
 Arguments:
   <type>    Type name

--- a/cmd/testdata/help/diagram.golden
+++ b/cmd/testdata/help/diagram.golden
@@ -25,10 +25,12 @@ Graph & Structure:
     Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)
 
   diagram flow <entry> [flags]
-    Depth-limited call graph from an entry symbol
+    Depth-limited call graph from an entry symbol. Writes
+    docs/diagrams/flow-<name>.md by default (--format d2/svg for stdout)
 
   diagram lifecycle <type>
-    Render lifecycle CRUD groups for a type as D2
+    Render lifecycle CRUD groups for a type as D2. Writes
+    docs/diagrams/lifecycle-<name>.md by default (--format d2/svg for stdout)
 
   diagram seams [flags]
     Rank pluggable interfaces by implementation count and fan-in. Writes

--- a/cmd/testdata/help/root.golden
+++ b/cmd/testdata/help/root.golden
@@ -147,10 +147,12 @@ Graph & Structure:
     Writes docs/diagrams/arch.md by default (--format d2/svg for stdout)
 
   diagram flow <entry> [flags]
-    Depth-limited call graph from an entry symbol
+    Depth-limited call graph from an entry symbol. Writes
+    docs/diagrams/flow-<name>.md by default (--format d2/svg for stdout)
 
   diagram lifecycle <type>
-    Render lifecycle CRUD groups for a type as D2
+    Render lifecycle CRUD groups for a type as D2. Writes
+    docs/diagrams/lifecycle-<name>.md by default (--format d2/svg for stdout)
 
   diagram seams [flags]
     Rank pluggable interfaces by implementation count and fan-in. Writes

--- a/test/blackbox/behavioral_golden_test.go
+++ b/test/blackbox/behavioral_golden_test.go
@@ -3,6 +3,9 @@
 package blackbox
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -220,7 +223,12 @@ func TestGolden_Diagram_Flow(t *testing.T) {
 	initGitRepo(t, repoDir)
 	indexRepo(t, repoDir)
 
-	stdout, _, exitCode := runRaw(t, repoDir, "diagram", "flow", "CallMany")
+	// sn-l1kh.8: the truly-unset default now writes
+	// docs/diagrams/flow-<name>.md instead of printing D2 to stdout (see
+	// TestGolden_Diagram_Flow_DefaultWritesDoc below for that path).
+	// --format d2 keeps the explicit-opt-in stdout dump this golden checks
+	// byte-for-byte.
+	stdout, _, exitCode := runRaw(t, repoDir, "diagram", "flow", "CallMany", "--format", "d2")
 	if exitCode != 0 {
 		t.Fatalf("exit %d", exitCode)
 	}
@@ -232,9 +240,109 @@ func TestGolden_Diagram_Lifecycle(t *testing.T) {
 	initGitRepo(t, repoDir)
 	indexRepo(t, repoDir)
 
-	stdout, _, exitCode := runRaw(t, repoDir, "diagram", "lifecycle", "Widget")
+	// sn-l1kh.8: the truly-unset default now writes
+	// docs/diagrams/lifecycle-<name>.md instead of printing D2 to stdout (see
+	// TestGolden_Diagram_Lifecycle_DefaultWritesDoc and
+	// TestGolden_Diagram_Lifecycle_QualifiedNameUsesResolvedSymbol below for
+	// that path). --format d2 keeps the explicit-opt-in stdout dump this
+	// golden checks byte-for-byte.
+	stdout, _, exitCode := runRaw(t, repoDir, "diagram", "lifecycle", "Widget", "--format", "d2")
 	if exitCode != 0 {
 		t.Fatalf("exit %d", exitCode)
 	}
 	assertGoldenDiagram(t, repoDir, stdout)
+}
+
+// TestGolden_Diagram_Flow_DefaultWritesDoc pins the new emitDoc default path
+// (sn-l1kh.8): no --format ⇒ docs/diagrams/flow-<entry>.md on disk, nothing
+// on stdout, mirroring arch's default (sn-l1kh.1).
+func TestGolden_Diagram_Flow_DefaultWritesDoc(t *testing.T) {
+	repoDir, _ := writeFixture(t)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := runRaw(t, repoDir, "diagram", "flow", "CallMany")
+	if exitCode != 0 {
+		t.Fatalf("exit %d stderr=%s", exitCode, string(stderr))
+	}
+	// Default format writes the doc to disk and prints only a "wrote <path>"
+	// confirmation — never the D2 source itself.
+	if strings.Contains(string(stdout), "```d2") {
+		t.Errorf("default format must not dump D2 to stdout; got %q", string(stdout))
+	}
+
+	docPath := filepath.Join(repoDir, "docs", "diagrams", "flow-CallMany.md")
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	for _, want := range []string{"diagram flow · entry=CallMany", "```d2"} {
+		if !strings.Contains(string(doc), want) {
+			t.Errorf("doc missing %q:\n%s", want, doc)
+		}
+	}
+}
+
+// TestGolden_Diagram_Lifecycle_DefaultWritesDoc mirrors the flow case above
+// for `diagram lifecycle` (sn-l1kh.8).
+func TestGolden_Diagram_Lifecycle_DefaultWritesDoc(t *testing.T) {
+	repoDir := writeLifecycleFixture(t)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	stdout, stderr, exitCode := runRaw(t, repoDir, "diagram", "lifecycle", "Widget")
+	if exitCode != 0 {
+		t.Fatalf("exit %d stderr=%s", exitCode, string(stderr))
+	}
+	// Default format writes the doc to disk and prints only a "wrote <path>"
+	// confirmation — never the D2 source itself.
+	if strings.Contains(string(stdout), "```d2") {
+		t.Errorf("default format must not dump D2 to stdout; got %q", string(stdout))
+	}
+
+	docPath := filepath.Join(repoDir, "docs", "diagrams", "lifecycle-Widget.md")
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	for _, want := range []string{"diagram lifecycle · type=Widget", "```d2"} {
+		if !strings.Contains(string(doc), want) {
+			t.Errorf("doc missing %q:\n%s", want, doc)
+		}
+	}
+}
+
+// TestGolden_Diagram_Lifecycle_QualifiedNameUsesResolvedSymbol is the
+// qualified-name-safety acceptance case (sn-l1kh.8 plan step 2):
+// runDiagramLifecycle must name the doc from the RESOLVED sym.Name ("Widget"),
+// not the raw qualified CLI arg ("example.com/lifecyclefix/store.Widget"),
+// which contains "/" and "." — both sanitized to "_" by diagram.SanitizeID,
+// but the resolved name is the canonical, predictable filename and the only
+// value that keeps repeated flow/lifecycle diagrams for the same symbol
+// landing on the same doc regardless of how the caller spelled the query.
+func TestGolden_Diagram_Lifecycle_QualifiedNameUsesResolvedSymbol(t *testing.T) {
+	repoDir := writeLifecycleFixture(t)
+	initGitRepo(t, repoDir)
+	indexRepo(t, repoDir)
+
+	_, stderr, exitCode := runRaw(t, repoDir, "diagram", "lifecycle", "example.com/lifecyclefix/store.Widget")
+	if exitCode != 0 {
+		t.Fatalf("exit %d stderr=%s", exitCode, string(stderr))
+	}
+
+	diagramsDir := filepath.Join(repoDir, "docs", "diagrams")
+	docPath := filepath.Join(diagramsDir, "lifecycle-Widget.md")
+	if _, err := os.Stat(docPath); err != nil {
+		t.Fatalf("expected resolved-name doc %s: %v", docPath, err)
+	}
+
+	entries, err := os.ReadDir(diagramsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", diagramsDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("unexpected subdirectory %q under docs/diagrams/ (qualified CLI arg must not leak into the path)", e.Name())
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Wires `diagram flow` and `diagram lifecycle` onto the existing `emitDoc` helper — the same docs/diagrams/*.md default already shipped for arch/seams/datastore-map/system-map (sn-l1kh.1). No `--format` flag now writes `docs/diagrams/flow-<entry>.md` and `docs/diagrams/lifecycle-<type>.md` (embedded SVG + fenced D2 source); `--format d2/svg` behavior is unchanged.

Scope narrowed during P-priorart: the epic's original description covered arch/flow/lifecycle + all comprehension commands, but arch/seams/datastore-map/system-map already shipped this under sn-l1kh.1-.6. Only flow and lifecycle were missing.

Review caught and fixed one real bug before merge: flow's doc filename used the bare symbol name, so two different receivers with the same method name would silently overwrite each other's doc. Fixed by deriving the filename from the receiver-qualified `displayLabel`, matching the guard lifecycle already had.

Audit trail: `~/Projects/dk/Project/snipe/plans/sn-l1kh.8-diagram-default-output.md` + `reviews/sn-l1kh.8-*`

## Commits

- `08a5b63` — wire flow/lifecycle to emitDoc
- `61e9903` — fix flow filename collision (receiver-qualified)

## Test plan

- [x] make audit green (vet, lint, unit, race, blackbox, govulncheck)
- [x] new blackbox test: qualified type name in lifecycle → flat filename, no subdirectory
- [x] new unit test: two same-named methods on different receivers → distinct flow filenames
- [x] golden help fixtures regenerated

Closes: sn-l1kh.8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagram flow and lifecycle commands now save Markdown documentation under `docs/diagrams` by default.
  * Added support for `--format d2` and `--format svg` output to stdout.
  * Diagram filenames now distinguish methods with the same name across different receivers.

* **Documentation**
  * Updated command help text with default file locations and supported output formats.

* **Bug Fixes**
  * Prevented qualified diagram names from creating nested or conflicting file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->