### PR TITLE
ci: add -race gate (ccp-sbp.4)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,38 @@
+name: check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          # Keep in lockstep with the `go` directive in go.mod.
+          go-version: '1.26'
+          check-latest: true
+
+      - name: vet
+        run: go vet ./...
+
+      # The -race gate (epic ccp-sbp.4): the race detector is the machine that
+      # catches the concurrency-lifecycle defect class. -count=1 bypasses the
+      # test cache so race runs on every push.
+      - name: test (race)
+        run: go test -race -count=1 ./...
+
+      - name: build
+        run: go build ./...


### PR DESCRIPTION
## What

Adds a `check` CI workflow running `go test -race -count=1 ./...` on every PR and push to main.

## Why

The 9-repo bug-class scan (2026-08-04, decision nug `d7ea466a8172`, epic `ccp-sbp.4`) found concurrency-lifecycle defects as a recurring, race-detector-catchable class. This repo had **no CI test gate** — race ran only in local `make audit`. This closes the gap.

## Notes

- **Review-only — do not merge without a maintainer pass.** Minimal, focused on the `-race` gap only (goleak/synctest wiring is per-repo judgment, documented separately).
- CI will validate whether the suite currently passes under `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated checks for code quality, testing, race detection, and build validation.
  - Checks run for pull requests and updates to the main branch.
  - Added safeguards to prevent outdated runs from continuing unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->