### PR TITLE
chore(lint): sn-3wlh adopt shared gorules bug-class pack (ccp-sbp)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,5 +37,12 @@ jobs:
       - name: test (race)
         run: go test -race -count=1 ./...
 
+      # bugclasses pack drift (ccp-sbp): fail if .golangci-rules/bugclasses.go
+      # has drifted from upstream. Network-soft — skips cleanly when upstream is
+      # unreachable (cc-plugins is private; activates once a token or public URL
+      # is wired via PACK_UPSTREAM_URL).
+      - name: pack-drift
+        run: make pack-drift
+
       - name: build
         run: go build ./...

--- a/.golangci-rules/bugclasses.go
+++ b/.golangci-rules/bugclasses.go
@@ -1,0 +1,117 @@
+// Package gorules is a ruleguard bundle: machine-checkable rules for the
+// recurring Go defect classes surfaced by the 9-repo cross-repo scan
+// (decision nug d7ea466a8172). Each rule traces to real, verbatim-repeated
+// defects and runs inside golangci-lint's gocritic ruleguard checker. See
+// README.md for enablement, per-rule provenance, and the escape hatch.
+//
+// This file is DSL, not a program: ruleguard parses it, `go build` never
+// compiles it. It still lives in a real module so editor tooling and the
+// analysistest harness (rules_test.go) work.
+//
+// Rule coverage lives across three surfaces because no single golangci
+// mechanism spans them:
+//   - ruleguard (this file): scanner-buffer, raw-state-write, err-substring,
+//     pid-liveness.
+//   - forbidigo (see golangci.snippet.yml): context.Background in daemons.
+//   - a standalone analyzer (../omitemptyscalar): omitempty on meaningful
+//     zero-value fields — ruleguard can't read struct tags (README §rule 3).
+//
+// A consuming repo copies this file to .golangci-rules/bugclasses.go verbatim.
+// That copy drifts silently when the pack changes, so the pack is versioned:
+// bump the token below on ANY rule edit; each repo runs check-pack-drift.sh in
+// CI to compare its copy's hash against upstream (golangci.snippet.yml §drift).
+//
+//pack:version v1
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// Bundle is the ruleguard bundle handle. It exists for the standalone
+// `ruleguard` binary, which can dsl.ImportRules() this pack from the module
+// cache and skip the file copy.
+//
+// It does NOT work under golangci-lint (the surface every consuming repo
+// actually runs). golangci-lint's embedded gocritic/ruleguard typechecks rule
+// files with a GOPATH-only source importer — it ignores go.mod, replace
+// directives, the module cache, and vendor/. A downstream file that imports
+// this package by module path fails ruleguard init with "cannot find package
+// ... (from $GOROOT)/(from $GOPATH)". Verified against golangci-lint v2.12.2 /
+// ruleguard dsl v0.3.22 (spike, 2026-08-04). So consuming repos MUST copy the
+// rule file and drift-check the copy — see check-pack-drift.sh. Do not wire an
+// ImportRules shim expecting golangci-lint to resolve it.
+var Bundle = dsl.Bundle{}
+
+// --- Rule 1: bufio.Scanner with the default 64KB token cap ------------------
+
+//doc:summary bufio.NewScanner consumed without a Buffer() cap override
+//doc:before  sc := bufio.NewScanner(r); for sc.Scan() { ... }
+//doc:after   sc := bufio.NewScanner(r); sc.Buffer(buf, max); for sc.Scan() { ... }
+//doc:tags    correctness
+func scannerDefaultBuffer(m dsl.Matcher) {
+	// The defect shape: a scanner is created and consumed with the scan loop
+	// adjacent to the constructor. A Buffer() call sits BETWEEN the two lines
+	// in fixed code, breaking statement adjacency, so this stays silent once
+	// the cap is set. Heuristic, not flow analysis — README §rule 1.
+	m.Match(
+		`$sc := bufio.NewScanner($r)
+		 for $sc.Scan() { $*_ }`,
+	).
+		// Skip tests (fixtures aren't production input) and in-memory readers
+		// (strings/bytes.NewReader is bounded by an already-loaded value —
+		// the same carve-out the alloc-bounds lens makes for ReadAll).
+		Where(!m.File().Name.Matches(`_test\.go$`) &&
+			!m["r"].Text.Matches(`^(strings|bytes)\.NewReader`)).
+		Report(`bufio.Scanner default 64KB token cap truncates long input; call $sc.Buffer(buf, max)`)
+}
+
+// Rule 2 (raw durable-state write) lives in optin_rawstatewrite.go — it ships
+// OFF, so it is a separate file the `rules` glob includes only once a repo
+// adopts atomicfile. gocritic's ruleguard checker exposes no per-group
+// disable, so file selection is the toggle (README §enablement).
+
+// --- Rule 4: error classification by substring ------------------------------
+
+//doc:summary error classified by matching err.Error() text
+//doc:before  strings.Contains(err.Error(), "not found")
+//doc:after   errors.Is(err, ErrNotFound)
+//doc:tags    correctness
+func errSubstringMatch(m dsl.Matcher) {
+	// strings.Contains / HasPrefix / HasSuffix over an .Error() string.
+	// Test files legitimately assert on error text; the defect is production
+	// control flow keyed on a message. Exclude _test.go from both groups.
+	m.Match(
+		`strings.Contains($err.Error(), $_)`,
+		`strings.HasPrefix($err.Error(), $_)`,
+		`strings.HasSuffix($err.Error(), $_)`,
+	).
+		Where(m["err"].Type.Implements(`error`) &&
+			!m.File().Name.Matches(`_test\.go$`)).
+		Report(`error classified by substring; use typed sentinels + errors.Is/As`)
+
+	// Direct equality/inequality of an error's message to a constant.
+	m.Match(
+		`$err.Error() == $s`,
+		`$err.Error() != $s`,
+		`$s == $err.Error()`,
+		`$s != $err.Error()`,
+	).
+		Where(m["err"].Type.Implements(`error`) && m["s"].Const &&
+			!m.File().Name.Matches(`_test\.go$`)).
+		Report(`error compared by message text; use errors.Is with a sentinel`)
+}
+
+// --- Rule 6: PID-only liveness check ----------------------------------------
+
+//doc:summary liveness probed by signalling a PID with no start-time witness
+//doc:before  proc.Signal(syscall.Signal(0))
+//doc:after   witness process start-time (PID reuse gives a false positive)
+//doc:tags    correctness
+func pidLivenessSignal(m dsl.Matcher) {
+	// Signal(0) on an *os.Process is the textbook PID-liveness probe; it says
+	// nothing about PID reuse. Narrow — the zero-signal idiom is rare outside
+	// this check, so it does not fire on real signalling.
+	m.Match(
+		`$p.Signal(syscall.Signal(0))`,
+	).
+		Report(`PID-only liveness: reused PID gives a false positive; witness proc start-time`)
+}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - errname
     - errorlint
     - exhaustive
+    - forbidigo
     - goconst
     - gocritic
     - misspell
@@ -68,8 +69,35 @@ linters:
       enabled-tags:
         - diagnostic
         - performance
+      # bugclasses pack (ccp-sbp, decision nug d7ea466a8172): the ruleguard
+      # checker runs the shared machine rules for the recurring cross-repo Go
+      # defect classes (scanner-buffer, err-substring, pid-liveness). Rules live
+      # in .golangci-rules/bugclasses.go — a verbatim copy of the upstream pack,
+      # drift-guarded by scripts/check-pack-drift.sh.
+      enabled-checks:
+        - ruleguard
+      settings:
+        ruleguard:
+          # ${base-path} = the .golangci.yml directory (golangci-lint v2). The
+          # glob names ONLY bugclasses.go, so rule 2 (raw-state-write, the
+          # opt-in file) stays off — snipe adopts the always-on rules only.
+          rules: "${base-path}/.golangci-rules/bugclasses.go"
+          # Fail the run on rule-compile errors — never silently skip them.
+          failOn: dsl
       disabled-checks:
         - hugeParam
+
+    forbidigo:
+      # bugclasses rule 5: context.Background() deep in daemon code should
+      # thread the caller/shutdown ctx (strand st-47z, trixi #606,
+      # trixi-bot gg-8rq.3, canapay can-x38). Path-scoped in exclusions below to
+      # snipe's non-daemon paths. Types-aware so a `ctx.Background` field can't
+      # misfire. Setting `forbid` replaces forbidigo's defaults, so the stock
+      # fmt.Print* bans stay off — only context.Background is forbidden.
+      analyze-types: true
+      forbid:
+        - pattern: '^context\.Background$'
+          msg: "thread the caller/shutdown ctx; context.Background belongs only at a daemon's root (main/startup)"
 
     godot:
       scope: declarations
@@ -142,6 +170,16 @@ linters:
         linters:
           - forbidigo
         text: "fmt.Fprintf"
+
+      # bugclasses rule 5 (forbidigo Background ban) is noise everywhere except
+      # long-lived daemon paths. context.Background is legitimate at snipe's
+      # root (root main.go, cmd/ subcommand startup) and in tests. snipe is a
+      # CLI/indexer, not a resident daemon — the ban guards the watcher/indexer
+      # goroutines that must thread the run/shutdown ctx.
+      - linters:
+          - forbidigo
+        path: '(_test\.go$|(^|/)cmd/|(^|/)main\.go$)'
+        text: 'context\.Background'
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include .sandbox/lib/Makefile.doctor.mk
 include .sandbox/lib/Makefile.cross.mk
 
 .PHONY: help scan check audit deploy report report-human \
-        vet lint test race blackbox vuln \
+        vet lint test race blackbox vuln pack-drift \
         install clean \
         baseline bench eval eval-setup
 
@@ -51,7 +51,7 @@ help: ## Show this help
 		/^## [^-]/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 4) } \
 		/^[a-zA-Z0-9_-]+:.*?## / { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-check: vet lint test ## Full repo: vet + lint + test + build
+check: vet lint test pack-drift ## Full repo: vet + lint + test + drift + build
 	@go build ./...
 	@echo "=== check pass ==="
 
@@ -91,6 +91,12 @@ blackbox: ## Run blackbox integration tests (fo-rendered)
 
 vuln: ## Scan for known vulnerabilities
 	govulncheck ./...
+
+# bugclasses pack (ccp-sbp): fail if .golangci-rules/bugclasses.go has drifted
+# from the upstream cc-plugins pack. Network-soft — an unreachable upstream
+# warns and passes, so this never breaks an offline/private-repo build.
+pack-drift: ## Check bugclasses pack for drift from upstream
+	@scripts/check-pack-drift.sh .golangci-rules/bugclasses.go
 
 ## ---------------------------------------------------------------------
 ## Build

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require github.com/rogpeppe/go-internal v1.15.0
 require (
 	github.com/dkoosis/atomicfile v0.0.0-20260804145440-ef7d3b3067ae
 	github.com/dkoosis/keyring v0.2.2
+	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 )
 
 require github.com/google/renameio/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=

--- a/internal/context/buildinfo.go
+++ b/internal/context/buildinfo.go
@@ -280,7 +280,7 @@ func fileHasGoGenerate(path string) bool {
 		return false
 	}
 	defer f.Close()
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(f) //nolint:gocritic // seeks the "//go:generate" line comment, which is always short; a >64KB line can't carry it, so the default cap can't change the result
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), "//go:generate") {
 			return true

--- a/internal/context/flows.go
+++ b/internal/context/flows.go
@@ -653,7 +653,7 @@ func extractCobraShorts(repoRoot string) map[string]string {
 		}
 
 		var short, runFunc string
-		scanner := bufio.NewScanner(f)
+		scanner := bufio.NewScanner(f) //nolint:gocritic // extracts Short:/RunE: struct-field tokens, which live on short lines; a >64KB line can't carry them, so the default cap can't change the result
 		for scanner.Scan() {
 			line := scanner.Text()
 			if m := shortRe.FindStringSubmatch(line); m != nil && short == "" {

--- a/internal/graphmetrics/graph.go
+++ b/internal/graphmetrics/graph.go
@@ -206,7 +206,7 @@ func moduleImportPath(s *store.Store) (string, error) {
 	}
 	defer func() { _ = f.Close() }()
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(f) //nolint:gocritic // reads go.mod, whose lines are short by format; the 64KB cap is unreachable here
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(line, "module ") {

--- a/internal/index/loader.go
+++ b/internal/index/loader.go
@@ -60,7 +60,7 @@ func DefaultExclude() []string {
 func Load(cfg LoadConfig) (*LoadResult, error) {
 	ctx := cfg.Context
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = context.Background() //nolint:forbidigo // nil-guard default for the optional cfg.Context; the caller's ctx is threaded when supplied
 	}
 
 	if cfg.Dir == "" {

--- a/internal/metrics/capture.go
+++ b/internal/metrics/capture.go
@@ -230,13 +230,13 @@ func Capture(cfg CaptureConfig) (*Baseline, error) {
 	// Search metrics
 	start = time.Now()
 	for i := 0; i < runs; i++ {
-		_, _ = search.Search(context.Background(), cfg.Dir, "func", 50, 0)
+		_, _ = search.Search(context.Background(), cfg.Dir, "func", 50, 0) //nolint:forbidigo // one-shot baseline capture; no caller ctx and not a cancellable request path
 	}
 	baseline.Search.SimplePatternMs = float64(time.Since(start).Microseconds()) / float64(runs) / 1000.0
 
 	start = time.Now()
 	for i := 0; i < runs; i++ {
-		_, _ = search.Search(context.Background(), cfg.Dir, "func.*Error", 50, 0)
+		_, _ = search.Search(context.Background(), cfg.Dir, "func.*Error", 50, 0) //nolint:forbidigo // one-shot baseline capture; no caller ctx and not a cancellable request path
 	}
 	baseline.Search.RegexPatternMs = float64(time.Since(start).Microseconds()) / float64(runs) / 1000.0
 

--- a/internal/query/overlap.go
+++ b/internal/query/overlap.go
@@ -147,7 +147,7 @@ func FindOverlappingSymbols(db *sql.DB, repoRoot string, changes map[string][]Li
 	// nothing to commit; the deferred Rollback also runs on any early error
 	// return below. This consistency guarantee is structural — verified by
 	// construction, not by a (necessarily flaky) mid-loop-writer timing test.
-	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true}) //nolint:forbidigo // FindOverlappingSymbols has no ctx param; threading one is the pre-existing noctx debt tracked separately, out of this pack-adoption's scope
 	if err != nil {
 		return nil, fmt.Errorf("query overlapping symbols: %w", err)
 	}

--- a/internal/search/rg.go
+++ b/internal/search/rg.go
@@ -50,7 +50,7 @@ type rgSubmatch struct {
 // finishes. A nil ctx is treated as context.Background().
 func Search(ctx context.Context, dir, pattern string, limit, contextLines int, globs ...string) ([]output.Result, error) {
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = context.Background() //nolint:forbidigo // nil-guard default for the optional ctx param (documented contract); the caller's ctx bounds rg when supplied
 	}
 
 	if _, err := exec.LookPath("rg"); err != nil {

--- a/internal/sensitive/sensitive.go
+++ b/internal/sensitive/sensitive.go
@@ -71,7 +71,7 @@ func Load(repoRoot string) *Classifier {
 	}
 	defer func() { _ = f.Close() }()
 
-	sc := bufio.NewScanner(f)
+	sc := bufio.NewScanner(f) //nolint:gocritic // reads the .snipe/sensitive config, one short "glob zone" rule per line; the 64KB cap is unreachable here
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -221,7 +221,7 @@ func lockHeldByDeadProcess(lockPath string) (stale bool, observed string) {
 	}
 	defer func() { _ = proc.Release() }() // release the Windows handle FindProcess opened; no-op on Unix
 
-	sigErr := proc.Signal(syscall.Signal(0))
+	sigErr := proc.Signal(syscall.Signal(0)) //nolint:gocritic // TODO(sn): true positive — the lock file stores only a PID, so a reused PID reads as alive and wedges the stale lock; witnessing proc start-time is a lock-format change tracked outside this pack adoption
 	switch {
 	case sigErr == nil:
 		// Holder alive.

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -545,14 +545,14 @@ func (s *Store) WriteIndexIncremental(
 	}
 	incCount++
 
-	conn, err := s.db.Conn(context.Background())
+	conn, err := s.db.Conn(context.Background()) //nolint:forbidigo // WriteIndexIncremental has no ctx param; threading one is the pre-existing noctx debt tracked separately, out of this pack-adoption's scope
 	if err != nil {
 		return nil, fmt.Errorf("acquire connection: %w", err)
 	}
 	defer conn.Close()
 
 	// Disable FK constraints (must be outside transaction in SQLite)
-	if _, err := conn.ExecContext(context.Background(), "PRAGMA foreign_keys=OFF"); err != nil {
+	if _, err := conn.ExecContext(context.Background(), "PRAGMA foreign_keys=OFF"); err != nil { //nolint:forbidigo // WriteIndexIncremental has no ctx param; pre-existing noctx debt tracked separately, out of this pack-adoption's scope
 		return nil, fmt.Errorf("disable FK: %w", err)
 	}
 	defer func() {
@@ -561,12 +561,12 @@ func (s *Store) WriteIndexIncremental(
 		// silently-failed restore would leave FK enforcement off for every
 		// later write/read in the process. Surface the error into the named
 		// return (only when no earlier error already won) so it can't be lost.
-		if _, ferr := conn.ExecContext(context.Background(), "PRAGMA foreign_keys=ON"); ferr != nil && err == nil {
+		if _, ferr := conn.ExecContext(context.Background(), "PRAGMA foreign_keys=ON"); ferr != nil && err == nil { //nolint:forbidigo // WriteIndexIncremental has no ctx param; pre-existing noctx debt tracked separately, out of this pack-adoption's scope
 			err = fmt.Errorf("re-enable FK: %w", ferr)
 		}
 	}()
 
-	tx, err := conn.BeginTx(context.Background(), nil)
+	tx, err := conn.BeginTx(context.Background(), nil) //nolint:forbidigo // WriteIndexIncremental has no ctx param; pre-existing noctx debt tracked separately, out of this pack-adoption's scope
 	if err != nil {
 		return nil, fmt.Errorf("begin transaction: %w", err)
 	}

--- a/scripts/check-pack-drift.sh
+++ b/scripts/check-pack-drift.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check-pack-drift.sh — fail CI when a consuming repo's copied bugclasses rules
+# have drifted from the upstream cc-plugins pack.
+#
+# The pack ships as a copied file (.golangci-rules/bugclasses.go, a verbatim
+# copy of gorules/rules.go). Copies rot silently: upstream fixes a rule, the
+# copy stays stale, or someone hand-edits the copy. This makes both loud.
+#
+# It compares two things:
+#   1. version token — the //pack:version line in the local copy vs upstream.
+#   2. content hash  — sha256 of the local copy vs upstream rules.go (catches
+#      local edits that DIDN'T bump the version).
+#
+# Vendor this into the consuming repo (e.g. .golangci-rules/) and run it in CI
+# after golangci-lint. Network-soft: an unreachable upstream WARNS and exits 0
+# so a transient outage never breaks the build; a real mismatch exits 1.
+#
+# Usage: check-pack-drift.sh [path-to-local-bugclasses.go]
+#   default local path: .golangci-rules/bugclasses.go
+set -euo pipefail
+
+UPSTREAM_URL="${PACK_UPSTREAM_URL:-https://raw.githubusercontent.com/dkoosis/cc-plugins/main/plugins/lintbrush/gorules/rules.go}"
+LOCAL="${1:-.golangci-rules/bugclasses.go}"
+
+die()  { printf '✗ pack-drift: %s\n' "$*" >&2; exit 1; }
+warn() { printf '⚠ pack-drift: %s\n' "$*" >&2; }
+
+[[ -f "$LOCAL" ]] || die "local copy not found: $LOCAL"
+
+sha()  { shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'; }
+vtok() { grep -m1 '//pack:version' "$1" 2>/dev/null | awk '{print $2}'; }
+
+upstream="$(mktemp)"
+trap 'rm -f "$upstream"' EXIT
+if ! curl -fsSL --max-time 10 "$UPSTREAM_URL" -o "$upstream" 2>/dev/null; then
+	warn "upstream unreachable ($UPSTREAM_URL) — skipping drift check"
+	exit 0
+fi
+
+lv="$(vtok "$LOCAL")"; uv="$(vtok "$upstream")"
+lh="$(sha "$LOCAL")";  uh="$(sha "$upstream")"
+
+if [[ "$lh" == "$uh" ]]; then
+	printf '✓ pack-drift: in sync (%s)\n' "${lv:-unversioned}"
+	exit 0
+fi
+
+if [[ "$lv" != "$uv" ]]; then
+	die "version drift: local ${lv:-none} vs upstream ${uv:-none}. Re-copy rules.go → $LOCAL and re-tune exclusions."
+fi
+die "content drift: $LOCAL differs from upstream at the same version ($lv). A local hand-edit? Re-copy or bump upstream."

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,15 @@
+//go:build tools
+
+// Package tools pins build-only tool dependencies into the module graph so
+// `go mod tidy` keeps them, without letting them enter the snipe binary.
+//
+// The lone entry is the ruleguard DSL: .golangci-rules/bugclasses.go (the
+// shared bugclasses pack, ccp-sbp) imports it, but that file lives in a
+// dot-directory the Go toolchain ignores — so tidy never sees the import and
+// would drop dsl from go.mod, leaving golangci-lint's embedded ruleguard unable
+// to typecheck the rules file (its importer resolves only from the module
+// graph, not $GOROOT/$GOPATH). This blank import is the bridge. The `tools`
+// build tag keeps the file out of every normal build.
+package tools
+
+import _ "github.com/quasilyte/go-ruleguard/dsl"

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/LICENSE
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Iskander (Alex) Sharipov / quasilyte
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/bundle.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/bundle.go
@@ -1,0 +1,19 @@
+package dsl
+
+// Bundle is a rules file export manifest.
+type Bundle struct {
+	// TODO: figure out which fields we might want to add here.
+}
+
+// ImportRules imports all rules from the bundle and prefixes them with a specified string.
+//
+// Empty string prefix is something like "dot import" in Go.
+// Group name collisions will result in an error.
+//
+// Only packages that have an exported Bundle variable can be imported.
+//
+// Note: right now imported bundle can't import other bundles.
+// This is not a fundamental limitation but rather a precaution
+// measure before we understand how it should work better.
+// If you need this feature, please open an issue at github.com/quasilyte/go-ruleguard.
+func ImportRules(prefix string, bundle Bundle) {}

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/do.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/do.go
@@ -1,0 +1,19 @@
+package dsl
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl/types"
+)
+
+type DoContext struct{}
+
+func (*DoContext) Var(varname string) *DoVar { return nil }
+
+func (*DoContext) SetReport(report string) {}
+
+func (*DoContext) SetSuggest(suggest string) {}
+
+type DoVar struct{}
+
+func (*DoVar) Text() string { return "" }
+
+func (*DoVar) Type() types.Type { return nil }

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/dsl.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/dsl.go
@@ -1,0 +1,365 @@
+package dsl
+
+// Matcher is a main API group-level entry point.
+// It's used to define and configure the group rules.
+// It also represents a map of all rule-local variables.
+type Matcher map[string]Var
+
+// Import loads given package path into a rule group imports table.
+//
+// That table is used during the rules compilation.
+//
+// The table has the following effect on the rules:
+//	* For type expressions, it's used to resolve the
+//	  full package paths of qualified types, like `foo.Bar`.
+//	  If Import(`a/b/foo`) is called, `foo.Bar` will match
+//	  `a/b/foo.Bar` type during the pattern execution.
+func (m Matcher) Import(pkgPath string) {}
+
+// ImportAs is like Import, but can handle "/v2" packages
+// and package name conflicts (e.g. "x/path" vs "y/path").
+func (m Matcher) ImportAs(pkgPath, localName string) {}
+
+// Match specifies a set of patterns that match a rule being defined.
+// Pattern matching succeeds if at least 1 pattern matches.
+//
+// If none of the given patterns matched, rule execution stops.
+func (m Matcher) Match(pattern string, alternatives ...string) Matcher {
+	return m
+}
+
+// MatchComment is like Match, but handles only comments and uses regexp patterns.
+//
+// Multi-line /**/ comments are passed as a single string.
+// Single-line // comments are passed line-by-line.
+//
+// Hint: if you want to match a plain text and don't want to do meta char escaping,
+// prepend `\Q` to your pattern. `\Qf(x)` will match `f(x)` as a plain text
+// and there is no need to escape the `(` and `)` chars.
+//
+// Named regexp capture groups can be accessed using the usual indexing notation.
+//
+// Given this pattern:
+//
+//     `(?P<first>\d+)\.(\d+).(?P<second>\d+)`
+//
+// And this input comment: `// 14.6.600`
+//
+// We'll get these submatches:
+//
+//     m["$$"] => `14.6.600`
+//     m["first"] => `14`
+//     m["second"] => `600`
+//
+// All usual filters can be applied:
+//
+//     Where(!m["first"].Text.Matches(`foo`))
+//
+// You can use this to reject some matches (allow-list behavior).
+func (m Matcher) MatchComment(pattern string, alternatives ...string) Matcher {
+	return m
+}
+
+// Where applies additional constraint to a match.
+// If a given cond is not satisfied, a match is rejected and
+// rule execution stops.
+func (m Matcher) Where(cond bool) Matcher {
+	return m
+}
+
+// Report prints a message if associated rule match is successful.
+//
+// A message is a string that can contain interpolated expressions.
+// For every matched variable it's possible to interpolate
+// their printed representation into the message text with $<name>.
+// An entire match can be addressed with $$.
+func (m Matcher) Report(message string) Matcher {
+	return m
+}
+
+// Suggest assigns a quickfix suggestion for the matched code.
+func (m Matcher) Suggest(suggestion string) Matcher {
+	return m
+}
+
+func (m Matcher) Do(fn func(*DoContext)) Matcher {
+	return m
+}
+
+// At binds the reported node to a named submatch.
+// If no explicit location is given, the outermost node ($$) is used.
+func (m Matcher) At(v Var) Matcher {
+	return m
+}
+
+// File returns the current file context.
+func (m Matcher) File() File { return File{} }
+
+// GoVersion returns the analyzer associated target Go language version.
+func (m Matcher) GoVersion() GoVersion { return GoVersion{} }
+
+// Deadcode reports whether this match is contained inside a dead code path.
+func (m Matcher) Deadcode() bool { return boolResult }
+
+// Var is a pattern variable that describes a named submatch.
+type Var struct {
+	// Pure reports whether expr matched by var is side-effect-free.
+	Pure bool
+
+	// Const reports whether expr matched by var is a constant value.
+	Const bool
+
+	// ConstSlice reports whether expr matched by var is a slice literal
+	// consisting of constant elements.
+	//
+	// We need a separate Const-like predicate here because Go doesn't
+	// treat slices of const elements as constants, so including
+	// them in Const would be incorrect.
+	// Use `m["x"].Const || m["x"].ConstSlice` when you need
+	// to have extended definition of "constant value".
+	//
+	// Some examples:
+	//     []byte("foo") -- constant byte slice
+	//     []byte{'f', 'o', 'o'} -- same constant byte slice
+	//     []int{1, 2} -- constant int slice
+	ConstSlice bool
+
+	// Value is a compile-time computable value of the expression.
+	Value ExprValue
+
+	// Addressable reports whether the corresponding expression is addressable.
+	// See https://golang.org/ref/spec#Address_operators.
+	Addressable bool
+
+	// Comparable reports whether the corresponding expression value is comparable.
+	// See https://pkg.go.dev/go/types#Comparable.
+	Comparable bool
+
+	// Type is a type of a matched expr.
+	//
+	// For function call expressions, a type is a function result type,
+	// but for a function expression itself it's a *types.Signature.
+	//
+	// Suppose we have a `a.b()` expression:
+	//	`$x()` m["x"].Type is `a.b` function type
+	//	`$x` m["x"].Type is `a.b()` function call result type
+	Type ExprType
+
+	SinkType SinkType
+
+	// Object is an associated "go/types" Object.
+	Object TypesObject
+
+	// Text is a captured node text as in the source code.
+	Text MatchedText
+
+	// Node is a captured AST node.
+	Node MatchedNode
+
+	// Line is a source code line number that contains this match.
+	// If this match is multi-line, this is the first line number.
+	Line int
+}
+
+// Filter applies a custom predicate function on a submatch.
+//
+// The callback function should use VarFilterContext to access the
+// information that is usually accessed through Var.
+// For example, `VarFilterContext.Type` is mapped to `Var.Type`.
+func (Var) Filter(pred func(*VarFilterContext) bool) bool { return boolResult }
+
+// Contains runs a sub-search from a given pattern using the captured
+// vars from the original pattern match.
+//
+// For example, given the Match(`$lhs = append($lhs, $x)`) pattern,
+// we can do m["lhs"].Contains(`$x`) and learn whether $lhs contains
+// $x as its sub-expression.
+//
+// Experimental: this function is not part of the stable API.
+func (Var) Contains(pattern string) bool { return boolResult }
+
+// MatchedNode represents an AST node associated with a named submatch.
+type MatchedNode struct{}
+
+// Is reports whether a matched node AST type is compatible with the specified type.
+// A valid argument is a ast.Node implementing type name from the "go/ast" package.
+// Examples: "BasicLit", "Expr", "Stmt", "Ident", "ParenExpr".
+// See https://golang.org/pkg/go/ast/.
+func (MatchedNode) Is(typ string) bool { return boolResult }
+
+// Parent returns a matched node parent.
+func (MatchedNode) Parent() Node { return Node{} }
+
+// Node represents an AST node somewhere inside a match.
+// Unlike MatchedNode, it doesn't have to be associated with a named submatch.
+type Node struct{}
+
+// Is reports whether a node AST type is compatible with the specified type.
+// See `MatchedNode.Is` for the full reference.
+func (Node) Is(typ string) bool { return boolResult }
+
+// ExprValue describes a compile-time computable value of a matched expr.
+type ExprValue struct{}
+
+// Int returns compile-time computable int value of the expression.
+// If value can't be computed, condition will fail.
+func (ExprValue) Int() int { return intResult }
+
+// TypesObject is a types.Object mapping.
+type TypesObject struct{}
+
+// Is reports whether an associated types.Object is compatible with the specified type.
+// A valid argument is a types.Object type name from the "go/types" package.
+// Examples: "Func", "Var", "Const", "TypeName", "Label", "PkgName", "Builtin", "Nil"
+// See https://golang.org/pkg/go/types/.
+func (TypesObject) Is(typ string) bool { return boolResult }
+
+// IsGlobal reports whether an associated types.Object is defined in global scope.
+func (TypesObject) IsGlobal() bool { return boolResult }
+
+// IsVariadicParam reports whether this object represents a function variadic param.
+// This property is not propagated between the assignments.
+func (TypesObject) IsVariadicParam() bool { return boolResult }
+
+type SinkType struct{}
+
+// Is reports whether a type is identical to a given type.
+// Works like ExprType.Is method.
+func (SinkType) Is(typ string) bool { return boolResult }
+
+// ExprType describes a type of a matcher expr.
+type ExprType struct {
+	// Size represents expression type size in bytes.
+	//
+	// For expressions of unknown size, like type params in generics,
+	// any filter using this operand will fail.
+	Size int
+}
+
+// IdenticalTo applies types.Identical(this, v.Type) operation.
+// See https://golang.org/pkg/go/types/#Identical function documentation.
+//
+// Experimental: this function is not part of the stable API.
+func (ExprType) IdenticalTo(v Var) bool { return boolResult }
+
+// Underlying returns expression type underlying type.
+// See https://golang.org/pkg/go/types/#Type Underlying() method documentation.
+// Read https://golang.org/ref/spec#Types section to learn more about underlying types.
+func (ExprType) Underlying() ExprType { return underlyingType }
+
+// AssignableTo reports whether a type is assign-compatible with a given type.
+// See https://golang.org/pkg/go/types/#AssignableTo.
+func (ExprType) AssignableTo(typ string) bool { return boolResult }
+
+// ConvertibleTo reports whether a type is conversible to a given type.
+// See https://golang.org/pkg/go/types/#ConvertibleTo.
+func (ExprType) ConvertibleTo(typ string) bool { return boolResult }
+
+// Implements reports whether a type implements a given interface.
+// See https://golang.org/pkg/go/types/#Implements.
+func (ExprType) Implements(typ typeName) bool { return boolResult }
+
+// HasMethod reports whether a type has a given method.
+// Unlike Implements(), it will work for both value and pointer types.
+//
+// fn argument is a function signature, like `WriteString(string) (int, error)`.
+// It can also be in form of a method reference for importable types: `io.StringWriter.WriteString`.
+//
+// To avoid confusion with Implements() method, here is a hint when to use which:
+//
+//	- To check if it's possible to call F on x, use HasMethod(F)
+//	- To check if x can be passed as I interface, use Implements(I)
+func (ExprType) HasMethod(fn string) bool { return boolResult }
+
+// Is reports whether a type is identical to a given type.
+func (ExprType) Is(typ string) bool { return boolResult }
+
+// HasPointers reports whether a type contains at least one pointer.
+//
+// We try to be as close to the Go sense of pointer-free objects as possible,
+// therefore string type is not considered to be a pointer-free type.
+//
+// This function may return "true" for some complicated cases as a
+// conservative result. It never returns "false" for a type that
+// actually contains a pointer.
+//
+// So this function is mostly useful for !HasPointers() form.
+func (ExprType) HasPointers() bool { return boolResult }
+
+// OfKind reports whether a matched expr type is compatible with the specified kind.
+//
+// Only a few "kinds" are recognized, the list is provided below.
+//
+//	"integer"  -- typ is *types.Basic, where typ.Info()&types.Integer != 0
+//	"unsigned" -- typ is *types.Basic, where typ.Info()&types.Unsigned != 0
+//	"float"    -- typ is *types.Basic, where typ.Info()&types.Float != 0
+//	"complex"  -- typ is *types.Basic, where typ.Info()&types.Complex != 0
+//	"untyped"  -- typ is *types.Basic, where typ.Info()&types.Untyped != 0
+//	"numeric"  -- typ is *types.Basic, where typ.Info()&types.Numeric != 0
+//  "signed"   -- identical to `OfKind("integer") && !OfKind("unsigned")`
+//  "int"      -- int, int8, int16, int32, int64
+//  "uint"     -- uint, uint8, uint16, uint32, uint64
+//
+// Note: "int" will include "rune" as well, as it's an alias.
+// In the same manner, "uint" includes the "byte" type.
+//
+// Using OfKind("unsigned") is more efficient (and concise) than using a set
+// of or-conditions with Is("uint8"), Is("uint16") and so on.
+func (ExprType) OfKind(kind string) bool { return boolResult }
+
+// MatchedText represents a source text associated with a matched node.
+type MatchedText string
+
+// Matches reports whether the text matches the given regexp pattern.
+func (MatchedText) Matches(pattern string) bool { return boolResult }
+
+// String represents an arbitrary string-typed data.
+type String string
+
+// Matches reports whether a string matches the given regexp pattern.
+func (String) Matches(pattern string) bool { return boolResult }
+
+// File represents the current Go source file.
+type File struct {
+	// Name is a file base name.
+	Name String
+
+	// PkgPath is a file package path.
+	// Examples: "io/ioutil", "strings", "github.com/quasilyte/go-ruleguard/dsl".
+	PkgPath String
+}
+
+// Imports reports whether the current file imports the given path.
+func (File) Imports(path string) bool { return boolResult }
+
+// GoVersion is an analysis target go language version.
+// It can be compared to Go versions like "1.10", "1.16" using
+// the associated methods.
+type GoVersion struct{}
+
+// Eq asserts that target Go version is equal to (==) specified version.
+func (GoVersion) Eq(version string) bool { return boolResult }
+
+// GreaterEqThan asserts that target Go version is greater or equal than (>=) specified version.
+func (GoVersion) GreaterEqThan(version string) bool { return boolResult }
+
+// GreaterThan asserts that target Go version is greater than (>) specified version.
+func (GoVersion) GreaterThan(version string) bool { return boolResult }
+
+// LessThan asserts that target Go version is less than (<) specified version.
+func (GoVersion) LessThan(version string) bool { return boolResult }
+
+// LessEqThan asserts that target Go version is less or equal than (<=) specified version.
+func (GoVersion) LessEqThan(version string) bool { return boolResult }
+
+// typeName is a helper type used to document function params better.
+//
+// A type name can be:
+//	- builtin type name: `error`, `string`, etc.
+//	- qualified name from a standard library: `io.Reader`, etc.
+//	- fully-qualified type name, like `github.com/username/pkgname.TypeName`
+//
+// typeName is also affected by a local import table, which can override
+// how qualified names are interpreted.
+// See `Matcher.Import` for more info.
+type typeName = string

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/filter.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/filter.go
@@ -1,0 +1,24 @@
+package dsl
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl/types"
+)
+
+// VarFilterContext carries Var and environment information into the filter function.
+// It's an input parameter type for the Var.Filter function callback.
+type VarFilterContext struct {
+	// Type is mapped to Var.Type field.
+	Type types.Type
+}
+
+// SizeOf returns the size of the given type.
+// It uses the ruleguard.Context.Sizes to calculate the result.
+func (*VarFilterContext) SizeOf(x types.Type) int { return 0 }
+
+// GetType finds a type value by a given name.
+// If a type can't be found (or a name is malformed), this function panics.
+func (*VarFilterContext) GetType(name typeName) types.Type { return nil }
+
+// GetInterface finds a type value that represents an interface by a given name.
+// Works like `types.AsInterface(ctx.GetType(name))`.
+func (*VarFilterContext) GetInterface(name typeName) *types.Interface { return nil }

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/internal.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/internal.go
@@ -1,0 +1,6 @@
+package dsl
+
+var boolResult bool
+var intResult int
+
+var underlyingType ExprType

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/types/ext.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/types/ext.go
@@ -1,0 +1,21 @@
+package types
+
+// AsArray is a type-assert like operation, x.(*Array), but never panics.
+// Returns nil if type is not an array.
+func AsArray(x Type) *Array { return nil }
+
+// AsSlice is a type-assert like operation, x.(*Slice), but never panics.
+// Returns nil if type is not an array.
+func AsSlice(x Type) *Slice { return nil }
+
+// AsPointer is a type-assert like operation, x.(*Pointer), but never panics.
+// Returns nil if type is not a pointer.
+func AsPointer(x Type) *Pointer { return nil }
+
+// AsStruct is a type-assert like operation, x.(*Struct), but never panics.
+// Returns nil if type is not a struct.
+func AsStruct(x Type) *Struct { return nil }
+
+// AsInterface is a type-assert like operation, x.(*Interface), but never panics.
+// Returns nil if type is not an interface.
+func AsInterface(x Type) *Interface { return nil }

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/types/type_impl.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/types/type_impl.go
@@ -1,0 +1,17 @@
+package types
+
+// Method stubs to make various types implement Type interface.
+//
+// Nothing interesting here, hence it's moved to a separate file.
+
+func (*Array) String() string     { return "" }
+func (*Slice) String() string     { return "" }
+func (*Pointer) String() string   { return "" }
+func (*Interface) String() string { return "" }
+func (*Struct) String() string    { return "" }
+
+func (*Array) Underlying() Type     { return nil }
+func (*Slice) Underlying() Type     { return nil }
+func (*Pointer) Underlying() Type   { return nil }
+func (*Interface) Underlying() Type { return nil }
+func (*Struct) Underlying() Type    { return nil }

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/types/types.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/types/types.go
@@ -1,0 +1,68 @@
+// Package types mimics the https://golang.org/pkg/go/types/ package.
+// It also contains some extra utility functions, they're defined in ext.go file.
+package types
+
+// Implements reports whether a given type implements the specified interface.
+func Implements(typ Type, iface *Interface) bool { return false }
+
+// Identical reports whether x and y are identical types. Receivers of Signature types are ignored.
+func Identical(x, y Type) bool { return false }
+
+// A Type represents a type of Go. All types implement the Type interface.
+type Type interface {
+	// Underlying returns the underlying type of a type.
+	Underlying() Type
+
+	// String returns a string representation of a type.
+	String() string
+}
+
+type (
+	// An Array represents an array type.
+	Array struct{}
+
+	// A Slice represents a slice type.
+	Slice struct{}
+
+	// A Pointer represents a pointer type.
+	Pointer struct{}
+
+	// An Interface represents an interface type.
+	Interface struct{}
+
+	// A struct represents a struct type.
+	Struct struct{}
+)
+
+// NewArray returns a new array type for the given element type and length.
+// A negative length indicates an unknown length.
+func NewArray(elem Type, len int) *Array { return nil }
+
+// Elem returns element type of array.
+func (*Array) Elem() Type { return nil }
+
+// NewSlice returns a new slice type for the given element type.
+func NewSlice(elem Type) *Slice { return nil }
+
+// Elem returns element type of slice.
+func (*Slice) Elem() Type { return nil }
+
+// Len returns the length of array.
+// A negative result indicates an unknown length.
+func (*Array) Len() int { return 0 }
+
+// NewPointer returns a new pointer type for the given element (base) type.
+func NewPointer(elem Type) *Pointer { return nil }
+
+// Elem returns the element type for the given pointer.
+func (*Pointer) Elem() Type { return nil }
+
+func (*Struct) NumFields() int { return 0 }
+
+func (*Struct) Field(i int) *Var { return nil }
+
+type Var struct{}
+
+func (*Var) Embedded() bool { return false }
+
+func (*Var) Type() Type { return nil }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -52,6 +52,10 @@ github.com/ncruces/go-strftime
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
+# github.com/quasilyte/go-ruleguard/dsl v0.3.23
+## explicit; go 1.15
+github.com/quasilyte/go-ruleguard/dsl
+github.com/quasilyte/go-ruleguard/dsl/types
 # github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec
 ## explicit; go 1.12
 github.com/remyoudompheng/bigfft


### PR DESCRIPTION
Adopts the always-on half of the cc-plugins `bugclasses` ruleguard pack (decision nug `d7ea466a8172`) into snipe. Bead: sn-3wlh.

## Scope
Pack rules only — **rules 1, 4, 5, 6**. NOT rule 2 (raw-state-write opt-in), NOT rule 3 (omitempty analyzer), NOT the baseline floor. snipe deliberately disables `errcheck`/`noctx` (pre-existing 326/377 context/errcheck debt); that debt is **out of scope** and untouched.

## What landed
- `.golangci-rules/bugclasses.go` — verbatim copy of upstream `rules.go` (sha256 verified).
- `scripts/check-pack-drift.sh` — verbatim; wired into `make check` and CI. Network-soft: cc-plugins is private, so it warns+passes until `PACK_UPSTREAM_URL` is set.
- `tools.go` (build-tagged) + `go mod tidy` + `go mod vendor` — makes the ruleguard DSL importable so golangci's embedded gocritic/ruleguard can typecheck the rules file (snipe vendors, so dsl is vendored too).
- `.golangci.yml` — enable `forbidigo`; `gocritic` `enabled-checks: [ruleguard]` + `settings.ruleguard` (`failOn: dsl`); forbidigo `analyze-types: true` + `^context\.Background$` ban, path-scoped in exclusions to snipe's non-daemon paths. Fixed the scope regex `/cmd/` → `(^|/)cmd/` so snipe's relative `cmd/...` paths actually exclude (itzy's pattern relied on `main.go`).

## FP audit (pinned golangci-lint v2.12.2)
Matches the pack README's snipe row: **rule 1 scanner ×4, rule 6 pid ×1, rule 5 forbidigo ×9** — all `//nolint`ed with per-site reasons (no blanket ignores):
- Scanners (buildinfo/flows/graph/sensitive): read go.mod / config / Go source for short line-comment or struct-field tokens a >64KB line can't carry → 64KB cap can't change the result.
- pid (store.go): genuine true positive — lock file stores only a PID; witnessing start-time is a lock-format change tracked outside this adoption (`TODO(sn)`).
- forbidigo (index/search/query/store/metrics): nil-guard defaults for optional ctx params, or functions with no ctx param whose threading is the pre-existing noctx debt.

## Gate
`make check` green: vet + golangci-lint (0 issues) + tests + pack-drift + build. The pre-existing errcheck/noctx debt is behind disabled linters, so it does not block the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for common Go defect patterns, including scanner limits, error classification, and process liveness checks.
  * Added enforcement against unsuitable background contexts in selected production code.
* **Bug Fixes**
  * Clarified intentional exceptions for existing code patterns without changing runtime behavior.
* **Chores**
  * Added automated drift detection to ensure bundled lint rules remain synchronized with their upstream source.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->