### PR TITLE
test(telemetry): guard WriteResponse session_key propagation

### DIFF
--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -1,0 +1,58 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dkoosis/snipe/internal/telemetry"
+)
+
+// TestWriteResponse_EmitsSessionKey guards the shared WriteResponse -> Emit
+// path (internal/output/json.go) every Response[Result] consumer goes
+// through, including def (sn-yhl4). Investigation found no live defect —
+// every def code path calls OpenStore, which calls telemetry.SetSessionKey,
+// before any WriteResponse/WriteErrorWithMeta call that could emit a row —
+// but the mechanism itself had no direct test. This closes that gap.
+func TestWriteResponse_EmitsSessionKey(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".snipe"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	telemetry.SetRoot(root)
+	telemetry.SetSessionKey("sess-abc")
+	t.Cleanup(func() {
+		telemetry.SetRoot("")
+		telemetry.SetSessionKey("")
+	})
+
+	resp := Response[Result]{
+		Protocol: ProtocolVersion,
+		Ok:       true,
+		Results: []Result{
+			{ID: "abc123", File: "main.go", Kind: "func", Name: "main"},
+		},
+		Meta: Meta{
+			Command:    "def",
+			IndexState: IndexFresh,
+			Total:      1,
+		},
+	}
+
+	w := NewWriter(&strings.Builder{}, OutputClaude)
+	if err := w.WriteResponse(resp); err != nil {
+		t.Fatalf("WriteResponse: %v", err)
+	}
+
+	recs, err := telemetry.ReadAll(root)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d usage.jsonl rows, want 1", len(recs))
+	}
+	if recs[0].SessionKey != "sess-abc" {
+		t.Errorf("SessionKey = %q, want %q", recs[0].SessionKey, "sess-abc")
+	}
+}


### PR DESCRIPTION
## Summary

Investigated sn-yhl4 (def command's usage.jsonl rows reported with empty session_key). Found no live defect — empirically reproduced every `def` invocation shape (plain symbol, `--at`, `--file`, `--pkg`, with/without `CLAUDE_CODE_SESSION_ID`) and all populate session_key correctly. Static trace confirms all three of def's entry paths call `OpenStore` (which sets the session key) before any telemetry-emitting response.

Likely explanation for the original report: `SetSessionKey` shipped 2026-08-01 11:42 (#221), and sn-yhl4 was filed 2026-08-02 03:42 from a manual sample of an existing `usage.jsonl` — plausibly stale `def` rows predating the feature, mixed with newer rows from other commands.

Adds a regression test proving the shared `WriteResponse` → `telemetry.Emit` path (which every command, including `def`, goes through) populates session_key — verified meaningful by temporarily blanking `SessionKey` in `Emit` and confirming the test fails.

## Test plan

- [x] `make audit` green
- [x] New test `TestWriteResponse_EmitsSessionKey` fails when session_key propagation is broken (manually verified), passes on current code
- [x] Independent plan-adherence review: 0 findings

Closes: sn-yhl4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming successful responses emit exactly one telemetry record with the configured session key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->