### PR TITLE
fix(kg): kill orca subprocess process group on ctx cancel (sn-nw0m)

### DIFF
--- a/internal/kg/hints.go
+++ b/internal/kg/hints.go
@@ -87,6 +87,15 @@ func queryOrcaHints(ctx context.Context, orcaPath string, env []string, query st
 	cmd := exec.CommandContext(callCtx, orcaPath, "search_nugs", "--query", query, "--limit", "3", "--format", "oneline")
 	cmd.Env = env
 
+	// A bare exec.CommandContext only kills the direct child on ctx cancel —
+	// if orca (or a test shim) is itself a shell that spawns rather than
+	// exec's into its real work, the child survives and GetHints blocks
+	// until it exits on its own. Kill the whole process group instead, with
+	// WaitDelay as a backstop if even that doesn't land in time (sn-nw0m).
+	setProcGroup(cmd)
+	cmd.Cancel = func() error { return killProcGroup(cmd) }
+	cmd.WaitDelay = orcaQueryTimeout
+
 	output, err := cmd.Output()
 	if err != nil {
 		return nil

--- a/internal/kg/procgroup_unix.go
+++ b/internal/kg/procgroup_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package kg
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+// setProcGroup puts cmd in its own process group, so killProcGroup can reach
+// any children it forks (a shell shim that execs a long-running child, e.g.)
+// instead of only the direct child exec.CommandContext started.
+func setProcGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcGroup sends SIGKILL to cmd's whole process group. A bare
+// cmd.Process.Kill() only reaches the direct child; if that child is a shell
+// that spawned (rather than exec'd into) a hung grandchild, the grandchild
+// survives the kill and GetHints blocks until the grandchild exits on its
+// own — observed in CI as TestGetHints_HonorsContextCancel running the full
+// orca shim's 60s sleep instead of honoring ctx cancel (sn-nw0m).
+func killProcGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil // group already gone
+	}
+	return err
+}

--- a/internal/kg/procgroup_windows.go
+++ b/internal/kg/procgroup_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package kg
+
+import "os/exec"
+
+// setProcGroup is a no-op on Windows — process groups are POSIX-specific;
+// the orca subprocess this guards against (a hanging shell shim) is a
+// POSIX-only test fixture (see hints_test.go's windows skip).
+func setProcGroup(_ *exec.Cmd) {}
+
+// killProcGroup falls back to killing just the direct child, matching
+// exec.CommandContext's own default Cancel behavior.
+func killProcGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}


### PR DESCRIPTION
Fixes the CI-only `internal/kg` flake blocking `main` (sn-nw0m) — first exposed by the new -race check workflow (#231), unrelated to #234.

**Root cause:** `exec.CommandContext`'s default `Cancel` only kills the direct child. The test's fake orca shim is a shell script (`#!/bin/sh\nsleep 60`) — if the shell forks rather than exec's into the sleep, the grandchild survives `Kill()` and `GetHints` blocks until it exits naturally. CI showed exactly the sleep's full 60s elapsing instead of honoring ctx cancel at 50ms.

**Fix:** run the orca subprocess in its own process group (`Setpgid`) and kill the whole group on cancel, with `WaitDelay` as a backstop. Windows has no process groups — falls back to the prior single-`Kill()` behavior (the hung-shim scenario is a POSIX-only test fixture; `hints_test.go` already skips windows for it).

Couldn't reproduce the CI-only failure locally (passes there before and after), so this closes the specific gap the CI failure log points at rather than a directly-reproduced root cause. Will confirm via the next CI run on `main`.

`make check` green. `go test -race -count=1 ./...` green, full suite. Target test green x5 under `-race` locally.

Closes: sn-nw0m