### PR TITLE
chore: conform v0.2.0 pin bump — pr-template Surface 1 (sd-th5.22)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 )
 
 require (
-	github.com/dkoosis/conform v0.1.2 // indirect
+	github.com/dkoosis/conform v0.2.0 // indirect
 	github.com/google/renameio/v2 v2.0.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dkoosis/atomicfile v0.0.0-20260804145440-ef7d3b3067ae h1:STOihlz/k4K6
 github.com/dkoosis/atomicfile v0.0.0-20260804145440-ef7d3b3067ae/go.mod h1:6wCWesghtzLYJ0IjlbbddyTCU8ZowoiIUzcy4Qi9fDc=
 github.com/dkoosis/conform v0.1.2 h1:HzE/E/yy94s5FRQyY/GWok9VTCjIvmqHl7v9gAJ5GrM=
 github.com/dkoosis/conform v0.1.2/go.mod h1:TP6zWp9VK7MlmHNCHri0EhqZmHY3jAqUrUvSNhnosOk=
+github.com/dkoosis/conform v0.2.0 h1:w8spzU4WwFIA37/qln8zSKJVHZ81afvpU9oplWkkzwY=
+github.com/dkoosis/conform v0.2.0/go.mod h1:Zq32Tf2c7K8O2MPAja+pJfOWmbika4Wn5qCZoUdcKEQ=
 github.com/dkoosis/keyring v0.2.2 h1:Ob3hY2oSyidlyEWGovtWZcOl9KWY6K+bIZCA6qzkAZc=
 github.com/dkoosis/keyring v0.2.2/go.mod h1:EmEgoJa4a+rjxNdnzD1YerjK8vOE+r5oC5b5UfSL+AY=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/vendor/github.com/dkoosis/conform/internal/checks/checks.go
+++ b/vendor/github.com/dkoosis/conform/internal/checks/checks.go
@@ -34,6 +34,7 @@ const (
 	RuleRetiredFiles = "retired-files"     // files folded into conform are gone
 	RuleBDConfig     = "bd-config"         // bd config keys present
 	RuleHooksShape   = "hooks-shape"       // shape B: tracked .githooks
+	RulePRTemplate   = "pr-template"       // PR template present + non-empty (Surface 1 since v0.2.0)
 )
 
 // Finding is one contract violation: which file, which rule, what to run.
@@ -62,6 +63,7 @@ func Run(dir string) []Finding {
 	findings = append(findings, checkRetiredFiles(dir)...)
 	findings = append(findings, checkBDConfig(dir)...)
 	findings = append(findings, checkHooksShape(dir)...)
+	findings = append(findings, checkPRTemplate(dir)...)
 
 	findings = applyExceptions(findings, vals)
 	sort.SliceStable(findings, func(i, j int) bool {

--- a/vendor/github.com/dkoosis/conform/internal/checks/fleetcheck.go
+++ b/vendor/github.com/dkoosis/conform/internal/checks/fleetcheck.go
@@ -32,8 +32,6 @@ const (
 	// RuleMergePolicy — squash-only + delete-branch-on-merge, chosen, not
 	// GitHub's everything-on default.
 	RuleMergePolicy = "merge-policy"
-	// RulePRTemplate — .github/pull_request_template.md present.
-	RulePRTemplate = "pr-template"
 )
 
 const fleetOwner = "dkoosis"
@@ -146,7 +144,6 @@ func checkFleetRepo(ctx context.Context, name string) []Finding {
 	findings := protectionFindings(ctx, full, branch)
 	findings = append(findings, labelFindings(ctx, full)...)
 	findings = append(findings, mergePolicyFindings(full, settings)...)
-	findings = append(findings, templateFindings(ctx, full)...)
 
 	return applyExceptions(findings, fleetValues(ctx, full))
 }
@@ -238,20 +235,6 @@ func mergePolicyFindings(full string, s *repoSettings) []Finding {
 	return []Finding{{File: full, Rule: RuleMergePolicy,
 		Msg:    "merge policy is GitHub's accidental default, not the fleet choice (squash-only + delete-branch-on-merge): " + strings.Join(wrong, ", "),
 		Repair: repair}}
-}
-
-func templateFindings(ctx context.Context, full string) []Finding {
-	_, err := ghAPI(ctx, "repos/"+full+"/contents/.github/pull_request_template.md")
-	if errors.Is(err, errNotFound) {
-		return []Finding{{File: full, Rule: RulePRTemplate,
-			Msg:    "no PR template — agent PRs open with free-form bodies",
-			Repair: "add .github/pull_request_template.md (copy the fleet reference from conform)"}}
-	}
-	if err != nil {
-		return []Finding{{File: full, Rule: RulePRTemplate,
-			Msg: fmt.Sprintf("template unreadable: %v", err), Repair: "gh auth status"}}
-	}
-	return nil
 }
 
 // fleetValues fetches a repo's conform.json so its declared exceptions apply

--- a/vendor/github.com/dkoosis/conform/internal/checks/local.go
+++ b/vendor/github.com/dkoosis/conform/internal/checks/local.go
@@ -46,10 +46,21 @@ var noGitOpsFamily = []string{RuleHooksShape, RuleHooksPath, RuleBDHooks, RuleRe
 // trackedHookEvents are the bd hook events shape B tracks in .githooks.
 var trackedHookEvents = []string{"post-checkout", "post-merge", "pre-commit", "pre-push", "prepare-commit-msg"}
 
-// delegationMarker identifies the beads-managed delegation block inside a
-// tracked hook. Checked semantically (marker presence), not byte-wise — the
-// block's body is bd's to version.
-const delegationMarker = "BEADS INTEGRATION"
+// Two delegation shapes are accepted (cfm-wml; the itzy#161 pin surfaced the
+// second): the inline beads-managed block, or a delegating wrapper that
+// exec-chains to bd's shim in .beads/hooks/. Both are checked semantically
+// (marker/path presence), not byte-wise.
+const (
+	delegationMarker = "BEADS INTEGRATION"
+	delegationShim   = ".beads/hooks"
+)
+
+// delegatesToBD reports whether hook content hands the event to bd by either
+// accepted shape.
+func delegatesToBD(data []byte) bool {
+	return bytes.Contains(data, []byte(delegationMarker)) ||
+		bytes.Contains(data, []byte(delegationShim))
+}
 
 const (
 	gitTimeout = 2 * time.Second
@@ -139,12 +150,12 @@ func checkBDHooks(dir string) []Finding {
 			continue
 		}
 		data, err := os.ReadFile(path)
-		if err != nil || !bytes.Contains(data, []byte(delegationMarker)) {
+		if err != nil || !delegatesToBD(data) {
 			findings = append(findings, Finding{
 				File:   rel,
 				Rule:   RuleBDHooks,
-				Msg:    "hook does not carry the beads-managed delegation block — bd events silently skipped",
-				Repair: "bd hooks install (re-emits the managed block; keep custom logic outside the markers)",
+				Msg:    "hook neither carries the beads-managed block nor exec-chains to the .beads/hooks shim — bd events silently skipped",
+				Repair: "bd hooks install (inline block), or wrap: exec \"$repo_root/.beads/hooks/$hook_name\"",
 			})
 		}
 	}
@@ -178,7 +189,7 @@ func checkReviewGate(ctx context.Context, dir string) []Finding {
 	}
 
 	data, readErr := os.ReadFile(filepath.Join(dir, rel))
-	if readErr != nil || !bytes.Contains(data, []byte(delegationMarker)) {
+	if readErr != nil || !delegatesToBD(data) {
 		return []Finding{{
 			File:   rel,
 			Rule:   RuleReviewGate,

--- a/vendor/github.com/dkoosis/conform/internal/checks/prtemplate.go
+++ b/vendor/github.com/dkoosis/conform/internal/checks/prtemplate.go
@@ -1,0 +1,46 @@
+package checks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// prTemplatePaths are the casings GitHub accepts for a PR template. The
+// uppercase form is the fleet-canonical spelling; either passes.
+var prTemplatePaths = []string{
+	".github/PULL_REQUEST_TEMPLATE.md",
+	".github/pull_request_template.md",
+}
+
+// checkPRTemplate verifies a non-empty PR template exists (pr-template).
+//
+// Surface 1 since v0.2.0 — moved from --fleet by the files-here principle:
+// the template is a tracked repo file, so it belongs with hooks-shape and
+// bd-config in the in-repo surface (the same split that keeps live
+// core.hooksPath in --local and GitHub settings in --fleet). It is also the
+// named rule change for the sd-th5.22 iteration-loop proof: every repo
+// lacking the artifact goes red at the v0.2.0 pin bump.
+func checkPRTemplate(dir string) []Finding {
+	for _, rel := range prTemplatePaths {
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(data)) == "" {
+			return []Finding{{
+				File:   rel,
+				Rule:   RulePRTemplate,
+				Msg:    "PR template is empty — it structures nothing",
+				Repair: "fill " + rel + " (copy the fleet reference from conform)",
+			}}
+		}
+		return nil
+	}
+	return []Finding{{
+		File:   prTemplatePaths[0],
+		Rule:   RulePRTemplate,
+		Msg:    "no PR template — agent PRs open with free-form bodies",
+		Repair: "add " + prTemplatePaths[0] + " (copy the fleet reference from conform)",
+	}}
+}

--- a/vendor/github.com/dkoosis/conform/internal/values/fleet.json
+++ b/vendor/github.com/dkoosis/conform/internal/values/fleet.json
@@ -12,6 +12,7 @@
     {"name": "trixi", "visibility": "private"},
     {"name": "atomicfile", "visibility": "public"},
     {"name": "keyring", "visibility": "private"},
+    {"name": "next", "visibility": "public"},
     {"name": "conform", "visibility": "public"}
   ]
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/davecgh/go-spew/spew
 # github.com/dkoosis/atomicfile v0.0.0-20260804145440-ef7d3b3067ae
 ## explicit; go 1.26.4
 github.com/dkoosis/atomicfile
-# github.com/dkoosis/conform v0.1.2
+# github.com/dkoosis/conform v0.2.0
 ## explicit; go 1.26.3
 github.com/dkoosis/conform/cmd/conform
 github.com/dkoosis/conform/internal/checks


### PR DESCRIPTION
Pin v0.1.2 → v0.2.0. Template already present (added in #237) — green straight through. Part of the sd-th5.22 fleet wave.

https://claude.ai/code/session_01S5A5T3hy85tDfzU8XjGSCF